### PR TITLE
Trim strings in models

### DIFF
--- a/lib/nes/nesString.ml
+++ b/lib/nes/nesString.ml
@@ -307,4 +307,4 @@ let remove_duplicates ?(char_equal=Char.equal) ?(char=' ') input =
       (last_was_char := false;
        Buffer.add_char output input.[i])
   done;
-  trim ~char (Buffer.contents output)
+  trim ~char_equal ~char (Buffer.contents output)

--- a/src/common/model/credit/creditCore.ml
+++ b/src/common/model/credit/creditCore.ml
@@ -12,6 +12,13 @@ type t =
     created_at  : Datetime.t [@key "created-at"] }
 [@@deriving yojson, make]
 
+let make
+    ~slug ?status ~line ?persons ?scddb_id ~modified_at ~created_at
+    ()
+  =
+  let line = String.remove_duplicates ~char:' ' line in
+  make ~slug ?status ~line ?persons ?scddb_id ~modified_at ~created_at ()
+
 let slug c = Lwt.return c.slug
 let status c = Lwt.return c.status
 let line c = Lwt.return c.line

--- a/src/common/model/dance/danceCore.ml
+++ b/src/common/model/dance/danceCore.ml
@@ -20,6 +20,8 @@ let make
     ?disambiguation ~modified_at ~created_at
     ()
   =
+  let name = String.remove_duplicates ~char:' ' name in
+  let disambiguation = Option.map (String.remove_duplicates ~char:' ') disambiguation in
   let%lwt deviser =
     match deviser with
     | None -> Lwt.return_none

--- a/src/common/model/person/personCore.ml
+++ b/src/common/model/person/personCore.ml
@@ -10,6 +10,13 @@ type t =
     created_at  : Datetime.t [@key "created-at"] }
 [@@deriving yojson, make]
 
+let make
+    ~slug ?status ~name ~modified_at ~created_at
+    ()
+  =
+  let name = String.remove_duplicates ~char:' ' name in
+  make ~slug ?status ~name ~modified_at ~created_at ()
+
 let slug p = Lwt.return p.slug
 let status p = Lwt.return p.status
 let name p = Lwt.return p.name

--- a/src/common/model/set/setCore.ml
+++ b/src/common/model/set/setCore.ml
@@ -23,6 +23,7 @@ let make
     ~order ?dances ~modified_at ~created_at
     ()
   =
+  let name = String.remove_duplicates ~char:' ' name in
   let%lwt deviser =
     let%olwt deviser = Lwt.return deviser in
     let%lwt deviser = CreditCore.slug deviser in

--- a/src/common/model/tune/tuneCore.ml
+++ b/src/common/model/tune/tuneCore.ml
@@ -21,6 +21,8 @@ let make
     ?remark ?scddb_id ~modified_at ~created_at
     ()
   =
+  let name = String.remove_duplicates ~char:' ' name in
+  let alternative_names = Option.map (List.map (String.remove_duplicates ~char:' ')) alternative_names in
   let%lwt author =
     let%olwt author = Lwt.return author in
     let%lwt author_slug = CreditCore.slug author in

--- a/src/common/model/version/versionCore.ml
+++ b/src/common/model/version/versionCore.ml
@@ -23,6 +23,8 @@ let make
     ?disambiguation ?broken ~modified_at ~created_at
     ()
   =
+  let structure = String.remove_duplicates ~char:' ' structure in
+  let disambiguation = Option.map (String.remove_duplicates ~char:' ') disambiguation in
   let%lwt tune = TuneCore.slug tune in
   let%lwt arranger =
     let%olwt arranger = Lwt.return arranger in


### PR DESCRIPTION
This PR updates the `make` function of each model so as to trim all the given strings. This allows leaving random spaces in various places in the interface yet having a clean result.