### PR TITLE
Add a `modified-at` field to all objects - !72

### DIFF
--- a/dancelor.opam
+++ b/dancelor.opam
@@ -15,6 +15,7 @@ depends: [
   "cohttp-lwt-unix" {>= "4.0.0"}
   "dates_calc"
   "dune" {build & < "3.7.0"}
+  "ISO8601"
   "js_of_ocaml"
   "js_of_ocaml-lwt"
   "js_of_ocaml-ppx" {build}

--- a/dune-project
+++ b/dune-project
@@ -22,6 +22,7 @@
   (cohttp-lwt-unix     (>= 4.0.0))
    dates_calc
   (dune                (and :build (< 3.7.0)))
+   ISO8601
    js_of_ocaml
    js_of_ocaml-lwt
   (js_of_ocaml-ppx      :build)

--- a/lib/nes/dune
+++ b/lib/nes/dune
@@ -2,7 +2,8 @@
  (name nes)
  (public_name dancelor.nes)
  (wrapped false)
- (libraries yojson ppx_deriving_yojson.runtime unix lwt slug dates_calc)
+ (libraries yojson ppx_deriving_yojson.runtime unix lwt slug dates_calc
+   ISO8601)
  (preprocess
   (pps ppx_inline_test ppx_deriving_yojson lwt_ppx))
  (inline_tests))

--- a/lib/nes/nes.ml
+++ b/lib/nes/nes.ml
@@ -17,6 +17,7 @@ module Option = NesOption
 
 module Cache = NesCache
 module Date = NesDate
+module Datetime = NesDatetime
 module PartialDate = NesPartialDate
 module Filesystem = NesFilesystem
 module Json = NesJson

--- a/lib/nes/nesDate.ml
+++ b/lib/nes/nesDate.ml
@@ -23,6 +23,6 @@ let of_yojson = function
      with _ -> Error "NesDate.of_yojson: not a valid date")
   | _ -> Error "NesDate.of_yojson: not a JSON string"
 
-let now () =
+let today () =
   let tm = Unix.(localtime (time ())) in
   (1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday)

--- a/lib/nes/nesDate.ml
+++ b/lib/nes/nesDate.ml
@@ -13,3 +13,16 @@ let from_string str =
   | exception Failure _ -> failwith "NesDate.from_string"
   | None -> failwith "NesDate.from_string"
   | Some date -> date
+
+let to_yojson date =
+  `String (to_string date)
+
+let of_yojson = function
+  | `String s ->
+    (try Ok (from_string s)
+     with _ -> Error "NesDate.of_yojson: not a valid date")
+  | _ -> Error "NesDate.of_yojson: not a JSON string"
+
+let now () =
+  let tm = Unix.(localtime (time ())) in
+  (1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday)

--- a/lib/nes/nesDate.mli
+++ b/lib/nes/nesDate.mli
@@ -4,7 +4,7 @@
 
 val _key : string
 
-type t
+type t [@@deriving yojson]
 (** The type of a date. *)
 
 val from_string : string -> t
@@ -17,3 +17,6 @@ val to_pretty_string : ?at:bool -> t -> string
 (** Prints the date as a pretty string, eg. [9 November 2022]. The [?at]
     argument allows to represent the string “at <date>”, eg. [on 9 November
     2022]. *)
+
+val now : unit -> t
+(** Returns the current date. *)

--- a/lib/nes/nesDate.mli
+++ b/lib/nes/nesDate.mli
@@ -18,5 +18,5 @@ val to_pretty_string : ?at:bool -> t -> string
     argument allows to represent the string “at <date>”, eg. [on 9 November
     2022]. *)
 
-val now : unit -> t
+val today : unit -> t
 (** Returns the current date. *)

--- a/lib/nes/nesDatetime.ml
+++ b/lib/nes/nesDatetime.ml
@@ -1,0 +1,20 @@
+module I = ISO8601.Permissive
+
+let _key = "datetime"
+
+type t = float
+(* Number of seconds since 00:00:00 GMT, Jan. 1, 1970.*)
+
+let of_string = I.datetime ~reqtime:true
+let to_string = I.string_of_datetime
+
+let to_yojson date =
+  `String (to_string date)
+
+let of_yojson = function
+  | `String s ->
+    (try Ok (of_string s)
+     with _ -> Error "NesDatetime.of_yojson: not a valid datetime")
+  | _ -> Error "NesDatetime.of_yojson: not a JSON string"
+
+let now = Unix.gettimeofday

--- a/lib/nes/nesDatetime.mli
+++ b/lib/nes/nesDatetime.mli
@@ -1,0 +1,14 @@
+(** {1 Datetime} *)
+
+val _key : string
+
+type t [@@deriving yojson]
+
+val of_string : string -> t
+(** Parses the date and time from an ISO 8601 string. *)
+
+val to_string : t -> string
+(** Prints the date and time as an ISO 8601 string. *)
+
+val now : unit -> t
+(** Returns the current date and time. *)

--- a/lib/nes/nesPartialDate.ml
+++ b/lib/nes/nesPartialDate.ml
@@ -23,30 +23,15 @@ let check = function
   | Year _year -> true
 
 let from_string s =
-  try
-    let date =
-      let repr = String.split_on_char '-' s in
-      assert (repr <> []);
-      let year, repr = List.(hd repr, tl repr) in
-      assert (String.length year = 4);
-      let year = int_of_string year in
-      match repr with
-      | [] -> Year year
-      | month :: repr ->
-        assert (String.length month = 2);
-        let month = int_of_string month in
-        match repr with
-        | [] -> YearMonth (year, month)
-        | day :: repr ->
-          assert (repr = []);
-          assert (String.length day = 2);
-          let day = int_of_string day in
-          YearMonthDay (year, month, day)
-    in
-    assert (check date);
-    date
-  with
-    Assert_failure _ | Failure _ -> failwith "NesPartialDate.from_string"
+  let date =
+    match String.split_on_char '-' s |> List.map int_of_string_opt with
+    | [Some year] -> Year year
+    | [Some year; Some month] -> YearMonth (year, month)
+    | [Some year; Some month; Some day] -> YearMonthDay (year, month, day)
+    | _ -> failwith "NesPartialDate.from_string"
+  in
+  if not (check date) then failwith "NesPartialDate.from_string";
+  date
 
 let to_string = function
   | Year year -> spf "%04d" year
