### PR TITLE
Introduce richer dance kinds

### DIFF
--- a/src/client/views/set/setEditorInterface.ml
+++ b/src/client/views/set/setEditorInterface.ml
@@ -356,8 +356,8 @@ let create page =
     Inputs.Button.create ~kind:Inputs.Button.Kind.Success ~icon:"save" ~text:"Save"
       ~on_click:(fun () ->
           let b1, b2, b3, b4, b5 =
-            Inputs.Text.check t.input_kind Kind.Dance.check,
-            Inputs.Text.check t.input_name (fun str -> str <> ""),
+            Inputs.Text.check t.input_kind (Option.is_some % Kind.Dance.of_string_opt),
+            Inputs.Text.check t.input_name ((<>) ""),
             Inputs.Text.check (SearchBar.bar t.version_search)
               (fun _ -> SetEditor.count t.composer > 0),
             Inputs.Text.check (SearchBar.bar t.deviser_search)

--- a/src/common/model/kind/dune
+++ b/src/common/model/kind/dune
@@ -1,0 +1,4 @@
+(ocamllex kindDanceLexer)
+
+(menhir
+ (modules kindDanceParser))

--- a/src/common/model/kind/kindDance.ml
+++ b/src/common/model/kind/kindDance.ml
@@ -2,7 +2,7 @@ open Nes
 
 let _key = "kind-dance"
 
-type t = int * KindVersion.t list
+include KindDanceType
 
 let to_string (repeats, versions) =
   List.map KindVersion.to_string versions

--- a/src/common/model/kind/kindDance.ml
+++ b/src/common/model/kind/kindDance.ml
@@ -50,8 +50,6 @@ let rec to_pretty_string = function
 
 (* Filters *)
 
-type dance_kind = t (* needed for signature of filters *)
-
 module Filter = struct
   type predicate =
     | Is of t

--- a/src/common/model/kind/kindDance.ml
+++ b/src/common/model/kind/kindDance.ml
@@ -81,9 +81,11 @@ module Filter = struct
        | _ -> Lwt.return Formula.interpret_false)
 
     | Version vfilter ->
-      (match kind with
-       | Mul (_, Version vkind) -> KindVersion.Filter.accepts vfilter vkind
-       | _ -> Lwt.return Formula.interpret_false)
+      Lwt.map
+        Formula.interpet_and_l
+        (Lwt_list.map_s
+           (KindVersion.Filter.accepts vfilter)
+           (version_kinds kind))
 
   let raw string =
     match KindBase.of_string_opt string with

--- a/src/common/model/kind/kindDance.ml
+++ b/src/common/model/kind/kindDance.ml
@@ -48,6 +48,11 @@ let rec to_pretty_string = function
     (match kind with Add _ -> spf "%d x (%s)" | _ -> spf "%d x %s")
       n (to_pretty_string kind)
 
+let rec version_kinds = function
+  | Version vkind -> [vkind]
+  | Add (kind1, kind2) -> version_kinds kind1 @ version_kinds kind2
+  | Mul (_n, kind) -> version_kinds kind
+
 (* Filters *)
 
 module Filter = struct

--- a/src/common/model/kind/kindDance.mli
+++ b/src/common/model/kind/kindDance.mli
@@ -14,8 +14,6 @@ val of_string_opt : string -> t option
 val to_pretty_string : t -> string
 (** Pretty version *)
 
-val check : string -> bool
-
 val to_yojson : t -> Json.t
 val of_yojson : Json.t -> (t, string) result
 

--- a/src/common/model/kind/kindDance.mli
+++ b/src/common/model/kind/kindDance.mli
@@ -17,6 +17,10 @@ val to_pretty_string : t -> string
 val to_yojson : t -> Json.t
 val of_yojson : Json.t -> (t, string) result
 
+val version_kinds : t -> KindVersion.t list
+(** Returns the version kinds contained in the dance kind. For instance, for
+    [2x32R + 8x(40R + 64J)], {!version_kinds} returns [\[32R; 40R; 64J\]]. *)
+
 (** {2 Filters} *)
 
 module Filter : sig

--- a/src/common/model/kind/kindDance.mli
+++ b/src/common/model/kind/kindDance.mli
@@ -4,8 +4,8 @@ open Nes
 
 val _key : string
 
-type t = int * KindVersion.t list
-(** The kind of a dance. For instance, [7x(32R + 64S + 128J)]. *)
+include module type of KindDanceType
+(** The kind of a dance. For instance, [7x(32R + 2x64S + 128J)]. *)
 
 val to_string : t -> string
 val of_string : string -> t

--- a/src/common/model/kind/kindDance.mli
+++ b/src/common/model/kind/kindDance.mli
@@ -19,15 +19,12 @@ val of_yojson : Json.t -> (t, string) result
 
 (** {2 Filters} *)
 
-type dance_kind = t
-(** Alias for {!t} needed for the type interface of {!Filter}. *)
-
 module Filter : sig
   type t [@@deriving yojson]
 
