### PR TITLE
Setup Nix caches for Dancelor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
             ## Access token to avoid triggering GitHub's rate limiting.
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Nix caches
+        uses: cachix/cachix-action@v12
+        with:
+          name: dancelor
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
       - name: Build Nix environment
         run: nix develop --command true
 

--- a/flake.nix
+++ b/flake.nix
@@ -45,4 +45,13 @@
         ./.nix/timidity-overlay.nix
       ];
     };
+
+  nixConfig = {
+    extra-trusted-substituters =
+      [ "https://dancelor.cachix.org/" "https://pre-commit-hooks.cachix.org/" ];
+    extra-trusted-public-keys = [
+      "dancelor.cachix.org-1:Q2pAI0MA6jIccQQeT8JEsY+Wfwb/751zmoUHddZmDyY="
+      "pre-commit-hooks.cachix.org-1:Pkk3Panw5AW24TOv6kz3PvLhlH8puAsJTBbOPmBo7Rc="
+    ];
+  };
 }


### PR DESCRIPTION
This PR follows the recent announcement of Cachix that finally gave a free 5GB to organisations. There is now a “Paris Branch” Cachix organisation and a `dancelor.cachix.org` cache. The PR sets up CI so that it feeds the Cachix instance. It also adds this Cachix instance (and the one for `pre-commit-hooks`) in the flake. For non-Nix users, this will make no difference. For Nix users, this will allow to download the whole development environment instead of having to build it again. It will also make the Nix part of the CI much faster, but it was already tie with the OPAM part so the overall execution time will remain the same.