@@ -59,8 +44,8 @@ let to_yojson date =
 let of_yojson = function
   | `String s ->
     (try Ok (from_string s)
-     with _ -> Error "NesDate.Partialof_yojson: not a valid date")
-  | _ -> Error "NesDate.Partialof_yojson: not a JSON string"
+     with _ -> Error "NesPartialDate.of_yojson: not a valid date")
+  | _ -> Error "NesPartialDate.of_yojson: not a JSON string"
 
 let month_to_pretty_string month =
   [| "January"; "February"; "March"; "April"; "May"; "June"; "July";

--- a/src/client/model/book/book.ml
+++ b/src/client/model/book/book.ml
@@ -4,7 +4,7 @@ module E = Dancelor_common_model.BookEndpoints
 module A = E.Arguments
 
 let make_and_save
-    ?status ~title ?date ?contents_and_parameters ()
+    ?status ~title ?date ?contents_and_parameters ~modified_at ()
   =
   let%lwt contents_and_parameters =
     let%olwt contents = Lwt.return contents_and_parameters in
@@ -16,7 +16,8 @@ let make_and_save
     o A.status status;
     a A.title title;
     o A.date date;
-    o A.contents_and_parameters contents_and_parameters
+    o A.contents_and_parameters contents_and_parameters;
+    a A.modified_at modified_at;
   )
 
 let search ?pagination ?threshold filter =
@@ -28,7 +29,7 @@ let search ?pagination ?threshold filter =
   )
 
 let update
-    ?status ~slug ~title ?date ?contents_and_parameters ()
+    ?status ~slug ~title ?date ?contents_and_parameters ~modified_at ()
   =
   let%lwt contents_and_parameters =
     let%olwt contents = Lwt.return contents_and_parameters in
@@ -41,5 +42,6 @@ let update
     a A.slug slug;
     a A.title title;
     o A.date date;
-    o A.contents_and_parameters contents_and_parameters
+    o A.contents_and_parameters contents_and_parameters;
+    a A.modified_at modified_at;
   )

--- a/src/client/model/book/book.ml
+++ b/src/client/model/book/book.ml
@@ -4,7 +4,8 @@ module E = Dancelor_common_model.BookEndpoints
 module A = E.Arguments
 
 let make_and_save
-    ?status ~title ?date ?contents_and_parameters ~modified_at ()
+    ?status ~title ?date ?contents_and_parameters ~modified_at ~created_at
+    ()
   =
   let%lwt contents_and_parameters =
     let%olwt contents = Lwt.return contents_and_parameters in
@@ -18,6 +19,7 @@ let make_and_save
     o A.date date;
     o A.contents_and_parameters contents_and_parameters;
     a A.modified_at modified_at;
+    a A.created_at created_at;
   )
 
 let search ?pagination ?threshold filter =
@@ -29,7 +31,8 @@ let search ?pagination ?threshold filter =
   )
 
 let update
-    ?status ~slug ~title ?date ?contents_and_parameters ~modified_at ()
+    ?status ~slug ~title ?date ?contents_and_parameters ~modified_at ~created_at
+    ()
   =
   let%lwt contents_and_parameters =
     let%olwt contents = Lwt.return contents_and_parameters in
@@ -44,4 +47,5 @@ let update
     o A.date date;
     o A.contents_and_parameters contents_and_parameters;
     a A.modified_at modified_at;
+    a A.created_at created_at;
   )

--- a/src/client/model/credit/credit.ml
+++ b/src/client/model/credit/credit.ml
@@ -3,7 +3,7 @@ include CreditLifted
 module E = Dancelor_common_model.CreditEndpoints
 module A = E.Arguments
 
-let make_and_save ?status ~line ?persons ?scddb_id ~modified_at () =
+let make_and_save ?status ~line ?persons ?scddb_id ~modified_at ~created_at () =
   Madge_client.(
     call ~endpoint:E.make_and_save @@ fun {a} {o} ->
     o A.status status;
@@ -11,6 +11,7 @@ let make_and_save ?status ~line ?persons ?scddb_id ~modified_at () =
     o A.persons persons;
     o A.scddb_id scddb_id;
     a A.modified_at modified_at;
+    a A.created_at created_at;
   )
 
 let search ?pagination ?threshold filter =

--- a/src/client/model/credit/credit.ml
+++ b/src/client/model/credit/credit.ml
@@ -3,13 +3,14 @@ include CreditLifted
 module E = Dancelor_common_model.CreditEndpoints
 module A = E.Arguments
 
-let make_and_save ?status ~line ?persons ?scddb_id () =
+let make_and_save ?status ~line ?persons ?scddb_id ~modified_at () =
   Madge_client.(
     call ~endpoint:E.make_and_save @@ fun {a} {o} ->
     o A.status status;
     a A.line line;
     o A.persons persons;
-    o A.scddb_id scddb_id
+    o A.scddb_id scddb_id;
+    a A.modified_at modified_at;
   )
 
 let search ?pagination ?threshold filter =

--- a/src/client/model/dance/dance.ml
+++ b/src/client/model/dance/dance.ml
@@ -4,7 +4,7 @@ module E = Dancelor_common_model.DanceEndpoints
 module A = E.Arguments
 
 let make_and_save
-    ?status ~name ~kind ?deviser ~two_chords ?scddb_id ()
+    ?status ~name ~kind ?deviser ~two_chords ?scddb_id ~modified_at ()
   =
   Madge_client.(
     call ~endpoint:E.make_and_save @@ fun {a} {o} ->
@@ -13,7 +13,8 @@ let make_and_save
     a A.kind kind;
     o A.deviser deviser;
     a A.two_chords two_chords;
-    o A.scddb_id scddb_id
+    o A.scddb_id scddb_id;
+    a A.modified_at modified_at;
   )
 
 let search ?pagination ?threshold filter =

--- a/src/client/model/dance/dance.ml
+++ b/src/client/model/dance/dance.ml
@@ -4,7 +4,9 @@ module E = Dancelor_common_model.DanceEndpoints
 module A = E.Arguments
 
 let make_and_save
-    ?status ~name ~kind ?deviser ~two_chords ?scddb_id ~modified_at ()
+    ?status ~name ~kind ?deviser ~two_chords ?scddb_id
+    ?disambiguation ~modified_at ~created_at
+    ()
   =
   Madge_client.(
     call ~endpoint:E.make_and_save @@ fun {a} {o} ->
@@ -14,7 +16,9 @@ let make_and_save
     o A.deviser deviser;
     a A.two_chords two_chords;
     o A.scddb_id scddb_id;
+    o A.disambiguation disambiguation;
     a A.modified_at modified_at;
+    a A.created_at created_at;
   )
 
 let search ?pagination ?threshold filter =

--- a/src/client/model/person/person.ml
+++ b/src/client/model/person/person.ml
@@ -3,12 +3,13 @@ include PersonLifted
 module E = Dancelor_common_model.PersonEndpoints
 module A = E.Arguments
 
-let make_and_save ?status ~name ~modified_at () =
+let make_and_save ?status ~name ~modified_at ~created_at () =
   Madge_client.(
     call ~endpoint:E.make_and_save @@ fun {a} {o} ->
     o A.status status;
     a A.name name;
     a A.modified_at modified_at;
+    a A.created_at created_at;
   )
 
 let search ?pagination ?threshold filter =

--- a/src/client/model/person/person.ml
+++ b/src/client/model/person/person.ml
@@ -3,11 +3,12 @@ include PersonLifted
 module E = Dancelor_common_model.PersonEndpoints
 module A = E.Arguments
 
-let make_and_save ?status ~name () =
+let make_and_save ?status ~name ~modified_at () =
   Madge_client.(
     call ~endpoint:E.make_and_save @@ fun {a} {o} ->
     o A.status status;
-    a A.name name
+    a A.name name;
+    a A.modified_at modified_at;
   )
 
 let search ?pagination ?threshold filter =

--- a/src/client/model/set/set.ml
+++ b/src/client/model/set/set.ml
@@ -4,7 +4,8 @@ include SetLifted
 module E = Dancelor_common_model.SetEndpoints
 module A = E.Arguments
 
-let make_and_save ?status ~name ?deviser ~kind ?versions_and_parameters ~order ?dances () =
+let make_and_save ?status ~name ?deviser ~kind
+    ?versions_and_parameters ~order ?dances ~modified_at () =
   Madge_client.(
     call ~endpoint:E.make_and_save @@ fun {a} {o} ->
     o A.status status;
@@ -13,7 +14,8 @@ let make_and_save ?status ~name ?deviser ~kind ?versions_and_parameters ~order ?
     a A.kind kind;
     o A.versions_and_parameters versions_and_parameters;
     a A.order order;
-    o A.dances dances
+    o A.dances dances;
+    a A.modified_at modified_at;
   )
 
 let delete s =

--- a/src/client/model/set/set.ml
+++ b/src/client/model/set/set.ml
@@ -4,8 +4,11 @@ include SetLifted
 module E = Dancelor_common_model.SetEndpoints
 module A = E.Arguments
 
-let make_and_save ?status ~name ?deviser ~kind
-    ?versions_and_parameters ~order ?dances ~modified_at () =
+let make_and_save
+    ?status ~name ?deviser ~kind ?versions_and_parameters
+    ~order ?dances ~modified_at ~created_at
+    ()
+  =
   Madge_client.(
     call ~endpoint:E.make_and_save @@ fun {a} {o} ->
     o A.status status;
@@ -16,6 +19,7 @@ let make_and_save ?status ~name ?deviser ~kind
     a A.order order;
     o A.dances dances;
     a A.modified_at modified_at;
+    a A.created_at created_at;
   )
 
 let delete s =

--- a/src/client/model/tune/tune.ml
+++ b/src/client/model/tune/tune.ml
@@ -4,8 +4,8 @@ module E = Dancelor_common_model.TuneEndpoints
 module A = E.Arguments
 
 let make_and_save
-    ?status ~name ?alternative_names
-    ~kind ?author ?dances ?remark ?scddb_id ~modified_at ()
+    ?status ~name ?alternative_names ~kind ?author ?dances
+    ?remark ?scddb_id ~modified_at ~created_at ()
   =
   Madge_client.(
     call ~endpoint:E.make_and_save @@ fun {a} {o} ->
@@ -18,6 +18,7 @@ let make_and_save
     o A.remark remark;
     o A.scddb_id scddb_id;
     a A.modified_at modified_at;
+    a A.created_at created_at;
   )
 
 let search ?pagination ?threshold filter =

--- a/src/client/model/tune/tune.ml
+++ b/src/client/model/tune/tune.ml
@@ -5,7 +5,7 @@ module A = E.Arguments
 
 let make_and_save
     ?status ~name ?alternative_names
-    ~kind ?author ?dances ?remark ?scddb_id ()
+    ~kind ?author ?dances ?remark ?scddb_id ~modified_at ()
   =
   Madge_client.(
     call ~endpoint:E.make_and_save @@ fun {a} {o} ->
@@ -16,7 +16,8 @@ let make_and_save
     o A.author author;
     o A.dances dances;
     o A.remark remark;
-    o A.scddb_id scddb_id
+    o A.scddb_id scddb_id;
+    a A.modified_at modified_at;
   )
 
 let search ?pagination ?threshold filter =

--- a/src/client/model/version/version.ml
+++ b/src/client/model/version/version.ml
@@ -4,8 +4,8 @@ module E = Dancelor_common_model.VersionEndpoints
 module A = E.Arguments
 
 let make_and_save
-    ?status ~tune ~bars ~key ~structure ?arranger
-    ?remark ?disambiguation ?broken ~content ~modified_at ()
+    ?status ~tune ~bars ~key ~structure ?arranger ?remark
+    ?disambiguation ?broken ~content ~modified_at ~created_at ()
   =
   Madge_client.(
     call ~endpoint:E.make_and_save @@ fun {a} {o} ->
@@ -20,6 +20,7 @@ let make_and_save
     o A.broken broken;
     a A.content content;
     a A.modified_at modified_at;
+    a A.created_at created_at;
   )
 
 let search ?pagination ?threshold filter =

--- a/src/client/model/version/version.ml
+++ b/src/client/model/version/version.ml
@@ -5,7 +5,7 @@ module A = E.Arguments
 
 let make_and_save
     ?status ~tune ~bars ~key ~structure ?arranger
-    ?remark ?disambiguation ?broken ~content ()
+    ?remark ?disambiguation ?broken ~content ~modified_at ()
   =
   Madge_client.(
     call ~endpoint:E.make_and_save @@ fun {a} {o} ->
@@ -19,6 +19,7 @@ let make_and_save
     o A.disambiguation disambiguation;
     o A.broken broken;
     a A.content content;
+    a A.modified_at modified_at;
   )
 
 let search ?pagination ?threshold filter =

--- a/src/client/views/book/bookEditor.ml
+++ b/src/client/views/book/bookEditor.ml
@@ -90,4 +90,5 @@ let submit t =
   let date = if t.date <> "" then Some (PartialDate.from_string t.date) else None in
   let contents = fold t (fun _ set acc -> snd set :: acc) [] in
   let contents_and_parameters = List.map (fun set -> Book.Set (set, SetParameters.none)) contents in
-  Book.make_and_save ~title ?date ~contents_and_parameters ()
+  let modified_at = NesDate.now () in
+  Book.make_and_save ~title ?date ~contents_and_parameters ~modified_at ()

--- a/src/client/views/book/bookEditor.ml
+++ b/src/client/views/book/bookEditor.ml
@@ -90,5 +90,6 @@ let submit t =
   let date = if t.date <> "" then Some (PartialDate.from_string t.date) else None in
   let contents = fold t (fun _ set acc -> snd set :: acc) [] in
   let contents_and_parameters = List.map (fun set -> Book.Set (set, SetParameters.none)) contents in
-  let modified_at = NesDate.today () in
-  Book.make_and_save ~title ?date ~contents_and_parameters ~modified_at ()
+  let modified_at = Datetime.now () in
+  let created_at = Datetime.now () in
+  Book.make_and_save ~title ?date ~contents_and_parameters ~modified_at ~created_at ()

--- a/src/client/views/book/bookEditor.ml
+++ b/src/client/views/book/bookEditor.ml
@@ -90,5 +90,5 @@ let submit t =
   let date = if t.date <> "" then Some (PartialDate.from_string t.date) else None in
   let contents = fold t (fun _ set acc -> snd set :: acc) [] in
   let contents_and_parameters = List.map (fun set -> Book.Set (set, SetParameters.none)) contents in
-  let modified_at = NesDate.now () in
+  let modified_at = NesDate.today () in
   Book.make_and_save ~title ?date ~contents_and_parameters ~modified_at ()

--- a/src/client/views/credit/creditEditor.ml
+++ b/src/client/views/credit/creditEditor.ml
@@ -120,8 +120,9 @@ let clear t =
 let submit t =
   let save_and_get_person = function
     | `Edit name ->
-      let modified_at = NesDate.today () in
-      Person.make_and_save ~name ~modified_at ()
+      let modified_at = Datetime.now () in
+      let created_at = Datetime.now () in
+      Person.make_and_save ~name ~modified_at ~created_at ()
     | `Person p ->
       Lwt.return p.person
   in
@@ -142,5 +143,6 @@ let submit t =
         | Ok scddb_id -> Some scddb_id
         | Error _ -> None
   in
-  let modified_at = NesDate.today () in
-  Credit.make_and_save ~line:t.name ~persons ?scddb_id ~modified_at ()
+  let modified_at = Datetime.now () in
+  let created_at = Datetime.now () in
+  Credit.make_and_save ~line:t.name ~persons ?scddb_id ~modified_at ~created_at ()

--- a/src/client/views/credit/creditEditor.ml
+++ b/src/client/views/credit/creditEditor.ml
@@ -120,7 +120,7 @@ let clear t =
 let submit t =
   let save_and_get_person = function
     | `Edit name ->