-  val accepts : t -> dance_kind -> float Lwt.t
+  val accepts : t -> KindDanceType.t -> float Lwt.t
 
-  val is : dance_kind -> t
+  val is : KindDanceType.t -> t
   val base : KindBase.Filter.t -> t
 
   val raw : string -> t TextFormula.or_error

--- a/src/common/model/kind/kindDanceLexer.mll
+++ b/src/common/model/kind/kindDanceLexer.mll
@@ -1,0 +1,20 @@
+{
+  open Nes
+  open KindDanceParser
+
+  exception UnexpectedCharacter of char
+}
+
+let alpha = ['a'-'z' 'A'-'Z']
+let digit = ['0'-'9']
+
+rule token = parse
+  | ' ' { token lexbuf }
+  | '(' { LPAR }
+  | ')' { RPAR }
+  | '+' { PLUS }
+  | 'x' { TIMES }
+  | digit+ as n { NUMBER (int_of_string n) }
+  | alpha+ as w { WORD w }
+  | _ as c { failwith (spf "Unexpected character: %c" c) }
+  | eof { EOF }

--- a/src/common/model/kind/kindDanceParser.mly
+++ b/src/common/model/kind/kindDanceParser.mly
@@ -1,0 +1,23 @@
+%{
+  open KindDanceType
+%}
+
+%token TIMES PLUS RPAR LPAR
+%token<string> WORD
+%token<int> NUMBER
+%token EOF
+
+%left TIMES
+%left PLUS
+
+%start<KindDanceType.t> main
+%%
+
+main:
+  | e=expression EOF { e }
+
+expression:
+  | n=NUMBER w=WORD { Version (n, KindBase.of_string w) }
+  | e1=expression PLUS e2=expression { Add (e1, e2) }
+  | n=NUMBER TIMES e=expression { Mul (n, e) }
+  | LPAR e=expression RPAR { e }

--- a/src/common/model/kind/kindDanceType.ml
+++ b/src/common/model/kind/kindDanceType.ml
@@ -1,0 +1,4 @@
+type t =
+  | Version of KindVersion.t
+  | Add of t * t
+  | Mul of int * t

--- a/src/common/model/set/setLifter.ml
+++ b/src/common/model/set/setLifter.ml
@@ -97,14 +97,10 @@ module Lift
     (* Check that version kinds and bars correspond to set's kind. *)
     let%lwt (bars, kind) =
       match%lwt kind s with
-      | (_, []) ->
-        add_warning WrongKind;
-        Lwt.return (32, Kind.Base.Reel) (* FIXME *)
-      | (_, [(bars, kind)]) ->
-        Lwt.return (bars, kind)
-      | (_, (bars, kind) :: _) ->
+      | Mul (_, Version (bars, kind)) -> Lwt.return (bars, kind)
+      | _ ->
         (* FIXME: more complicated that it appears *)
-        Lwt.return (bars, kind)
+        Lwt.return (32, KindBase.Reel) (* FIXME *)
     in
     let%lwt versions =
       let%lwt versions_and_parameters = versions_and_parameters s in

--- a/src/common/model/set/setLifter.ml
+++ b/src/common/model/set/setLifter.ml
@@ -99,8 +99,12 @@ module Lift
       match%lwt kind s with
       | Mul (_, Version (bars, kind)) -> Lwt.return (bars, kind)
       | _ ->
-        (* FIXME: more complicated that it appears *)
-        Lwt.return (32, KindBase.Reel) (* FIXME *)
+        (* FIXME: more complicated that it appears: For sets that have a medley
+           kind, checking that “the version has a compatible kind” makes little
+           sense. I don't think there is a very good solution right now; ideally
+           later we should check that the versions “added” as per the set's
+           order sum up to the kind of the set, but that's more involved. *)
+        Lwt.return (32, KindBase.Reel)
     in
     let%lwt versions =
       let%lwt versions_and_parameters = versions_and_parameters s in

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -107,7 +107,7 @@ module Ly = struct
                 let%lwt kind = Tune.kind tune in
                 let parameters = VersionParameters.set_display_name trivia parameters in
                 let%lwt set =
-                  Set.make_temp ~name ~kind:(1, [bars, kind])
+                  Set.make_temp ~name ~kind:(Kind.Dance.Version (bars, kind))
                     ~versions_and_parameters:[version, parameters]
                     ~order:[Internal 1]
                     ~modified_at:(NesDatetime.now ())


### PR DESCRIPTION
closes https://github.com/paris-branch/dancelor/issues/86

Previous dance kinds were fairly limited, supporting only a product of sums. This is no good for dance kinds such as `2x32S + 2x32R` or `40R + 8x32R + 40R` and the likes. We generalise kinds to arithmetic expressions with scalar multiplication and sums. This is probably way too generic but also not harder to handle than a tighter generalisation.

The commits do not compile but they are meant to make reviewing easy. I therefore recommend reading this PR one commit at a time (GitHub's interface makes it easy). The PR should then be squashed.

WDYT?