### PR TITLE
Replace predicate `Is` by `Slug` in all models

### DIFF
--- a/src/client/model/book/bookFilter.ml
+++ b/src/client/model/book/bookFilter.ml
@@ -6,8 +6,9 @@ let accepts filter book =
   let char_equal = Char.Sensible.equal in
   Formula.interpret filter @@ function
 
-  | Is book' ->
-    equal book book' >|=| Formula.interpret_bool
+  | Slug book' ->
+    let%lwt book = Dancelor_common_model.BookCore.slug book in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal book book'
 
   | Title string ->
     let%lwt title = BookLifted.title book in

--- a/src/client/model/credit/creditFilter.ml
+++ b/src/client/model/credit/creditFilter.ml
@@ -6,8 +6,9 @@ let accepts filter credit =
   let char_equal = Char.Sensible.equal in
   Formula.interpret filter @@ function
 
-  | Is credit' ->
-    equal credit credit' >|=| Formula.interpret_bool
+  | Slug credit' ->
+    let%lwt credit = Dancelor_common_model.CreditCore.slug credit in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal credit credit'
 
   | Line string ->
     let%lwt line = CreditLifted.line credit in

--- a/src/client/model/dance/danceFilter.ml
+++ b/src/client/model/dance/danceFilter.ml
@@ -5,8 +5,9 @@ let accepts filter dance =
   let char_equal = Char.Sensible.equal in
   Formula.interpret filter @@ function
 
-  | Is dance' ->
-    DanceLifted.equal dance dance' >|=| Formula.interpret_bool
+  | Slug dance' ->
+    let%lwt dance = Dancelor_common_model.DanceCore.slug dance in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal dance dance'
 
   | Name string ->
     let%lwt name = DanceLifted.name dance in

--- a/src/client/model/person/personFilter.ml
+++ b/src/client/model/person/personFilter.ml
@@ -1,1 +1,18 @@
+open Nes
 include Dancelor_common_model.PersonFilter
+
+let accepts filter person =
+  let char_equal = Char.Sensible.equal in
+  Formula.interpret filter @@ function
+
+  | Slug person' ->
+    let%lwt person = PersonLifted.slug person in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal person person'
+
+  | Name string ->
+    let%lwt name = PersonLifted.name person in
+    Lwt.return (String.proximity ~char_equal string name)
+
+  | NameMatches string ->
+    let%lwt name = PersonLifted.name person in
+    Lwt.return (String.inclusion_proximity ~char_equal ~needle:string name)

--- a/src/client/model/set/setFilter.ml
+++ b/src/client/model/set/setFilter.ml
@@ -5,8 +5,9 @@ let accepts filter set =
   let char_equal = Char.Sensible.equal in
   Formula.interpret filter @@ function
 
-  | Is set' ->
-    Set.equal set set' >|=| Formula.interpret_bool
+  | Slug set' ->
+    let%lwt set = Dancelor_common_model.SetCore.slug set in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal set set'
 
   | Name string ->
     let%lwt name = Set.name set in

--- a/src/client/model/tune/tuneFilter.ml
+++ b/src/client/model/tune/tuneFilter.ml
@@ -1,13 +1,13 @@
 open Nes
-open TuneLifted
 include Dancelor_common_model.TuneFilter
 
 let accepts filter tune =
   let char_equal = Char.Sensible.equal in
   Formula.interpret filter @@ function
 
-  | Is tune' ->
-    equal tune tune' >|=| Formula.interpret_bool
+  | Slug tune' ->
+    let%lwt tune = Dancelor_common_model.TuneCore.slug tune in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal tune tune'
 
   | Name string ->
     let%lwt name = TuneLifted.name tune in

--- a/src/client/model/version/versionFilter.ml
+++ b/src/client/model/version/versionFilter.ml
@@ -5,8 +5,9 @@ include Dancelor_common_model.VersionFilter
 let accepts filter version =
   Formula.interpret filter @@ function
 
-  | Is version' ->
-    equal version version' >|=| Formula.interpret_bool
+  | Slug version' ->
+    let%lwt version = Dancelor_common_model.VersionCore.slug version in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal version version'
 
   | Tune tfilter ->
     let%lwt tune = VersionLifted.tune version in

--- a/src/common/model/book/bookFilter.ml
+++ b/src/common/model/book/bookFilter.ml
@@ -3,7 +3,7 @@ open Nes
 let _key = "book-filter"
 
 type predicate =
-  | Is of BookCore.t
+  | Slug of BookCore.t Slug.t
   | IsSource
   | Title of string
   | TitleMatches of string
@@ -17,7 +17,8 @@ type predicate =
 type t = predicate Formula.t
 [@@deriving yojson]
 
-let is book = Formula.pred (Is book)
+let slug book = Formula.pred (Slug book)
+let is book = slug book.BookCore.slug
 let title string = Formula.pred (Title string)
 let titleMatches string = Formula.pred (TitleMatches string)
 let subtitle string = Formula.pred (Subtitle string)