-      let modified_at = NesDate.now () in
+      let modified_at = NesDate.today () in
       Person.make_and_save ~name ~modified_at ()
     | `Person p ->
       Lwt.return p.person
@@ -142,5 +142,5 @@ let submit t =
         | Ok scddb_id -> Some scddb_id
         | Error _ -> None
   in
-  let modified_at = NesDate.now () in
+  let modified_at = NesDate.today () in
   Credit.make_and_save ~line:t.name ~persons ?scddb_id ~modified_at ()

--- a/src/client/views/credit/creditEditor.ml
+++ b/src/client/views/credit/creditEditor.ml
@@ -120,7 +120,8 @@ let clear t =
 let submit t =
   let save_and_get_person = function
     | `Edit name ->
-      Person.make_and_save ~name ()
+      let modified_at = NesDate.now () in
+      Person.make_and_save ~name ~modified_at ()
     | `Person p ->
       Lwt.return p.person
   in
@@ -141,4 +142,5 @@ let submit t =
         | Ok scddb_id -> Some scddb_id
         | Error _ -> None
   in
-  Credit.make_and_save ~line:t.name ~persons ?scddb_id ()
+  let modified_at = NesDate.now () in
+  Credit.make_and_save ~line:t.name ~persons ?scddb_id ~modified_at ()

--- a/src/client/views/dance/danceEditor.ml
+++ b/src/client/views/dance/danceEditor.ml
@@ -78,6 +78,7 @@ let submit t =
         | Ok scddb_id -> Some scddb_id
         | Error _ -> None
   in
-  let modified_at = NesDate.today () in
+  let modified_at = Datetime.now () in
+  let created_at = Datetime.now () in
   Dance.make_and_save ~name ~kind ?deviser:(deviser t)
-    ~two_chords ?scddb_id ~modified_at ()
+    ~two_chords ?scddb_id ~modified_at ~created_at ()

--- a/src/client/views/dance/danceEditor.ml
+++ b/src/client/views/dance/danceEditor.ml
@@ -78,6 +78,6 @@ let submit t =
         | Ok scddb_id -> Some scddb_id
         | Error _ -> None
   in
-  let modified_at = NesDate.now () in
+  let modified_at = NesDate.today () in
   Dance.make_and_save ~name ~kind ?deviser:(deviser t)
     ~two_chords ?scddb_id ~modified_at ()

--- a/src/client/views/dance/danceEditor.ml
+++ b/src/client/views/dance/danceEditor.ml
@@ -78,6 +78,6 @@ let submit t =
         | Ok scddb_id -> Some scddb_id
         | Error _ -> None
   in
-  Dance.make_and_save ~name ~kind ?deviser:(deviser t) ~two_chords ?scddb_id ()
-
-
+  let modified_at = NesDate.now () in
+  Dance.make_and_save ~name ~kind ?deviser:(deviser t)
+    ~two_chords ?scddb_id ~modified_at ()

--- a/src/client/views/set/setEditor.ml
+++ b/src/client/views/set/setEditor.ml
@@ -240,14 +240,18 @@ let submit_updated_book set opt_book =
     let%lwt contents = Book.contents book in
     let%lwt set = set in
     let contents_and_parameters = contents@[Set (set, SetParameters.none)] in
-    Book.update ~slug ~title ?date ~contents_and_parameters ()
+    let modified_at = NesDate.now () in
+    Book.update ~slug ~title ?date ~contents_and_parameters ~modified_at ()
 
 let submit t =
   let versions = fold t (fun _ version acc -> version.version :: acc) [] in
   let versions_and_parameters = List.map (fun version -> (version, VersionParameters.none)) versions in
   let kind = Kind.dance_of_string t.kind in
   let order = SetOrder.of_string t.order in
-  let answer = Set.make_and_save ~kind ~name:t.name ~versions_and_parameters ~order ?deviser:(deviser t) () in
+  let modified_at = NesDate.now () in
+  let answer =
+    Set.make_and_save ~kind ~name:t.name ~versions_and_parameters
+      ~order ?deviser:(deviser t) ~modified_at () in
   Lwt.on_success answer (fun _ -> erase_storage t;
                           Lwt.on_success (submit_updated_book answer t.for_book) (fun _ -> ())
                         );

--- a/src/client/views/set/setEditor.ml
+++ b/src/client/views/set/setEditor.ml
@@ -240,7 +240,7 @@ let submit_updated_book set opt_book =
     let%lwt contents = Book.contents book in
     let%lwt set = set in
     let contents_and_parameters = contents@[Set (set, SetParameters.none)] in
-    let modified_at = NesDate.now () in
+    let modified_at = NesDate.today () in
     Book.update ~slug ~title ?date ~contents_and_parameters ~modified_at ()
 
 let submit t =
@@ -248,7 +248,7 @@ let submit t =
   let versions_and_parameters = List.map (fun version -> (version, VersionParameters.none)) versions in
   let kind = Kind.dance_of_string t.kind in
   let order = SetOrder.of_string t.order in
-  let modified_at = NesDate.now () in
+  let modified_at = NesDate.today () in
   let answer =
     Set.make_and_save ~kind ~name:t.name ~versions_and_parameters
       ~order ?deviser:(deviser t) ~modified_at () in

--- a/src/client/views/set/setEditor.ml
+++ b/src/client/views/set/setEditor.ml
@@ -239,20 +239,23 @@ let submit_updated_book set opt_book =
     let%lwt date = Book.date book in
     let%lwt contents = Book.contents book in
     let%lwt set = set in
-    let contents_and_parameters = contents@[Set (set, SetParameters.none)] in
-    let modified_at = NesDate.today () in
-    Book.update ~slug ~title ?date ~contents_and_parameters ~modified_at ()
+    let contents_and_parameters = contents @ [Set (set, SetParameters.none)] in
+    let modified_at = Datetime.now () in
+    let%lwt created_at = Book.created_at book in
+    Book.update ~slug ~title ?date ~contents_and_parameters ~modified_at ~created_at ()
 
 let submit t =
   let versions = fold t (fun _ version acc -> version.version :: acc) [] in
   let versions_and_parameters = List.map (fun version -> (version, VersionParameters.none)) versions in
   let kind = Kind.dance_of_string t.kind in
   let order = SetOrder.of_string t.order in
-  let modified_at = NesDate.today () in
+  let modified_at = Datetime.now () in
+  let created_at = Datetime.now () in
   let answer =
     Set.make_and_save ~kind ~name:t.name ~versions_and_parameters
-      ~order ?deviser:(deviser t) ~modified_at () in
-  Lwt.on_success answer (fun _ -> erase_storage t;
-                          Lwt.on_success (submit_updated_book answer t.for_book) (fun _ -> ())
-                        );
+      ~order ?deviser:(deviser t) ~modified_at ~created_at ()
+  in
+  Lwt.on_success answer
+    (fun _ -> erase_storage t;
+      Lwt.on_success (submit_updated_book answer t.for_book) (fun _ -> ()));
   answer

--- a/src/client/views/tune/tuneEditor.ml
+++ b/src/client/views/tune/tuneEditor.ml
@@ -144,6 +144,6 @@ let submit t =
       try%opt int_of_string_opt t.scddb_id
       with _ -> Result.to_option (SCDDB.tune_from_uri t.scddb_id)
   in
-  let modified_at = NesDate.now () in
+  let modified_at = NesDate.today () in
   Tune.make_and_save ~name ~alternative_names ~kind ?author:(author t)
     ~dances ?remark ?scddb_id ~modified_at ()

--- a/src/client/views/tune/tuneEditor.ml
+++ b/src/client/views/tune/tuneEditor.ml
@@ -144,4 +144,6 @@ let submit t =
       try%opt int_of_string_opt t.scddb_id
       with _ -> Result.to_option (SCDDB.tune_from_uri t.scddb_id)
   in
-  Tune.make_and_save ~name ~alternative_names ~kind ?author:(author t) ~dances ?remark ?scddb_id ()
+  let modified_at = NesDate.now () in
+  Tune.make_and_save ~name ~alternative_names ~kind ?author:(author t)
+    ~dances ?remark ?scddb_id ~modified_at ()

--- a/src/client/views/tune/tuneEditor.ml
+++ b/src/client/views/tune/tuneEditor.ml
@@ -144,6 +144,7 @@ let submit t =
       try%opt int_of_string_opt t.scddb_id
       with _ -> Result.to_option (SCDDB.tune_from_uri t.scddb_id)
   in
-  let modified_at = NesDate.today () in
+  let modified_at = Datetime.now () in
+  let created_at = Datetime.now () in
   Tune.make_and_save ~name ~alternative_names ~kind ?author:(author t)
-    ~dances ?remark ?scddb_id ~modified_at ()
+    ~dances ?remark ?scddb_id ~modified_at ~created_at ()

--- a/src/client/views/version/versionEditor.ml
+++ b/src/client/views/version/versionEditor.ml
@@ -105,4 +105,6 @@ let submit t =
   let remark = if t.remark = "" then None else Some t.remark in
   let disambiguation = if t.disambiguation = "" then None else Some t.disambiguation in
   let content = t.content in
-  Version.make_and_save ~tune ~bars ~key ~structure ?arranger ?remark ?disambiguation ~content ()
+  let modified_at = NesDate.now () in
+  Version.make_and_save ~tune ~bars ~key ~structure ?arranger
+    ?remark ?disambiguation ~content ~modified_at ()

--- a/src/client/views/version/versionEditor.ml
+++ b/src/client/views/version/versionEditor.ml
@@ -105,6 +105,6 @@ let submit t =
   let remark = if t.remark = "" then None else Some t.remark in
   let disambiguation = if t.disambiguation = "" then None else Some t.disambiguation in
   let content = t.content in
-  let modified_at = NesDate.now () in
+  let modified_at = NesDate.today () in
   Version.make_and_save ~tune ~bars ~key ~structure ?arranger
     ?remark ?disambiguation ~content ~modified_at ()

--- a/src/client/views/version/versionEditor.ml
+++ b/src/client/views/version/versionEditor.ml
@@ -105,6 +105,7 @@ let submit t =
   let remark = if t.remark = "" then None else Some t.remark in
   let disambiguation = if t.disambiguation = "" then None else Some t.disambiguation in
   let content = t.content in
-  let modified_at = NesDate.today () in
+  let modified_at = Datetime.now () in
+  let created_at = Datetime.now () in
   Version.make_and_save ~tune ~bars ~key ~structure ?arranger
-    ?remark ?disambiguation ~content ~modified_at ()
+    ?remark ?disambiguation ~content ~modified_at ~created_at ()

--- a/src/common/model/book/bookCore.ml
+++ b/src/common/model/book/bookCore.ml
@@ -37,6 +37,8 @@ let contents book = Lwt.return book.contents
 let source book = Lwt.return book.source (* FIXME: Should be removed *)
 let remark book = Lwt.return book.remark
 let scddb_id book = Lwt.return book.scddb_id
+let modified_at book = Lwt.return book.modified_at
+let created_at book = Lwt.return book.created_at
 
 let equal book1 book2 =
   let%lwt slug1 = slug book1 in

--- a/src/common/model/book/bookCore.ml
+++ b/src/common/model/book/bookCore.ml
@@ -23,7 +23,8 @@ type t =
     source      : bool       [@default false] ;
     remark      : string     [@default ""] ;
     scddb_id    : int option [@default None] [@key "scddb-id"] ;
-    modified_at : Date.t     [@key "modified-at"] }
+    modified_at : Datetime.t [@key "modified-at"] ;
+    created_at  : Datetime.t [@key "created-at"] }
 [@@deriving make, yojson]
 
 let slug book = Lwt.return book.slug

--- a/src/common/model/book/bookCore.ml
+++ b/src/common/model/book/bookCore.ml
@@ -89,11 +89,13 @@ let page_to_page_core = function
   | (InlineSet (set, params) : page) ->
     Lwt.return @@ PageCore.InlineSet (set, params)
 
-let make ?status ~slug ~title ?date ?contents_and_parameters ~modified_at () =
+let make ?status ~slug ~title ?date ?contents_and_parameters ~modified_at ~created_at () =
   let%lwt contents_and_parameters =
     let%olwt contents = Lwt.return contents_and_parameters in
     let%lwt contents = Lwt_list.map_s page_to_page_core contents in
     Lwt.return_some contents
   in
-  Lwt.return (make ?status ~slug ~title ?date
-                ?contents:contents_and_parameters ~modified_at ())
+  Lwt.return (make
+                ?status ~slug ~title ?date
+                ?contents:contents_and_parameters ~modified_at ~created_at
+                ())

--- a/src/common/model/book/bookCore.ml
+++ b/src/common/model/book/bookCore.ml
@@ -22,7 +22,8 @@ type t =
     contents    : PageCore.t list ;
     source      : bool       [@default false] ;
     remark      : string     [@default ""] ;
-    scddb_id    : int option [@default None] [@key "scddb-id"] }
+    scddb_id    : int option [@default None] [@key "scddb-id"] ;
+    modified_at : Date.t     [@key "modified-at"] }
 [@@deriving make, yojson]
 
 let slug book = Lwt.return book.slug
@@ -87,10 +88,11 @@ let page_to_page_core = function
   | (InlineSet (set, params) : page) ->
     Lwt.return @@ PageCore.InlineSet (set, params)
 
-let make ?status ~slug ~title ?date ?contents_and_parameters () =
+let make ?status ~slug ~title ?date ?contents_and_parameters ~modified_at () =
   let%lwt contents_and_parameters =
     let%olwt contents = Lwt.return contents_and_parameters in
     let%lwt contents = Lwt_list.map_s page_to_page_core contents in
     Lwt.return_some contents
   in
-  Lwt.return (make ?status ~slug ~title ?date ?contents:contents_and_parameters ())
+  Lwt.return (make ?status ~slug ~title ?date
+                ?contents:contents_and_parameters ~modified_at ())

--- a/src/common/model/book/bookEndpoints.ml
+++ b/src/common/model/book/bookEndpoints.ml
@@ -9,6 +9,7 @@ module Arguments = struct
   let filter = arg (module BookFilter)
   let pagination = optarg (module Pagination)
   let threshold = optarg ~key:"threshold" (module MFloat)
+  let modified_at = arg ~key:"modified-at" (module NesDate)
 end
 
 let get = endpoint ~path:"/book" (module BookCore)

--- a/src/common/model/book/bookEndpoints.ml
+++ b/src/common/model/book/bookEndpoints.ml
@@ -9,7 +9,8 @@ module Arguments = struct
   let filter = arg (module BookFilter)
   let pagination = optarg (module Pagination)
   let threshold = optarg ~key:"threshold" (module MFloat)
-  let modified_at = arg ~key:"modified-at" (module NesDate)
+  let modified_at = arg ~key:"modified-at" (module NesDatetime)
+  let created_at = arg ~key:"created-at" (module NesDatetime)
 end
 
 let get = endpoint ~path:"/book" (module BookCore)

--- a/src/common/model/book/bookSignature.mli
+++ b/src/common/model/book/bookSignature.mli
@@ -35,6 +35,8 @@ val contents : t -> page list Lwt.t
 val source : t -> bool Lwt.t (* FIXME: Should be removed *)
 val remark : t -> string Lwt.t
 val scddb_id : t -> int option Lwt.t
+val modified_at : t -> Datetime.t Lwt.t
+val created_at : t -> Datetime.t Lwt.t
 
 (** {2 Advanced Field Getters} *)
 

--- a/src/common/model/book/bookSignature.mli
+++ b/src/common/model/book/bookSignature.mli
@@ -85,6 +85,7 @@ val make_and_save :
   title:string ->
   ?date:PartialDate.t ->
   ?contents_and_parameters:page list ->
+  modified_at:Date.t ->
   unit -> t Lwt.t
 
 val search :
@@ -99,4 +100,5 @@ val update :
   title:string ->
   ?date:PartialDate.t ->
   ?contents_and_parameters:page list ->
+  modified_at:Date.t ->
   unit -> unit Lwt.t

--- a/src/common/model/book/bookSignature.mli
+++ b/src/common/model/book/bookSignature.mli
@@ -85,7 +85,8 @@ val make_and_save :
   title:string ->
   ?date:PartialDate.t ->
   ?contents_and_parameters:page list ->
-  modified_at:Date.t ->
+  modified_at:Datetime.t ->
+  created_at:Datetime.t ->
   unit -> t Lwt.t
 
 val search :
@@ -100,5 +101,6 @@ val update :
   title:string ->
   ?date:PartialDate.t ->
   ?contents_and_parameters:page list ->
-  modified_at:Date.t ->
+  modified_at:Datetime.t ->
+  created_at:Datetime.t ->
   unit -> unit Lwt.t

--- a/src/common/model/credit/creditCore.ml
+++ b/src/common/model/credit/creditCore.ml
@@ -8,7 +8,8 @@ type t =
     line : string ;
     persons : PersonCore.t Slug.t list [@default []];
     scddb_id : int option [@default None] [@key "scddb-id"] ;
-    modified_at : NesDate.t [@key "modified-at"] }
+    modified_at : Datetime.t [@key "modified-at"] ;
+    created_at  : Datetime.t [@key "created-at"] }
 [@@deriving yojson, make]
 
 let slug c = Lwt.return c.slug

--- a/src/common/model/credit/creditCore.ml
+++ b/src/common/model/credit/creditCore.ml
@@ -7,7 +7,8 @@ type t =
     status : Status.t [@default Status.bot] ;
     line : string ;
     persons : PersonCore.t Slug.t list [@default []];
-    scddb_id : int option [@default None] [@key "scddb-id"] }
+    scddb_id : int option [@default None] [@key "scddb-id"] ;
+    modified_at : NesDate.t [@key "modified-at"] }
 [@@deriving yojson, make]
 
 let slug c = Lwt.return c.slug

--- a/src/common/model/credit/creditEndpoints.ml
+++ b/src/common/model/credit/creditEndpoints.ml
@@ -9,7 +9,8 @@ module Arguments = struct
   let pagination = optarg (module Pagination)
   let filter = arg (module CreditFilter)
   let threshold = optarg ~key:"threshold" (module MFloat)
-  let modified_at = arg ~key:"modified-at" (module NesDate)
+  let modified_at = arg ~key:"modified-at" (module NesDatetime)
+  let created_at = arg ~key:"created-at" (module NesDatetime)
 end
 
 let get = endpoint ~path:"/credit" (module CreditCore)

--- a/src/common/model/credit/creditEndpoints.ml
+++ b/src/common/model/credit/creditEndpoints.ml
@@ -9,6 +9,7 @@ module Arguments = struct
   let pagination = optarg (module Pagination)
   let filter = arg (module CreditFilter)
   let threshold = optarg ~key:"threshold" (module MFloat)
+  let modified_at = arg ~key:"modified-at" (module NesDate)
 end
 
 let get = endpoint ~path:"/credit" (module CreditCore)

--- a/src/common/model/credit/creditSignature.mli
+++ b/src/common/model/credit/creditSignature.mli
@@ -19,6 +19,7 @@ val make_and_save :
   line:string ->
   ?persons:PersonCore.t list ->
   ?scddb_id:int ->
+  modified_at:Date.t ->
   unit -> t Lwt.t
 
 val search :

--- a/src/common/model/credit/creditSignature.mli
+++ b/src/common/model/credit/creditSignature.mli
@@ -19,7 +19,8 @@ val make_and_save :
   line:string ->
   ?persons:PersonCore.t list ->
   ?scddb_id:int ->
-  modified_at:Date.t ->
+  modified_at:Datetime.t ->
+  created_at:Datetime.t ->
   unit -> t Lwt.t
 
 val search :

--- a/src/common/model/dance/danceCore.ml
+++ b/src/common/model/dance/danceCore.ml
@@ -11,7 +11,8 @@ type t =
     two_chords : bool [@default false] [@key "two-chords"] ;
     scddb_id : int option [@default None] [@key "scddb-id"] ;
     disambiguation : string [@default ""] ;
-    modified_at : NesDate.t [@key "modified-at"] }
+    modified_at : Datetime.t [@key "modified-at"] ;
+    created_at  : Datetime.t [@key "created-at"] }
 [@@deriving make, yojson]
 
 let make ?status ~slug ~name ~kind ?deviser ~two_chords

--- a/src/common/model/dance/danceCore.ml
+++ b/src/common/model/dance/danceCore.ml
@@ -10,10 +10,12 @@ type t =
     deviser : CreditCore.t Slug.t option [@default None] ;
     two_chords : bool [@default false] [@key "two-chords"] ;
     scddb_id : int option [@default None] [@key "scddb-id"] ;
-    disambiguation : string [@default ""] }
+    disambiguation : string [@default ""] ;
+    modified_at : NesDate.t [@key "modified-at"] }
 [@@deriving make, yojson]
 
-let make ?status ~slug ~name ~kind ?deviser ~two_chords ?scddb_id ?disambiguation () =
+let make ?status ~slug ~name ~kind ?deviser ~two_chords
+    ?scddb_id ?disambiguation ~modified_at () =
   let%lwt deviser =
     match deviser with
     | None -> Lwt.return_none
@@ -21,7 +23,8 @@ let make ?status ~slug ~name ~kind ?deviser ~two_chords ?scddb_id ?disambiguatio
       let%lwt deviser = CreditCore.slug deviser in
       Lwt.return_some deviser
   in
-  Lwt.return (make ?status ~slug ~name ~kind ~deviser ~two_chords ~scddb_id ?disambiguation ())
+  Lwt.return (make ?status ~slug ~name ~kind ~deviser ~two_chords
+                ~scddb_id ?disambiguation ~modified_at ())
 
 let slug d = Lwt.return d.slug
 let status d = Lwt.return d.status

--- a/src/common/model/dance/danceCore.ml
+++ b/src/common/model/dance/danceCore.ml
@@ -15,8 +15,11 @@ type t =
     created_at  : Datetime.t [@key "created-at"] }
 [@@deriving make, yojson]
 
-let make ?status ~slug ~name ~kind ?deviser ~two_chords
-    ?scddb_id ?disambiguation ~modified_at () =
+let make
+    ?status ~slug ~name ~kind ?deviser ~two_chords ?scddb_id
+    ?disambiguation ~modified_at ~created_at
+    ()
+  =
   let%lwt deviser =
     match deviser with
     | None -> Lwt.return_none
@@ -24,8 +27,10 @@ let make ?status ~slug ~name ~kind ?deviser ~two_chords
       let%lwt deviser = CreditCore.slug deviser in
       Lwt.return_some deviser
   in
-  Lwt.return (make ?status ~slug ~name ~kind ~deviser ~two_chords
-                ~scddb_id ?disambiguation ~modified_at ())
+  Lwt.return (make
+                ?status ~slug ~name ~kind ~deviser ~two_chords ~scddb_id
+                ?disambiguation ~modified_at ~created_at
+                ())
 
 let slug d = Lwt.return d.slug
 let status d = Lwt.return d.status

--- a/src/common/model/dance/danceEndpoints.ml
+++ b/src/common/model/dance/danceEndpoints.ml
@@ -11,6 +11,7 @@ module Arguments = struct
   let deviser = optarg ~key:"deviser" (module CreditCore)
   let two_chords = arg ~key:"two-chords" (module MBool)
   let scddb_id = optarg ~key:"scddb-id" (module MInteger)
+  let modified_at = arg ~key:"modified-at" (module NesDate)
 end
 
 let get = endpoint ~path:"/dance" (module DanceCore)

--- a/src/common/model/dance/danceEndpoints.ml
+++ b/src/common/model/dance/danceEndpoints.ml
@@ -11,7 +11,8 @@ module Arguments = struct
   let deviser = optarg ~key:"deviser" (module CreditCore)
   let two_chords = arg ~key:"two-chords" (module MBool)
   let scddb_id = optarg ~key:"scddb-id" (module MInteger)
-  let modified_at = arg ~key:"modified-at" (module NesDate)
+  let modified_at = arg ~key:"modified-at" (module NesDatetime)
+  let created_at = arg ~key:"created-at" (module NesDatetime)
 end
 
 let get = endpoint ~path:"/dance" (module DanceCore)

--- a/src/common/model/dance/danceEndpoints.ml
+++ b/src/common/model/dance/danceEndpoints.ml
@@ -9,6 +9,7 @@ module Arguments = struct
   let name = arg ~key:"name" (module MString)
   let kind = arg ~key:"kind" (module Kind.Dance)
   let deviser = optarg ~key:"deviser" (module CreditCore)
+  let disambiguation = optarg ~key:"disambiguation" (module MString)
   let two_chords = arg ~key:"two-chords" (module MBool)
   let scddb_id = optarg ~key:"scddb-id" (module MInteger)
   let modified_at = arg ~key:"modified-at" (module NesDatetime)

--- a/src/common/model/dance/danceSignature.mli
+++ b/src/common/model/dance/danceSignature.mli
@@ -22,7 +22,8 @@ val make_and_save :
   ?deviser:CreditCore.t ->
   two_chords:bool ->
   ?scddb_id:int ->
-  modified_at:Date.t ->
+  modified_at:Datetime.t ->
+  created_at:Datetime.t ->
   unit -> t Lwt.t
 
 val search :

--- a/src/common/model/dance/danceSignature.mli
+++ b/src/common/model/dance/danceSignature.mli
@@ -22,6 +22,7 @@ val make_and_save :
   ?deviser:CreditCore.t ->
   two_chords:bool ->
   ?scddb_id:int ->
+  ?disambiguation:string ->
   modified_at:Datetime.t ->
   created_at:Datetime.t ->
   unit -> t Lwt.t

--- a/src/common/model/dance/danceSignature.mli
+++ b/src/common/model/dance/danceSignature.mli
@@ -22,6 +22,7 @@ val make_and_save :
   ?deviser:CreditCore.t ->
   two_chords:bool ->
   ?scddb_id:int ->
+  modified_at:Date.t ->
   unit -> t Lwt.t
 
 val search :

--- a/src/common/model/person/personCore.ml
+++ b/src/common/model/person/personCore.ml
@@ -5,7 +5,8 @@ let _key = "person"
 type t =
   { slug : t Slug.t ;
     status : Status.t [@default Status.bot] ;
-    name : string }
+    name : string ;
+    modified_at : NesDate.t [@key "modified-at"] }
 [@@deriving yojson, make]
 
 let slug p = Lwt.return p.slug

--- a/src/common/model/person/personCore.ml
+++ b/src/common/model/person/personCore.ml
@@ -6,7 +6,8 @@ type t =
   { slug : t Slug.t ;
     status : Status.t [@default Status.bot] ;
     name : string ;
-    modified_at : NesDate.t [@key "modified-at"] }
+    modified_at : Datetime.t [@key "modified-at"] ;
+    created_at  : Datetime.t [@key "created-at"] }
 [@@deriving yojson, make]
 
 let slug p = Lwt.return p.slug

--- a/src/common/model/person/personEndpoints.ml
+++ b/src/common/model/person/personEndpoints.ml
@@ -7,6 +7,7 @@ module Arguments = struct
   let filter = arg (module PersonFilter)
   let pagination = optarg (module Pagination)
   let threshold = optarg ~key:"threshold" (module MFloat)
+  let modified_at = arg ~key:"modified-at" (module NesDate)
 end
 
 let get = endpoint ~path:"/person" (module PersonCore)

--- a/src/common/model/person/personEndpoints.ml
+++ b/src/common/model/person/personEndpoints.ml
@@ -7,7 +7,8 @@ module Arguments = struct
   let filter = arg (module PersonFilter)
   let pagination = optarg (module Pagination)
   let threshold = optarg ~key:"threshold" (module MFloat)
-  let modified_at = arg ~key:"modified-at" (module NesDate)
+  let modified_at = arg ~key:"modified-at" (module NesDatetime)
+  let created_at = arg ~key:"created-at" (module NesDatetime)
 end
 
 let get = endpoint ~path:"/person" (module PersonCore)

--- a/src/common/model/person/personSignature.mli
+++ b/src/common/model/person/personSignature.mli
@@ -13,7 +13,8 @@ val get : t Slug.t -> t Lwt.t
 val make_and_save :
   ?status:Status.t ->
   name:string ->
-  modified_at:Date.t ->
+  modified_at:Datetime.t ->
+  created_at:Datetime.t ->
   unit -> t Lwt.t
 
 val search :

--- a/src/common/model/person/personSignature.mli
+++ b/src/common/model/person/personSignature.mli
@@ -13,6 +13,7 @@ val get : t Slug.t -> t Lwt.t
 val make_and_save :
   ?status:Status.t ->
   name:string ->
+  modified_at:Date.t ->
   unit -> t Lwt.t
 
 val search :

--- a/src/common/model/set/setCore.ml
+++ b/src/common/model/set/setCore.ml
@@ -18,8 +18,11 @@ type t =
     created_at  : Datetime.t      [@key "created-at"] }
 [@@deriving make, yojson]
 
-let make ?status ~slug ~name ?deviser ~kind
-    ?versions_and_parameters ~order ?dances ~modified_at () =
+let make
+    ?status ~slug ~name ?deviser ~kind ?versions_and_parameters
+    ~order ?dances ~modified_at ~created_at
+    ()
+  =
   let%lwt deviser =
     let%olwt deviser = Lwt.return deviser in
     let%lwt deviser = CreditCore.slug deviser in
@@ -41,13 +44,19 @@ let make ?status ~slug ~name ?deviser ~kind
     let%lwt dances = Lwt_list.map_p DanceCore.slug dances in
     Lwt.return_some dances
   in
-  Lwt.return (make ?status ~slug ~name ~deviser ~kind
-                ?versions_and_parameters ~order ?dances ~modified_at ())
+  Lwt.return (make ?status ~slug ~name ~deviser ~kind ?versions_and_parameters
+                ~order ?dances ~modified_at ~created_at
+                ())
 
-let make_temp ~name ?deviser ~kind
-    ?versions_and_parameters ~order ?dances ~modified_at () =
-  make ~slug:Slug.none ~name ?deviser ~kind
-    ?versions_and_parameters ~order ?dances ~modified_at ()
+let make_temp
+    ~name ?deviser ~kind ?versions_and_parameters
+    ~order ?dances ~modified_at ~created_at
+    ()
+  =
+  make
+    ~slug:Slug.none ~name ?deviser ~kind ?versions_and_parameters
+    ~order ?dances ~modified_at ~created_at
+    ()
 
 let slug s = Lwt.return s.slug
 let is_slug_none s =

--- a/src/common/model/set/setCore.ml
+++ b/src/common/model/set/setCore.ml
@@ -14,7 +14,8 @@ type t =
     instructions : string            [@default ""] ;
     dances : DanceCore.t Slug.t list [@default []] ;
     remark : string                  [@default ""] ;
-    modified_at : NesDate.t          [@key "modified-at"] }
+    modified_at : Datetime.t      [@key "modified-at"] ;
+    created_at  : Datetime.t      [@key "created-at"] }
 [@@deriving make, yojson]
 
 let make ?status ~slug ~name ?deviser ~kind

--- a/src/common/model/set/setCore.ml
+++ b/src/common/model/set/setCore.ml
@@ -69,10 +69,11 @@ let deviser s = Lwt.return s.deviser
 let kind s = Lwt.return s.kind
 let versions_and_parameters s = Lwt.return s.versions_and_parameters
 let order s = Lwt.return s.order
-
 let instructions s = Lwt.return s.instructions
 let dances set = Lwt.return set.dances
 let remark set = Lwt.return set.remark
+let modified_at set = Lwt.return set.modified_at
+let created_at set = Lwt.return set.created_at
 
 let compare =
   Slug.compare_slugs_or

--- a/src/common/model/set/setCore.ml
+++ b/src/common/model/set/setCore.ml
@@ -8,14 +8,17 @@ type t =
     name : string ;
     deviser : CreditCore.t Slug.t option [@default None] ;
     kind : Kind.dance ;
-    versions_and_parameters : (VersionCore.t Slug.t * VersionParameters.t) list [@key "versions-and-parameters"] [@default []] ;
+    versions_and_parameters : (VersionCore.t Slug.t * VersionParameters.t) list
+                              [@key "versions-and-parameters"] [@default []] ;
     order : SetOrder.t ;
     instructions : string            [@default ""] ;
     dances : DanceCore.t Slug.t list [@default []] ;
-    remark : string                  [@default ""] }
+    remark : string                  [@default ""] ;
+    modified_at : NesDate.t          [@key "modified-at"] }
 [@@deriving make, yojson]
 
-let make ?status ~slug ~name ?deviser ~kind ?versions_and_parameters ~order ?dances () =
+let make ?status ~slug ~name ?deviser ~kind
+    ?versions_and_parameters ~order ?dances ~modified_at () =
   let%lwt deviser =
     let%olwt deviser = Lwt.return deviser in
     let%lwt deviser = CreditCore.slug deviser in
@@ -37,10 +40,13 @@ let make ?status ~slug ~name ?deviser ~kind ?versions_and_parameters ~order ?dan
     let%lwt dances = Lwt_list.map_p DanceCore.slug dances in
     Lwt.return_some dances
   in
-  Lwt.return (make ?status ~slug ~name ~deviser ~kind ?versions_and_parameters ~order ?dances ())
+  Lwt.return (make ?status ~slug ~name ~deviser ~kind
+                ?versions_and_parameters ~order ?dances ~modified_at ())
 
-let make_temp ~name ?deviser ~kind ?versions_and_parameters ~order ?dances () =
-  make ~slug:Slug.none ~name ?deviser ~kind ?versions_and_parameters ~order ?dances ()
+let make_temp ~name ?deviser ~kind
+    ?versions_and_parameters ~order ?dances ~modified_at () =
+  make ~slug:Slug.none ~name ?deviser ~kind
+    ?versions_and_parameters ~order ?dances ~modified_at ()
 
 let slug s = Lwt.return s.slug
 let is_slug_none s =

--- a/src/common/model/set/setEndpoints.ml
+++ b/src/common/model/set/setEndpoints.ml
@@ -12,6 +12,7 @@ module Arguments = struct
   let filter = arg (module SetFilter)
   let pagination = optarg (module Pagination)
   let threshold = optarg ~key:"threshold" (module MFloat)
+  let modified_at = arg ~key:"modified-at" (module NesDate)
 end
 
 let get = endpoint ~path:"/set" (module SetCore)

--- a/src/common/model/set/setEndpoints.ml
+++ b/src/common/model/set/setEndpoints.ml
@@ -12,7 +12,8 @@ module Arguments = struct
   let filter = arg (module SetFilter)
   let pagination = optarg (module Pagination)
   let threshold = optarg ~key:"threshold" (module MFloat)
-  let modified_at = arg ~key:"modified-at" (module NesDate)
+  let modified_at = arg ~key:"modified-at" (module NesDatetime)
+  let created_at = arg ~key:"created-at" (module NesDatetime)
 end
 
 let get = endpoint ~path:"/set" (module SetCore)

--- a/src/common/model/set/setSignature.mli
+++ b/src/common/model/set/setSignature.mli
@@ -46,6 +46,7 @@ val make_temp :
   ?versions_and_parameters:(VersionCore.t * VersionParameters.t) list ->
   order:SetOrder.t ->
   ?dances:DanceCore.t list ->
+  modified_at:Date.t ->
   unit -> t Lwt.t
 
 val make_and_save :
@@ -56,6 +57,7 @@ val make_and_save :
   ?versions_and_parameters:(VersionCore.t * VersionParameters.t) list ->
   order:SetOrder.t ->
   ?dances:DanceCore.t list ->
+  modified_at:Date.t ->
   unit -> t Lwt.t
 
 val delete : t -> unit Lwt.t

--- a/src/common/model/set/setSignature.mli
+++ b/src/common/model/set/setSignature.mli
@@ -46,7 +46,8 @@ val make_temp :
   ?versions_and_parameters:(VersionCore.t * VersionParameters.t) list ->
   order:SetOrder.t ->
   ?dances:DanceCore.t list ->
-  modified_at:Date.t ->
+  modified_at:Datetime.t ->
+  created_at:Datetime.t ->
   unit -> t Lwt.t
 
 val make_and_save :
@@ -57,7 +58,8 @@ val make_and_save :
   ?versions_and_parameters:(VersionCore.t * VersionParameters.t) list ->
   order:SetOrder.t ->
   ?dances:DanceCore.t list ->
-  modified_at:Date.t ->
+  modified_at:Datetime.t ->
+  created_at:Datetime.t ->
   unit -> t Lwt.t
 
 val delete : t -> unit Lwt.t

--- a/src/common/model/set/setSignature.mli
+++ b/src/common/model/set/setSignature.mli
@@ -14,6 +14,8 @@ val order : t -> SetOrder.t Lwt.t
 val instructions : t -> string Lwt.t
 val dances : t -> DanceCore.t list Lwt.t
 val remark : t -> string Lwt.t
+val modified_at : t -> Datetime.t Lwt.t
+val created_at : t -> Datetime.t Lwt.t
 
 val contains_version : VersionCore.t Slug.t -> t -> bool
 

--- a/src/common/model/tune/tuneCore.ml
+++ b/src/common/model/tune/tuneCore.ml
@@ -16,8 +16,11 @@ type t =
     created_at  : Datetime.t            [@key "created-at"] }
 [@@deriving make, yojson]
 
-let make ?status ~slug ~name ?alternative_names ~kind ?author ?dances
-    ?remark ?scddb_id ~modified_at () =
+let make
+    ?status ~slug ~name ?alternative_names ~kind ?author ?dances
+    ?remark ?scddb_id ~modified_at ~created_at
+    ()
+  =
   let%lwt author =
     let%olwt author = Lwt.return author in
     let%lwt author_slug = CreditCore.slug author in
@@ -34,8 +37,10 @@ let make ?status ~slug ~name ?alternative_names ~kind ?author ?dances
     in
     Lwt.return_some dances
   in
-  Lwt.return (make ?status ~slug ~name ?alternative_names ~kind ~author ?dances
-                ?remark ~scddb_id ~modified_at ())
+  Lwt.return (make
+                ?status ~slug ~name ?alternative_names ~kind ~author ?dances
+                ?remark ~scddb_id ~modified_at ~created_at
+                ())
 
 let slug tune = Lwt.return tune.slug
 let status tune = Lwt.return tune.status

--- a/src/common/model/tune/tuneCore.ml
+++ b/src/common/model/tune/tuneCore.ml
@@ -11,10 +11,12 @@ type t =
     author : CreditCore.t Slug.t option [@default None] ;
     dances : DanceCore.t Slug.t list    [@default []] ;
     remark : string                     [@default ""] ;
-    scddb_id : int option               [@default None] [@key "scddb-id"] }
+    scddb_id : int option               [@default None] [@key "scddb-id"] ;
+    modified_at : NesDate.t             [@key "modified-at"] }
 [@@deriving make, yojson]
 
-let make ?status ~slug ~name ?alternative_names ~kind ?author ?dances ?remark ?scddb_id () =
+let make ?status ~slug ~name ?alternative_names ~kind ?author ?dances
+    ?remark ?scddb_id ~modified_at () =
   let%lwt author =
     let%olwt author = Lwt.return author in
     let%lwt author_slug = CreditCore.slug author in
@@ -31,7 +33,8 @@ let make ?status ~slug ~name ?alternative_names ~kind ?author ?dances ?remark ?s
     in
     Lwt.return_some dances
   in
-  Lwt.return (make ?status ~slug ~name ?alternative_names ~kind ~author ?dances ?remark ~scddb_id ())
+  Lwt.return (make ?status ~slug ~name ?alternative_names ~kind ~author ?dances
+                ?remark ~scddb_id ~modified_at ())
 
 let slug tune = Lwt.return tune.slug
 let status tune = Lwt.return tune.status

--- a/src/common/model/tune/tuneCore.ml
+++ b/src/common/model/tune/tuneCore.ml
@@ -12,7 +12,8 @@ type t =
     dances : DanceCore.t Slug.t list    [@default []] ;
     remark : string                     [@default ""] ;
     scddb_id : int option               [@default None] [@key "scddb-id"] ;
-    modified_at : NesDate.t             [@key "modified-at"] }
+    modified_at : Datetime.t            [@key "modified-at"] ;
+    created_at  : Datetime.t            [@key "created-at"] }
 [@@deriving make, yojson]
 
 let make ?status ~slug ~name ?alternative_names ~kind ?author ?dances

--- a/src/common/model/tune/tuneEndpoints.ml
+++ b/src/common/model/tune/tuneEndpoints.ml
@@ -13,6 +13,7 @@ module Arguments = struct
   let dances = optarg ~key:"dances" (module MList(DanceCore))
   let remark = optarg ~key:"remark" (module MString)
   let scddb_id = optarg ~key:"scddb-id" (module MInteger)
+  let modified_at = arg ~key:"modified-at" (module NesDate)
 end
 
 let get = endpoint ~path:"/tune" (module TuneCore)

--- a/src/common/model/tune/tuneEndpoints.ml
+++ b/src/common/model/tune/tuneEndpoints.ml
@@ -13,7 +13,8 @@ module Arguments = struct
   let dances = optarg ~key:"dances" (module MList(DanceCore))
   let remark = optarg ~key:"remark" (module MString)
   let scddb_id = optarg ~key:"scddb-id" (module MInteger)
-  let modified_at = arg ~key:"modified-at" (module NesDate)
+  let modified_at = arg ~key:"modified-at" (module NesDatetime)
+  let created_at = arg ~key:"created-at" (module NesDatetime)
 end
 
 let get = endpoint ~path:"/tune" (module TuneCore)

--- a/src/common/model/tune/tuneSignature.mli
+++ b/src/common/model/tune/tuneSignature.mli
@@ -28,7 +28,8 @@ val make_and_save :
   ?dances:DanceCore.t list ->
   ?remark:string ->
   ?scddb_id:int ->
-  modified_at:Date.t ->
+  modified_at:Datetime.t ->
+  created_at:Datetime.t ->
   unit -> t Lwt.t
 
 val search :

--- a/src/common/model/tune/tuneSignature.mli
+++ b/src/common/model/tune/tuneSignature.mli
@@ -28,6 +28,7 @@ val make_and_save :
   ?dances:DanceCore.t list ->
   ?remark:string ->
   ?scddb_id:int ->
+  modified_at:Date.t ->
   unit -> t Lwt.t
 
 val search :

--- a/src/common/model/version/versionCore.ml
+++ b/src/common/model/version/versionCore.ml
@@ -20,7 +20,8 @@ type t =
 
 let make
     ~slug ?status ~tune ~bars ~key ~structure ?arranger ?remark
-    ?disambiguation ?broken ~modified_at ()
+    ?disambiguation ?broken ~modified_at ~created_at
+    ()
   =
   let%lwt tune = TuneCore.slug tune in
   let%lwt arranger =
@@ -28,8 +29,10 @@ let make
     let%lwt arranger = CreditCore.slug arranger in
     Lwt.return_some arranger
   in
-  Lwt.return (make ~slug ?status ~tune ~bars ~key ~structure ~arranger ?remark
-                ?disambiguation ?broken ~modified_at ())
+  Lwt.return (make
+                ~slug ?status ~tune ~bars ~key ~structure ~arranger ?remark
+                ?disambiguation ?broken ~modified_at ~created_at
+                ())
 
 let slug t = Lwt.return t.slug
 let status t = Lwt.return t.status

--- a/src/common/model/version/versionCore.ml
+++ b/src/common/model/version/versionCore.ml
@@ -14,7 +14,8 @@ type t =
     remark : string                   [@default ""] ;
     disambiguation : string           [@default ""] ;
     broken : bool                     [@default false] ;
-    modified_at : NesDate.t           [@key "modified-at"] }
+    modified_at : Datetime.t          [@key "modified-at"] ;
+    created_at  : Datetime.t          [@key "created-at"] }
 [@@deriving make, yojson]
 
 let make

--- a/src/common/model/version/versionCore.ml
+++ b/src/common/model/version/versionCore.ml
@@ -13,12 +13,13 @@ type t =
     arranger : CreditCore.t Slug.t option [@default None] ;
     remark : string                   [@default ""] ;
     disambiguation : string           [@default ""] ;
-    broken : bool                     [@default false] }
+    broken : bool                     [@default false] ;
+    modified_at : NesDate.t           [@key "modified-at"] }
 [@@deriving make, yojson]
 
 let make
-    ~slug ?status ~tune ~bars ~key ~structure
-    ?arranger ?remark ?disambiguation ?broken ()
+    ~slug ?status ~tune ~bars ~key ~structure ?arranger ?remark
+    ?disambiguation ?broken ~modified_at ()
   =
   let%lwt tune = TuneCore.slug tune in
   let%lwt arranger =
@@ -26,8 +27,8 @@ let make
     let%lwt arranger = CreditCore.slug arranger in
     Lwt.return_some arranger
   in
-  Lwt.return (make ~slug ?status ~tune ~bars ~key ~structure
-                ~arranger ?remark ?disambiguation ?broken ())
+  Lwt.return (make ~slug ?status ~tune ~bars ~key ~structure ~arranger ?remark
+                ?disambiguation ?broken ~modified_at ())
 
 let slug t = Lwt.return t.slug
 let status t = Lwt.return t.status

--- a/src/common/model/version/versionEndpoints.ml
+++ b/src/common/model/version/versionEndpoints.ml
@@ -16,7 +16,8 @@ module Arguments = struct
   let disambiguation = optarg ~key:"disambiguation" (module MString)
   let broken = optarg ~key:"broken" (module MBool)
   let content = arg ~key:"content" (module MString)
-  let modified_at = arg ~key:"modified-at" (module NesDate)
+  let modified_at = arg ~key:"modified-at" (module NesDatetime)
+  let created_at = arg ~key:"created-at" (module NesDatetime)
 end
 
 let get = endpoint ~path:"/version" (module VersionCore)

--- a/src/common/model/version/versionEndpoints.ml
+++ b/src/common/model/version/versionEndpoints.ml
@@ -16,6 +16,7 @@ module Arguments = struct
   let disambiguation = optarg ~key:"disambiguation" (module MString)
   let broken = optarg ~key:"broken" (module MBool)
   let content = arg ~key:"content" (module MString)
+  let modified_at = arg ~key:"modified-at" (module NesDate)
 end
 
 let get = endpoint ~path:"/version" (module VersionCore)

--- a/src/common/model/version/versionSignature.mli
+++ b/src/common/model/version/versionSignature.mli
@@ -30,7 +30,8 @@ val make_and_save :
   ?disambiguation:string ->
   ?broken:bool ->
   content:string ->
-  modified_at:Date.t ->
+  modified_at:Datetime.t ->
+  created_at:Datetime.t ->
   unit -> t Lwt.t
 
 val search :

--- a/src/common/model/version/versionSignature.mli
+++ b/src/common/model/version/versionSignature.mli
@@ -30,6 +30,7 @@ val make_and_save :
   ?disambiguation:string ->
   ?broken:bool ->
   content:string ->
+  modified_at:Date.t ->
   unit -> t Lwt.t
 
 val search :

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -111,6 +111,7 @@ module Ly = struct
                   Set.make_temp ~name ~kind:(1, [bars, kind])
                     ~versions_and_parameters:[version, parameters]
                     ~order:[Internal 1]
+                    ~modified_at:(NesDate.now ())
                     ()
                 in
                 let%lwt for_dance = VersionParameters.for_dance parameters in

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -111,7 +111,7 @@ module Ly = struct
                   Set.make_temp ~name ~kind:(1, [bars, kind])
                     ~versions_and_parameters:[version, parameters]
                     ~order:[Internal 1]
-                    ~modified_at:(NesDate.now ())
+                    ~modified_at:(NesDate.today ())
                     ()
                 in
                 let%lwt for_dance = VersionParameters.for_dance parameters in

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -111,7 +111,8 @@ module Ly = struct
                   Set.make_temp ~name ~kind:(1, [bars, kind])
                     ~versions_and_parameters:[version, parameters]
                     ~order:[Internal 1]
-                    ~modified_at:(NesDate.today ())
+                    ~modified_at:(NesDatetime.now ())
+                    ~created_at:(NesDatetime.now ())
                     ()
                 in
                 let%lwt for_dance = VersionParameters.for_dance parameters in

--- a/src/server/model/book/book.ml
+++ b/src/server/model/book/book.ml
@@ -5,10 +5,10 @@ module E = Dancelor_common_model.BookEndpoints
 module A = E.Arguments
 
 let make_and_save
-    ?status ~title ?date ?contents_and_parameters ~modified_at ()
+    ?status ~title ?date ?contents_and_parameters ~modified_at ~created_at ()
   =
   Dancelor_server_database.Book.save ~slug_hint:title @@ fun slug ->
-  make ?status ~slug ~title ~date ?contents_and_parameters ~modified_at ()
+  make ?status ~slug ~title ~date ?contents_and_parameters ~modified_at ~created_at ()
 
 let () =
   Madge_server.(
@@ -24,6 +24,7 @@ let () =
       ?date:      (o A.date)
       ?contents_and_parameters
       ~modified_at: (a A.modified_at)
+      ~created_at: (a A.created_at)
       ()
   )
 
@@ -50,9 +51,11 @@ let () =
   )
 
 let update
-    ?status ~slug ~title ?date ?contents_and_parameters ~modified_at ()
+    ?status ~slug ~title ?date ?contents_and_parameters
+    ~modified_at ~created_at
+    ()
   =
-  let%lwt book = make ?status ~slug ~title ~date ?contents_and_parameters ~modified_at () in
+  let%lwt book = make ?status ~slug ~title ~date ?contents_and_parameters ~modified_at ~created_at () in
   Dancelor_server_database.Book.update book
 
 let () =
@@ -70,5 +73,6 @@ let () =
       ?date:      (o A.date)
       ?contents_and_parameters
       ~modified_at: (a A.modified_at)
+      ~created_at: (a A.created_at)
       ()
   )

--- a/src/server/model/book/book.ml
+++ b/src/server/model/book/book.ml
@@ -5,10 +5,10 @@ module E = Dancelor_common_model.BookEndpoints
 module A = E.Arguments
 
 let make_and_save
-    ?status ~title ?date ?contents_and_parameters ()
+    ?status ~title ?date ?contents_and_parameters ~modified_at ()
   =
   Dancelor_server_database.Book.save ~slug_hint:title @@ fun slug ->
-  make ?status ~slug ~title ~date ?contents_and_parameters ()
+  make ?status ~slug ~title ~date ?contents_and_parameters ~modified_at ()
 
 let () =
   Madge_server.(
@@ -23,6 +23,7 @@ let () =
       ~title:     (a A.title)
       ?date:      (o A.date)
       ?contents_and_parameters
+      ~modified_at: (a A.modified_at)
       ()
   )
 
@@ -49,9 +50,9 @@ let () =
   )
 
 let update
-    ?status ~slug ~title ?date ?contents_and_parameters ()
+    ?status ~slug ~title ?date ?contents_and_parameters ~modified_at ()
   =
-  let%lwt book = make ?status ~slug ~title ~date ?contents_and_parameters () in
+  let%lwt book = make ?status ~slug ~title ~date ?contents_and_parameters ~modified_at () in
   Dancelor_server_database.Book.update book
 
 let () =
@@ -68,5 +69,6 @@ let () =
       ~title:     (a A.title)
       ?date:      (o A.date)
       ?contents_and_parameters
+      ~modified_at: (a A.modified_at)
       ()
   )

--- a/src/server/model/credit/credit.ml
+++ b/src/server/model/credit/credit.ml
@@ -1,14 +1,14 @@
 open Nes
 include CreditLifted
 
-let make_and_save ?status ~line ?persons ?scddb_id () =
+let make_and_save ?status ~line ?persons ?scddb_id ~modified_at () =
   let%lwt persons =
     let%olwt persons = Lwt.return persons in
     let%lwt persons = Lwt_list.map_s Person.slug persons in
     Lwt.return_some persons
   in
   Dancelor_server_database.Credit.save ~slug_hint:line @@ fun slug ->
-  Lwt.return (make ?status ~slug ~line ?persons ~scddb_id ()) (* FIXME: status should probably go in save *)
+  Lwt.return (make ?status ~slug ~line ?persons ~scddb_id ~modified_at ()) (* FIXME: status should probably go in save *)
 
 let () =
   Madge_server.(
@@ -17,6 +17,7 @@ let () =
       ~line:   (a A.line)
       ?persons:(o A.persons)
       ?scddb_id:(o A.scddb_id)
+      ~modified_at:(a A.modified_at)
       ()
   )
 

--- a/src/server/model/credit/credit.ml
+++ b/src/server/model/credit/credit.ml
@@ -1,14 +1,14 @@
 open Nes
 include CreditLifted
 
-let make_and_save ?status ~line ?persons ?scddb_id ~modified_at () =
+let make_and_save ?status ~line ?persons ?scddb_id ~modified_at ~created_at () =
   let%lwt persons =
     let%olwt persons = Lwt.return persons in
     let%lwt persons = Lwt_list.map_s Person.slug persons in
     Lwt.return_some persons
   in
   Dancelor_server_database.Credit.save ~slug_hint:line @@ fun slug ->
-  Lwt.return (make ?status ~slug ~line ?persons ~scddb_id ~modified_at ()) (* FIXME: status should probably go in save *)
+  Lwt.return (make ?status ~slug ~line ?persons ~scddb_id ~modified_at ~created_at ()) (* FIXME: status should probably go in save *)
 
 let () =
   Madge_server.(
@@ -18,6 +18,7 @@ let () =
       ?persons:(o A.persons)
       ?scddb_id:(o A.scddb_id)
       ~modified_at:(a A.modified_at)
+      ~created_at:(a A.created_at)
       ()
   )
 

--- a/src/server/model/dance/dance.ml
+++ b/src/server/model/dance/dance.ml
@@ -5,10 +5,10 @@ module E = Dancelor_common_model.DanceEndpoints
 module A = E.Arguments
 
 let make_and_save
-    ?status ~name ~kind ?deviser ~two_chords ?scddb_id ()
+    ?status ~name ~kind ?deviser ~two_chords ?scddb_id ~modified_at ()
   =
   Dancelor_server_database.Dance.save ~slug_hint:name @@ fun slug ->
-  make ?status ~slug ~name ~kind ?deviser ~two_chords ?scddb_id ()
+  make ?status ~slug ~name ~kind ?deviser ~two_chords ?scddb_id ~modified_at ()
 
 let () =
   Madge_server.(
@@ -20,6 +20,7 @@ let () =
       ?deviser:     (o A.deviser)
       ~two_chords:  (a A.two_chords)
       ?scddb_id:    (o A.scddb_id)
+      ~modified_at: (a A.modified_at)
       ()
   )
 

--- a/src/server/model/dance/dance.ml
+++ b/src/server/model/dance/dance.ml
@@ -5,10 +5,15 @@ module E = Dancelor_common_model.DanceEndpoints
 module A = E.Arguments
 
 let make_and_save
-    ?status ~name ~kind ?deviser ~two_chords ?scddb_id ~modified_at ()
+    ?status ~name ~kind ?deviser ~two_chords ?scddb_id
+    ?disambiguation ~modified_at ~created_at
+    ()
   =
   Dancelor_server_database.Dance.save ~slug_hint:name @@ fun slug ->
-  make ?status ~slug ~name ~kind ?deviser ~two_chords ?scddb_id ~modified_at ()
+  make
+    ?status ~slug ~name ~kind ?deviser ~two_chords ?scddb_id
+    ?disambiguation ~modified_at ~created_at
+    ()
 
 let () =
   Madge_server.(
@@ -21,6 +26,7 @@ let () =
       ~two_chords:  (a A.two_chords)
       ?scddb_id:    (o A.scddb_id)
       ~modified_at: (a A.modified_at)
+      ~created_at:  (a A.created_at)
       ()
   )
 

--- a/src/server/model/person/person.ml
+++ b/src/server/model/person/person.ml
@@ -4,9 +4,9 @@ include PersonLifted
 module E = Dancelor_common_model.PersonEndpoints
 module A = E.Arguments
 
-let make_and_save ?status ~name ~modified_at () =
+let make_and_save ?status ~name ~modified_at ~created_at () =
   Dancelor_server_database.Person.save ~slug_hint:name @@ fun slug ->
-  Lwt.return (make ?status ~slug ~name ~modified_at ()) (* status should probably go in save *)
+  Lwt.return (make ?status ~slug ~name ~modified_at ~created_at ()) (* status should probably go in save *)
 
 let () =
   Madge_server.(
@@ -14,6 +14,7 @@ let () =
     make_and_save
       ~name:(a A.name)
       ~modified_at:(a A.modified_at)
+      ~created_at:(a A.created_at)
       ()
   )
 

--- a/src/server/model/person/person.ml
+++ b/src/server/model/person/person.ml
@@ -4,15 +4,16 @@ include PersonLifted
 module E = Dancelor_common_model.PersonEndpoints
 module A = E.Arguments
 
-let make_and_save ?status ~name () =
+let make_and_save ?status ~name ~modified_at () =
   Dancelor_server_database.Person.save ~slug_hint:name @@ fun slug ->
-  Lwt.return (make ?status ~slug ~name ()) (* status should probably go in save *)
+  Lwt.return (make ?status ~slug ~name ~modified_at ()) (* status should probably go in save *)
 
 let () =
   Madge_server.(
     register ~endpoint:E.make_and_save @@ fun {a} _ ->
     make_and_save
       ~name:(a A.name)
+      ~modified_at:(a A.modified_at)
       ()
   )
 

--- a/src/server/model/set/set.ml
+++ b/src/server/model/set/set.ml
@@ -4,9 +4,11 @@ include SetLifted
 module E = Dancelor_common_model.SetEndpoints
 module A = E.Arguments
 
-let make_and_save ?status ~name ?deviser ~kind ?versions_and_parameters ~order ?dances () =
+let make_and_save ?status ~name ?deviser ~kind
+    ?versions_and_parameters ~order ?dances ~modified_at () =
   Dancelor_server_database.Set.save ~slug_hint:name @@ fun slug ->
-  make ?status ~slug ~name ?deviser ~kind ?versions_and_parameters ~order ?dances ()
+  make ?status ~slug ~name ?deviser ~kind
+    ?versions_and_parameters ~order ?dances ~modified_at ()
 
 let () =
   Madge_server.(
@@ -19,6 +21,7 @@ let () =
       ?versions_and_parameters:(o A.versions_and_parameters)
       ~order:  (a A.order)
       ?dances: (o A.dances)
+      ~modified_at: (a A.modified_at)
       ()
   )
 

--- a/src/server/model/set/set.ml
+++ b/src/server/model/set/set.ml
@@ -4,11 +4,15 @@ include SetLifted
 module E = Dancelor_common_model.SetEndpoints
 module A = E.Arguments
 
-let make_and_save ?status ~name ?deviser ~kind
-    ?versions_and_parameters ~order ?dances ~modified_at () =
+let make_and_save
+    ?status ~name ?deviser ~kind ?versions_and_parameters
+    ~order ?dances ~modified_at ~created_at
+    ()
+  =
   Dancelor_server_database.Set.save ~slug_hint:name @@ fun slug ->
-  make ?status ~slug ~name ?deviser ~kind
-    ?versions_and_parameters ~order ?dances ~modified_at ()
+  make
+    ?status ~slug ~name ?deviser ~kind ?versions_and_parameters
+    ~order ?dances ~modified_at ~created_at ()
 
 let () =
   Madge_server.(
@@ -22,6 +26,7 @@ let () =
       ~order:  (a A.order)
       ?dances: (o A.dances)
       ~modified_at: (a A.modified_at)
+      ~created_at:  (a A.created_at)
       ()
   )
 

--- a/src/server/model/tune/tune.ml
+++ b/src/server/model/tune/tune.ml
@@ -6,10 +6,11 @@ module A = E.Arguments
 
 let make_and_save
     ?status ~name ?alternative_names
-    ~kind ?author ?dances ?remark ?scddb_id ()
+    ~kind ?author ?dances ?remark ?scddb_id ~modified_at ()
   =
   Dancelor_server_database.Tune.save ~slug_hint:name @@ fun slug ->
-  make ?status ~slug ~name ?alternative_names ~kind ?author ?dances ?remark ?scddb_id ()
+  make ?status ~slug ~name ?alternative_names
+    ~kind ?author ?dances ?remark ?scddb_id ~modified_at ()
 
 let () =
   Madge_server.(
@@ -23,6 +24,7 @@ let () =
       ?dances:  (o A.dances)
       ?remark:  (o A.remark)
       ?scddb_id:(o A.scddb_id)
+      ~modified_at:(a A.modified_at)
       ()
   )
 

--- a/src/server/model/tune/tune.ml
+++ b/src/server/model/tune/tune.ml
@@ -5,12 +5,15 @@ module E = Dancelor_common_model.TuneEndpoints
 module A = E.Arguments
 
 let make_and_save
-    ?status ~name ?alternative_names
-    ~kind ?author ?dances ?remark ?scddb_id ~modified_at ()
+    ?status ~name ?alternative_names ~kind ?author
+    ?dances ?remark ?scddb_id ~modified_at ~created_at
+    ()
   =
   Dancelor_server_database.Tune.save ~slug_hint:name @@ fun slug ->
-  make ?status ~slug ~name ?alternative_names
-    ~kind ?author ?dances ?remark ?scddb_id ~modified_at ()
+  make
+    ?status ~slug ~name ?alternative_names ~kind ?author
+    ?dances ?remark ?scddb_id ~modified_at ~created_at
+    ()
 
 let () =
   Madge_server.(
@@ -25,6 +28,7 @@ let () =
       ?remark:  (o A.remark)
       ?scddb_id:(o A.scddb_id)
       ~modified_at:(a A.modified_at)
+      ~created_at:(a A.created_at)
       ()
   )
 

--- a/src/server/model/version/version.ml
+++ b/src/server/model/version/version.ml
@@ -6,13 +6,13 @@ module A = E.Arguments
 
 let make_and_save
     ?status ~tune ~bars ~key ~structure ?arranger
-    ?remark ?disambiguation ?broken ~content ()
+    ?remark ?disambiguation ?broken ~content ~modified_at ()
   =
   let%lwt name = Tune.name tune in
   let%lwt version =
     Dancelor_server_database.Version.save ~slug_hint:name @@ fun slug ->
     make ~slug ?status ~tune ~bars ~key ~structure
-      ?arranger ?remark ?disambiguation ?broken ()
+      ?arranger ?remark ?disambiguation ?broken ~modified_at ()
   in
   Dancelor_server_database.Version.write_content version content;%lwt
   Lwt.return version
@@ -31,6 +31,7 @@ let () =
       ?disambiguation:(o A.disambiguation)
       ?broken:   (o A.broken)
       ~content:  (a A.content)
+      ~modified_at:(a A.modified_at)
       ()
   )
 

--- a/src/server/model/version/version.ml
+++ b/src/server/model/version/version.ml
@@ -5,14 +5,17 @@ module E = Dancelor_common_model.VersionEndpoints
 module A = E.Arguments
 
 let make_and_save
-    ?status ~tune ~bars ~key ~structure ?arranger
-    ?remark ?disambiguation ?broken ~content ~modified_at ()
+    ?status ~tune ~bars ~key ~structure ?arranger ?remark
+    ?disambiguation ?broken ~content ~modified_at ~created_at
+    ()
   =
   let%lwt name = Tune.name tune in
   let%lwt version =
     Dancelor_server_database.Version.save ~slug_hint:name @@ fun slug ->
-    make ~slug ?status ~tune ~bars ~key ~structure
-      ?arranger ?remark ?disambiguation ?broken ~modified_at ()
+    make
+      ~slug ?status ~tune ~bars ~key ~structure ?arranger ?remark
+      ?disambiguation ?broken ~modified_at ~created_at
+      ()
   in
   Dancelor_server_database.Version.write_content version content;%lwt
   Lwt.return version
@@ -32,6 +35,7 @@ let () =
       ?broken:   (o A.broken)
       ~content:  (a A.content)
       ~modified_at:(a A.modified_at)
+      ~created_at:(a A.created_at)
       ()
   )
 


### PR DESCRIPTION
https://gitlab.vlanvin.fr/paris-band/dancelor/-/merge_requests/72

This MR adds a `modified-at` field to all database objects. One might think that this field is included in the `git` logs; however, we will want to differentiate between updates that change the semantics of objects and updates that are here to fix things; the latter probably wouldn't count as modifications.

This MR is a first step: for now, this modification date is not shown for any object; but it will.