### PR TITLE
Make comparison in `Madge_router`'s `with_slug_and_query` more resilient

### DIFF
--- a/lib/nes/nesList.ml
+++ b/lib/nes/nesList.ml
@@ -19,18 +19,34 @@ let hd_opt = function
   | [] -> None
   | h :: _ -> Some h
 
-let bd l =
-  let rec bd acc = function
-    | [] -> failwith "bd"
-    | [_] -> List.rev acc
-    | h::q -> bd (h::acc) q
-  in
-  bd [] l
+(* Bodies and feet. *)
 
-let rec ft = function
-  | [] -> failwith "ft"
-  | [e] -> e
-  | _::q -> ft q
+let bd_ft_opt xs =
+  let rec bd_ft_opt acc = function
+    | [] -> None
+    | [x] -> Some (List.rev acc, x)
+    | x::xs -> bd_ft_opt (x :: acc) xs
+  in
+  bd_ft_opt [] xs
+
+let bd_ft xs =
+  match bd_ft_opt xs with
+  | Some result -> result
+  | None -> failwith "bd_ft"
+
+let bd_opt l = Option.map fst (bd_ft_opt l)
+
+let bd l =
+  match bd_opt l with
+  | Some l -> l
+  | _ -> failwith "bd"
+
+let ft_opt l = Option.map snd (bd_ft_opt l)
+
+let ft l =
+  match ft_opt l with
+  | Some x -> x
+  | _ -> failwith "ft"
 
 let intertwine f l =
   let rec intertwine i = function

--- a/lib/nes/nesList.mli
+++ b/lib/nes/nesList.mli
@@ -37,12 +37,34 @@ val sub : int -> 'a t -> 'a t
 val hd_opt : 'a t -> 'a option
 (** Return the first element of the given list or [None] if the list is empty. *)
 
+(** {4 Bodies and feet} *)
+
 val bd : 'a t -> 'a list
-(** Return the given list without its last element.
+(** Return the body of the given list, that is the list without its last
+    element.
     @raise Failure if the list is empty. *)
 
+val bd_opt : 'a t -> 'a list option
+(** Return the body of the given list, that is the list without its last
+    element, or [None] if the list is empty. *)
+
 val ft : 'a t -> 'a
-(** Return the last element of the given list.
+(** Return the foot of the given list, that is the last element of the list.
+    @raise Failure if the list is empty. *)
+
+val ft_opt : 'a t -> 'a option
+(** Return the foot of the given list, that is the last element of the list, or
+    [None] if the list is empty. *)
+
+val bd_ft : 'a t -> 'a list * 'a
+(** Return the pair of the body and the foot of the given list, that is the list
+    without its last element and the last element.
+    @raise Failure if the list is empty. *)
+
+val bd_ft_opt : 'a t -> ('a list * 'a) option
+(** Return the pair of the body and the foot of the given list, that is the list
+    without its last element and the last element, or [None] if the list is
+    empty.
     @raise Failure if the list is empty. *)
 
 val intertwine : (int -> 'a) -> 'a t -> 'a t


### PR DESCRIPTION
#183 broke things. I am not exactly sure why the problem wasn't triggered before but I know why it is happening now. The comparison in `Madge_router`'s `with_slug_and_query` is very sensitive to slashes, which leads to paths such as `/api/set/tam-lin-thrice.pdf` not matching correctly. I make the paths comparison more resilient, which fixes the issue. There would be some cleanup to do but this is a hot fix.