--- a/src/common/model/credit/creditFilter.ml
+++ b/src/common/model/credit/creditFilter.ml
@@ -3,7 +3,7 @@ open Nes
 let _key = "credit-filter"
 
 type predicate =
-  | Is of CreditCore.t
+  | Slug of CreditCore.t Slug.t
   | Line of string
   | LineMatches of string
   | ExistsPerson of PersonFilter.t
@@ -12,7 +12,8 @@ type predicate =
 type t = predicate Formula.t
 [@@deriving yojson]
 
-let is credit = Formula.pred (Is credit)
+let slug credit = Formula.pred (Slug credit)
+let is credit = slug credit.CreditCore.slug
 let line line = Formula.pred (Line line)
 let lineMatches line = Formula.pred (LineMatches line)
 let existsPerson pfilter = Formula.pred (ExistsPerson pfilter)

--- a/src/common/model/dance/danceFilter.ml
+++ b/src/common/model/dance/danceFilter.ml
@@ -3,7 +3,7 @@ open Nes
 let _key = "dance-filter"
 
 type predicate =
-  | Is of DanceCore.t
+  | Slug of DanceCore.t Slug.t
   | Name of string
   | NameMatches of string
   | Kind of KindFilter.Dance.t
@@ -13,7 +13,8 @@ type predicate =
 type t = predicate Formula.t
 [@@deriving yojson]
 
-let is dance = Formula.pred (Is dance)
+let slug dance = Formula.pred (Slug dance)
+let is dance = slug dance.DanceCore.slug
 let name name = Formula.pred (Name name)
 let nameMatches name = Formula.pred (NameMatches name)
 let kind kfilter = Formula.pred (Kind kfilter)

--- a/src/common/model/person/personFilter.ml
+++ b/src/common/model/person/personFilter.ml
@@ -18,22 +18,6 @@ let nameMatches name = Formula.pred (NameMatches name)
 
 let raw string = Ok (nameMatches string)
 
-let accepts filter person =
-  let char_equal = Char.Sensible.equal in
-  Formula.interpret filter @@ function
-
-  | Slug person' ->
-    let%lwt person = PersonCore.slug person in
-    Lwt.return @@ Formula.interpret_bool @@ Slug.equal person person'
-
-  | Name string ->
-    let%lwt name = PersonCore.name person in
-    Lwt.return (String.proximity ~char_equal string name)
-
-  | NameMatches string ->
-    let%lwt name = PersonCore.name person in
-    Lwt.return (String.inclusion_proximity ~char_equal ~needle:string name)
-
 let nullary_text_predicates = []
 
 let unary_text_predicates =

--- a/src/common/model/set/setFilter.ml
+++ b/src/common/model/set/setFilter.ml
@@ -3,7 +3,7 @@ open Nes
 let _key = "set-filter"
 
 type predicate =
-  | Is of SetCore.t
+  | Slug of SetCore.t Slug.t
   | Name of string
   | NameMatches of string
   | Deviser of CreditFilter.t (** deviser is defined and passes the filter *)
@@ -14,7 +14,8 @@ type predicate =
 type t = predicate Formula.t
 [@@deriving yojson]
 
-let is set = Formula.pred (Is set)
+let slug set = Formula.pred (Slug set)
+let is set = slug set.SetCore.slug
 let name name = Formula.pred (Name name)
 let nameMatches name = Formula.pred (NameMatches name)
 let deviser cfilter = Formula.pred (Deviser cfilter)

--- a/src/common/model/tune/tuneFilter.ml
+++ b/src/common/model/tune/tuneFilter.ml
@@ -3,7 +3,7 @@ open Nes
 let _key = "tune-filter"
 
 type predicate =
-  | Is of TuneCore.t
+  | Slug of TuneCore.t Slug.t
   | Name of string
   | NameMatches of string
   | Author of CreditFilter.t (** author is defined and passes the filter *)
@@ -14,7 +14,8 @@ type predicate =
 type t = predicate Formula.t
 [@@deriving yojson]
 
-let is tune = Formula.pred (Is tune)
+let slug tune = Formula.pred (Slug tune)
+let is tune = slug tune.TuneCore.slug
 let name string = Formula.pred (Name string)
 let nameMatches string = Formula.pred (NameMatches string)
 let author cfilter = Formula.pred (Author cfilter)

--- a/src/common/model/version/versionFilter.ml
+++ b/src/common/model/version/versionFilter.ml
@@ -3,7 +3,7 @@ open Nes
 let _key = "version-filter"
 
 type predicate =
-  | Is of VersionCore.t
+  | Slug of VersionCore.t Slug.t
   | Tune of TuneFilter.t
   | Key of Music.key
   | Kind of KindFilter.Version.t
@@ -13,7 +13,8 @@ type predicate =
 type t = predicate Formula.t
 [@@deriving yojson]
 
-let is version = Formula.pred (Is version)
+let slug version = Formula.pred (Slug version)
+let is version = slug version.VersionCore.slug
 let tune tfilter = Formula.pred (Tune tfilter)
 let tuneIs tune_ = tune (TuneFilter.is tune_)
 let key key_ = Formula.pred (Key key_)

--- a/src/server/model/book/bookFilter.ml
+++ b/src/server/model/book/bookFilter.ml
@@ -6,8 +6,9 @@ let accepts filter book =
   let char_equal = Char.Sensible.equal in
   Formula.interpret filter @@ function
 
-  | Is book' ->
-    equal book book' >|=| Formula.interpret_bool
+  | Slug book' ->
+    let%lwt book = Dancelor_common_model.BookCore.slug book in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal book book'
 
   | Title string ->
     let%lwt title = BookLifted.title book in

--- a/src/server/model/credit/creditFilter.ml
+++ b/src/server/model/credit/creditFilter.ml
@@ -6,8 +6,9 @@ let accepts filter credit =
   let char_equal = Char.Sensible.equal in
   Formula.interpret filter @@ function
 
-  | Is credit' ->
-    equal credit credit' >|=| Formula.interpret_bool
+  | Slug credit' ->
+    let%lwt credit = Dancelor_common_model.CreditCore.slug credit in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal credit credit'
 
   | Line string ->
     let%lwt line = CreditLifted.line credit in

--- a/src/server/model/dance/danceFilter.ml
+++ b/src/server/model/dance/danceFilter.ml
@@ -5,8 +5,9 @@ let accepts filter dance =
   let char_equal = Char.Sensible.equal in
   Formula.interpret filter @@ function
 
-  | Is dance' ->
-    DanceLifted.equal dance dance' >|=| Formula.interpret_bool
+  | Slug dance' ->
+    let%lwt dance = Dancelor_common_model.DanceCore.slug dance in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal dance dance'
 
   | Name string ->
     let%lwt name = DanceLifted.name dance in

--- a/src/server/model/person/personFilter.ml
+++ b/src/server/model/person/personFilter.ml
@@ -1,1 +1,18 @@
+open Nes
 include Dancelor_common_model.PersonFilter
+
+let accepts filter person =
+  let char_equal = Char.Sensible.equal in
+  Formula.interpret filter @@ function
+
+  | Slug person' ->
+    let%lwt person = PersonLifted.slug person in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal person person'
+
+  | Name string ->
+    let%lwt name = PersonLifted.name person in
+    Lwt.return (String.proximity ~char_equal string name)
+
+  | NameMatches string ->
+    let%lwt name = PersonLifted.name person in
+    Lwt.return (String.inclusion_proximity ~char_equal ~needle:string name)

--- a/src/server/model/set/setFilter.ml
+++ b/src/server/model/set/setFilter.ml
@@ -5,8 +5,9 @@ let accepts filter set =
   let char_equal = Char.Sensible.equal in
   Formula.interpret filter @@ function
 
-  | Is set' ->
-    SetLifted.equal set set' >|=| Formula.interpret_bool
+  | Slug set' ->
+    let%lwt set = Dancelor_common_model.SetCore.slug set in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal set set'
 
   | Name string ->
     let%lwt name = SetLifted.name set in

--- a/src/server/model/tune/tuneFilter.ml
+++ b/src/server/model/tune/tuneFilter.ml
@@ -1,13 +1,13 @@
 open Nes
-open TuneLifted
 include Dancelor_common_model.TuneFilter
 
 let accepts filter tune =
   let char_equal = Char.Sensible.equal in
   Formula.interpret filter @@ function
 
-  | Is tune' ->
-    equal tune tune' >|=| Formula.interpret_bool
+  | Slug tune' ->
+    let%lwt tune = Dancelor_common_model.TuneCore.slug tune in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal tune tune'
 
   | Name string ->
     let%lwt name = TuneLifted.name tune in

--- a/src/server/model/version/versionFilter.ml
+++ b/src/server/model/version/versionFilter.ml
@@ -5,8 +5,9 @@ include Dancelor_common_model.VersionFilter
 let accepts filter version =
   Formula.interpret filter @@ function
 
-  | Is version' ->
-    equal version version' >|=| Formula.interpret_bool
+  | Slug version' ->
+    let%lwt version = Dancelor_common_model.VersionCore.slug version in
+    Lwt.return @@ Formula.interpret_bool @@ Slug.equal version version'
 
   | Tune tfilter ->
     let%lwt tune = VersionLifted.tune version in


### PR DESCRIPTION
_builds on top of #220 and should be merged after that one_
_meant to be squashed_

Minor update to share with you in this pull request. We've made a small adjustment by replacing the existing high-level predicate `Is` with a lower-level predicate called `Slug`. The former predicate can be recovered by encoding it within the latter.

The impact of this modification is not significant, but it does have some positive implications for future pull requests, particularly related to URI-based search functionality.