### PR TITLE
Rewrite the set explorer using the new TyXML-based API

### DIFF
--- a/lib/nes/nesPervasives.ml
+++ b/lib/nes/nesPervasives.ml
@@ -68,3 +68,5 @@ let rec first_non_zero ?(or_=0) = function
 
 let (%) f g = fun x -> f (g x)
 let (%>) f g = fun x -> f x |> g
+
+let flip f = fun x y -> f y x

--- a/lib/nes/nesPervasives.ml
+++ b/lib/nes/nesPervasives.ml
@@ -68,5 +68,3 @@ let rec first_non_zero ?(or_=0) = function
 
 let (%) f g = fun x -> f (g x)
 let (%>) f g = fun x -> f x |> g
-
-let flip f = fun x y -> f y x

--- a/src/client/elements/dune
+++ b/src/client/elements/dune
@@ -6,4 +6,4 @@
  (preprocess
   (pps lwt_ppx js_of_ocaml-ppx))
  (libraries js_of_ocaml-lwt cohttp-lwt-jsoo dancelor.common
-   dancelor.client.model dancelor.client.html dancelor.nes))
+   dancelor.client.model dancelor.client.html dancelor.nes lwt_react))

--- a/src/client/elements/pageNavNewAPI.ml
+++ b/src/client/elements/pageNavNewAPI.ml
@@ -50,17 +50,18 @@ let button page pagination =
     [
       button ~a: [
         a_button_type `Button;
-      ] [
-        txt (string_of_int (1 + page))
+        a_onclick
+          (fun _ ->
+             pagination.updater (fun state -> { state with current_page = page });
+             false)
       ]
+        [txt (string_of_int (1 + page))]
     ]
 
 let status_text pagination =
   S.bind pagination.signal @@ fun state ->
   S.const @@
-  if state.current_page = 0 then
-    "Loading entries..."
-  else if state.number_of_entries = 0 then
+  if state.number_of_entries = 0 then
     "No entries"
   else
     let pagination = current_pagination state in

--- a/src/client/elements/pageNavNewAPI.ml
+++ b/src/client/elements/pageNavNewAPI.ml
@@ -3,7 +3,7 @@ open Dancelor_common_model
 open Dancelor_client_html.NewAPI
 
 type state = {
-  current_page : int; (* first page is [0] *)
+  current_page : int; (* first page is [1] *)
   entries_per_page : int;
   number_of_entries : int;
 }
@@ -15,9 +15,10 @@ let number_of_pages state =
   / state.entries_per_page
 
 let current_pagination state =
+  (* NOTE: Our page numbers start at 1. *)
   Pagination.{
-    start = state.current_page * state.entries_per_page;
-    end_ = (state.current_page + 1) * state.entries_per_page;
+    start = (state.current_page - 1) * state.entries_per_page;
+    end_ = min (state.current_page * state.entries_per_page) state.number_of_entries;
   }
 
 type t = {
@@ -28,7 +29,7 @@ type t = {
 
 let create ~number_of_entries ~entries_per_page =
   let initial = {
-    current_page = 0;
+    current_page = 1;
     entries_per_page;
     number_of_entries = 0;
   }
@@ -50,38 +51,104 @@ let status_text pagination =
       (Pagination.end_ pagination)
       state.number_of_entries
 
-let button page text pagination =
-  li
-    ~a:[
-      R.a_class (
-        flip S.map pagination.signal @@ fun state ->
-        if page = state.current_page then ["active"] else []
-      )
-    ]
-    [
-      button ~a: [
-        a_button_type `Button;
-        a_onclick
-          (fun _ ->
-             pagination.updater (fun state -> { state with current_page = page });
-             false)
+module Button = struct
+  (** [make ~active ~enabled ~target ~text pagination] is a button that shows
+      [text]. It is active (that is, it shows as different from the other) when
+      the predicate [active] returns [true] on the [pagination] state. It is
+      enabled (that is not grayed out and clickable) when the predicate [enabled]
+      returns [true] on the [pagination] state. It changes the page to the result
+      of [target] applied on the [pagination] state. *)
+  let make ~active ~enabled ~target ~text pagination =
+    li
+      ~a:[
+        R.a_class (
+          flip S.map pagination.signal @@ fun state ->
+          if active state then ["active"] else []
+        )
       ]
-        [txt text]
-    ]
+      [
+        button ~a: [
+          a_button_type `Button;
+          R.a_class (
+            flip S.map pagination.signal @@ fun state ->
+            if enabled state then ["clickable"] else ["disabled"]
+          );
+          a_onclick
+            (fun _ ->
+               let state = S.value pagination.signal in
+               if enabled state then
+                 pagination.updater (fun state ->
+                     { state with current_page = target state }
+                   );
+               false
+            )
+        ]
+          [txt text]
+      ]
+
+  (** A button that is never enabled and shows three dots. *)
+  let ellipsis =
+    make
+      ~active:(Fun.const false)
+      ~enabled:(Fun.const false)
+      ~target:(fun _ -> assert false)
+      ~text:"..."
+
+  (** A button that is constantly linked to a page number. *)
+  let numbered page =
+    make
+      ~active:(fun state -> state.current_page = page)
+      ~enabled:(Fun.const true)
+      ~target:(Fun.const page)
+      ~text:(string_of_int page)
+
+  (** A button that brings to the previous page. *)
+  let previous =
+    make
+      ~active:(Fun.const false)
+      ~enabled:(fun state -> state.current_page <> 1)
+      ~target:(fun state -> state.current_page - 1)
+      ~text:"Previous"
+
+  (** A button that brings to the next page. *)
+  let next =
+    make
+      ~active:(Fun.const false)
+      ~enabled:(fun state -> state.current_page <> number_of_pages state)
+      ~target:(fun state -> state.current_page + 1)
+      ~text:"Next"
+end
 
 let button_list pagination =
   flip S.map pagination.signal @@ fun state ->
-  [
-    button 0 "First" pagination
-  ]
-  @
-  List.init
-    (number_of_pages state)
-    (fun page -> button page (string_of_int (1 + page)) pagination)
-  @
-  [
-    button (number_of_pages state - 1) "Last" pagination
-  ]
+  let number_of_pages = number_of_pages state
+  and current_page = state.current_page
+  in
+  (* Select the page numbers to show. *)
+  let relevant_page_numbers =
+    number_of_pages
+    |> flip List.init ((+) 1)
+    |> List.filter
+      (fun i ->
+         i = 1
+         || i = number_of_pages
+         || abs (current_page - i) <= 2
+      )
+  in
+  let rec numbered_buttons previous = function
+    | [] -> []
+    | page_number :: page_numbers ->
+      (if page_number <> previous + 1 then [Button.ellipsis] else [])
+      @ [Button.numbered page_number]
+      @ numbered_buttons page_number page_numbers
+  in
+  List.map
+    (fun button -> button pagination)
+    (
+      [Button.previous]
+      @ numbered_buttons 0 relevant_page_numbers @
+      [Button.next]
+    )
 
 let render pagination =
   div ~a:[a_id "page_nav"] [

--- a/src/client/elements/pageNavNewAPI.ml
+++ b/src/client/elements/pageNavNewAPI.ml
@@ -25,7 +25,7 @@ type t = {
   updater : (state -> state) -> unit;
 }
 
-let create ~entries_per_page =
+let create ~number_of_entries ~entries_per_page =
   let initial = {
     current_page = 0;
     entries_per_page;
@@ -34,6 +34,8 @@ let create ~entries_per_page =
   in
   let (signal, setter) = S.create initial in
   let updater f = setter (f (S.value signal)) in
+  Lwt.on_success number_of_entries (fun number_of_entries ->
+      updater (fun state -> { state with number_of_entries }));
   { signal; setter; updater }
 
 let button page _pagination =
@@ -59,7 +61,7 @@ let button_list pagination =
   )
 
 let render pagination =
-  div [
+  div ~a:[a_id "page_nav"] [
     div [R.txt (status_text pagination)];
     R.ul (button_list pagination);
   ]

--- a/src/client/elements/pageNavNewAPI.ml
+++ b/src/client/elements/pageNavNewAPI.ml
@@ -40,8 +40,7 @@ let create ~number_of_entries ~entries_per_page =
   { signal; setter; updater }
 
 let status_text pagination =
-  S.bind pagination.signal @@ fun state ->
-  S.const @@
+  flip S.map pagination.signal @@ fun state ->
   if state.number_of_entries = 0 then
     "No entries"
   else
@@ -55,8 +54,8 @@ let button page text pagination =
   li
     ~a:[
       R.a_class (
-        S.bind pagination.signal @@ fun state ->
-        S.const @@ if page = state.current_page then ["active"] else []
+        flip S.map pagination.signal @@ fun state ->
+        if page = state.current_page then ["active"] else []
       )
     ]
     [
@@ -71,20 +70,18 @@ let button page text pagination =
     ]
 
 let button_list pagination =
-  S.bind pagination.signal @@ fun state ->
-  S.const (
-    [
-      button 0 "First" pagination
-    ]
-    @
-    List.init
-      (number_of_pages state)
-      (fun page -> button page (string_of_int (1 + page)) pagination)
-    @
-    [
-      button (number_of_pages state - 1) "Last" pagination
-    ]
-  )
+  flip S.map pagination.signal @@ fun state ->
+  [
+    button 0 "First" pagination
+  ]
+  @
+  List.init
+    (number_of_pages state)
+    (fun page -> button page (string_of_int (1 + page)) pagination)
+  @
+  [
+    button (number_of_pages state - 1) "Last" pagination
+  ]
 
 let render pagination =
   div ~a:[a_id "page_nav"] [

--- a/src/client/elements/pageNavNewAPI.ml
+++ b/src/client/elements/pageNavNewAPI.ml
@@ -73,11 +73,18 @@ let button page text pagination =
 let button_list pagination =
   S.bind pagination.signal @@ fun state ->
   S.const (
+    [
+      button 0 "First" pagination
+    ]
+    @
     List.init
       (number_of_pages state)
       (fun page -> button page (string_of_int (1 + page)) pagination)
+    @
+    [
+      button (number_of_pages state - 1) "Last" pagination
+    ]
   )
-
 
 let render pagination =
   div ~a:[a_id "page_nav"] [

--- a/src/client/elements/pageNavNewAPI.ml
+++ b/src/client/elements/pageNavNewAPI.ml
@@ -1,0 +1,52 @@
+open Nes
+open Dancelor_client_html.NewAPI
+
+type state = {
+  current_page : int;
+  entries_per_page : int;
+  number_of_entries : int;
+  number_of_pages : int;
+}
+
+type t = {
+  signal : state React.signal;
+  setter : state -> unit;
+  updater : (state -> state) -> unit;
+}
+
+let create ~entries_per_page =
+  let initial = {
+    current_page = 0;
+    entries_per_page;
+    number_of_entries = 0;
+    number_of_pages = 0;
+  }
+  in
+  let (signal, setter) = S.create initial in
+  let updater f = setter (f (S.value signal)) in
+  { signal; setter; updater }
+
+let button page _pagination =
+  li
+    ~a:[a_class ["active"]]
+    [
+      button ~a: [
+        a_button_type `Button;
+      ] [
+        txt (string_of_int page)
+      ]
+    ]
+
+let button_list pagination =
+  S.bind pagination.signal @@ fun state ->
+  S.const (
+    List.init state.number_of_pages (fun page ->
+        button (1 + page) pagination
+      )
+  )
+
+let render pagination =
+  div ~a:[a_id "page_nav"] [
+    div [txt "In progress"]; (* info *)
+    R.ul (button_list pagination);
+  ]

--- a/src/client/elements/pageNavNewAPI.ml
+++ b/src/client/elements/pageNavNewAPI.ml
@@ -27,7 +27,9 @@ type t = {
   updater : (state -> state) -> unit;
 }
 
-let create ~number_of_entries ~entries_per_page =
+(** Create a page navigation from a number of entries (as an {!Lwt} promise)
+    and a number of entries per page. *)
+let create ~(number_of_entries: int Lwt.t) ~(entries_per_page: int) : t =
   let initial = {
     current_page = 1;
     entries_per_page;

--- a/src/client/elements/pageNavNewAPI.ml
+++ b/src/client/elements/pageNavNewAPI.ml
@@ -41,7 +41,7 @@ let create ~number_of_entries ~entries_per_page =
   { signal; setter; updater }
 
 let status_text pagination =
-  flip S.map pagination.signal @@ fun state ->
+  Fun.flip S.map pagination.signal @@ fun state ->
   if state.number_of_entries = 0 then
     "No entries"
   else
@@ -62,7 +62,7 @@ module Button = struct
     li
       ~a:[
         R.a_class (
-          flip S.map pagination.signal @@ fun state ->
+          Fun.flip S.map pagination.signal @@ fun state ->
           if active state then ["active"] else []
         )
       ]
@@ -70,7 +70,7 @@ module Button = struct
         button ~a: [
           a_button_type `Button;
           R.a_class (
-            flip S.map pagination.signal @@ fun state ->
+            Fun.flip S.map pagination.signal @@ fun state ->
             if enabled state then ["clickable"] else ["disabled"]
           );
           a_onclick
@@ -120,14 +120,14 @@ module Button = struct
 end
 
 let button_list pagination =
-  flip S.map pagination.signal @@ fun state ->
+  Fun.flip S.map pagination.signal @@ fun state ->
   let number_of_pages = number_of_pages state
   and current_page = state.current_page
   in
   (* Select the page numbers to show. *)
   let relevant_page_numbers =
     number_of_pages
-    |> flip List.init ((+) 1)
+    |> Fun.flip List.init ((+) 1)
     |> List.filter
       (fun i ->
          i = 1

--- a/src/client/elements/pageNavNewAPI.ml
+++ b/src/client/elements/pageNavNewAPI.ml
@@ -39,7 +39,19 @@ let create ~number_of_entries ~entries_per_page =
       updater (fun state -> { state with number_of_entries }));
   { signal; setter; updater }
 
-let button page pagination =
+let status_text pagination =
+  S.bind pagination.signal @@ fun state ->
+  S.const @@
+  if state.number_of_entries = 0 then
+    "No entries"
+  else
+    let pagination = current_pagination state in
+    spf "Showing %i to %i of %i entries"
+      (Pagination.start pagination + 1)
+      (Pagination.end_ pagination)
+      state.number_of_entries
+
+let button page text pagination =
   li
     ~a:[
       R.a_class (
@@ -55,28 +67,17 @@ let button page pagination =
              pagination.updater (fun state -> { state with current_page = page });
              false)
       ]
-        [txt (string_of_int (1 + page))]
+        [txt text]
     ]
-
-let status_text pagination =
-  S.bind pagination.signal @@ fun state ->
-  S.const @@
-  if state.number_of_entries = 0 then
-    "No entries"
-  else
-    let pagination = current_pagination state in
-    spf "Showing %i to %i of %i entries"
-      (Pagination.start pagination + 1)
-      (Pagination.end_ pagination)
-      state.number_of_entries
 
 let button_list pagination =
   S.bind pagination.signal @@ fun state ->
   S.const (
     List.init
       (number_of_pages state)
-      (fun page -> button page pagination)
+      (fun page -> button page (string_of_int (1 + page)) pagination)
   )
+
 
 let render pagination =
   div ~a:[a_id "page_nav"] [

--- a/src/client/elements/pageNavNewAPI.ml
+++ b/src/client/elements/pageNavNewAPI.ml
@@ -86,12 +86,17 @@ module Button = struct
           [txt text]
       ]
 
+  (** A value that can be passed to [make]'s [~target] argument when the button
+      is never be enabled. *)
+  let no_target =
+    fun _ -> failwith "Dancelor_client.Eleents.PageNav.no_target"
+
   (** A button that is never enabled and shows three dots. *)
   let ellipsis =
     make
       ~active:(Fun.const false)
       ~enabled:(Fun.const false)
-      ~target:(fun _ -> assert false)
+      ~target:no_target
       ~text:"..."
 
   (** A button that is constantly linked to a page number. *)

--- a/src/client/html/newAPI.ml
+++ b/src/client/html/newAPI.ml
@@ -55,6 +55,14 @@ module C = Js_of_ocaml_tyxml.Tyxml_js.Html
 include C
 (** Constant HTML nodes. *)
 
+(** Reactive HTML nodes, based on {!React}'s signals. *)
+module R = struct
+  module R = Js_of_ocaml_tyxml.Tyxml_js.R.Html
+
+  let tbody ?a elts = R.tbody ?a (RList.from_signal elts)
+  let ul ?a elts = R.ul ?a (RList.from_signal elts)
+end
+
 (** Lwt HTML nodes. *)
 module L = struct
   (* NOTE: The following relies on [Tyxml_js]'s React-based HTML builders but

--- a/src/client/html/newAPI.ml
+++ b/src/client/html/newAPI.ml
@@ -59,6 +59,9 @@ include C
 module R = struct
   module R = Js_of_ocaml_tyxml.Tyxml_js.R.Html
 
+  let txt str = R.txt str
+
+  let div ?a elts = R.div ?a (RList.from_signal elts)
   let tbody ?a elts = R.tbody ?a (RList.from_signal elts)
   let ul ?a elts = R.ul ?a (RList.from_signal elts)
 end

--- a/src/client/html/newAPI.ml
+++ b/src/client/html/newAPI.ml
@@ -59,7 +59,9 @@ include C
 module R = struct
   module R = Js_of_ocaml_tyxml.Tyxml_js.R.Html
 
-  let txt str = R.txt str
+  let txt = R.txt
+
+  let a_class elts = R.a_class elts
 
   let div ?a elts = R.div ?a (RList.from_signal elts)
   let tbody ?a elts = R.tbody ?a (RList.from_signal elts)

--- a/src/client/views/set/setExplorer.ml
+++ b/src/client/views/set/setExplorer.ml
@@ -32,6 +32,8 @@ let create page =
     Dom.appendChild content @@ To_dom.of_div @@ div [
       h2 ~a:[a_class ["title"]] [txt "All sets"];
 
+      PageNavNewAPI.render pagination;
+
       tablex
         ~a:[a_class ["FIXME-separated-table"]]
         ~thead:(
@@ -46,7 +48,7 @@ let create page =
         )
         [
           R.tbody (
-            S.bind pagination.signal @@ fun _pagination ->
+            S.bind pagination.signal @@ fun pagination ->
             S.from' [] @@ Lwt.map
               (List.map
                  (fun set ->
@@ -62,8 +64,7 @@ let create page =
                       Lwt.return [txt ""];
                     ]
                  ))
-              (* (Set.search ~pagination Formula.true_ >|=| Score.list_erase) *)
-              (Set.search Formula.true_ >|=| Score.list_erase)
+              (Set.search ~pagination:(PageNavNewAPI.current_pagination pagination) Formula.true_ >|=| Score.list_erase)
           )
         ];
 

--- a/src/client/views/set/setExplorer.ml
+++ b/src/client/views/set/setExplorer.ml
@@ -19,7 +19,7 @@ let create page =
   let document = Page.document page in
   let content = Html.createDiv document in
 
-  document##.title := js "All Sets | Dancelor";
+  document##.title := js "All sets | Dancelor";
 
   let pagination =
     PageNavNewAPI.create
@@ -35,11 +35,14 @@ let create page =
       PageNavNewAPI.render pagination;
 
       tablex
-        ~a:[a_class ["FIXME-separated-table"]]
+        ~a:[a_class ["separated-table"]]
         ~thead:(
           thead [
             tr [
-              th [txt "Name"]; (* FIXME: alt text “Sets” when collapsed *)
+              th [
+                span ~a:[a_class ["full-content"]] [txt "Name"];
+                span ~a:[a_class ["collapse-content"]] [txt "Sets"];
+              ];
               th [txt "Deviser"];
               th [txt "Kind"];
               th [txt "Actions"];
@@ -49,7 +52,9 @@ let create page =
         [
           R.tbody (
             S.bind pagination.signal @@ fun pagination ->
-            S.from' [] @@ Lwt.map
+            S.from' [] @@
+            flip Lwt.map
+              (Set.search ~pagination:(PageNavNewAPI.current_pagination pagination) Formula.true_ >|=| Score.list_erase)
               (List.map
                  (fun set ->
                     let href =
@@ -63,8 +68,8 @@ let create page =
                       Lwt.return [L.txt (Set.kind set >|= Kind.Dance.to_string)];
                       Lwt.return [txt ""];
                     ]
-                 ))
-              (Set.search ~pagination:(PageNavNewAPI.current_pagination pagination) Formula.true_ >|=| Score.list_erase)
+                 )
+              )
           )
         ];
 

--- a/src/client/views/set/setExplorer.ml
+++ b/src/client/views/set/setExplorer.ml
@@ -13,80 +13,65 @@ type t =
   {
     page : Page.t;
     content : Html.divElement Js.t;
-    page_nav : PageNav.t;
-    table : Table.t;
   }
-
-let update_table t =
-  let rows =
-    let pagination = PageNav.pagination t.page_nav in
-    Lwt.map
-      (List.map
-         (fun set ->
-            let href =
-              let%lwt slug = Set.slug set in
-              Lwt.return PageRouter.(path (Set slug))
-            in
-            let cells =
-              let open Lwt in [
-                Table.Cell.create ~content:(
-                  let%lwt content = Formatters.Set.name_and_tunes ~link:false set in
-                  Lwt.return (Dancelor_client_html.nodes_to_dom_nodes (Page.document t.page) content)
-                ) t.page;
-                Table.Cell.create ~content:(
-                  let%lwt deviser = Set.deviser set in
-                  let%lwt content = Formatters.Credit.line deviser in
-                  Lwt.return (Dancelor_client_html.nodes_to_dom_nodes (Page.document t.page) content)
-                ) t.page;
-                Table.Cell.text ~text:(Set.kind set >|= Kind.Dance.to_string) t.page;
-                Table.Cell.text ~text:(Lwt.return "") t.page
-              ]
-            in
-            Table.Row.create ~href ~cells t.page))
-      (Set.search ~pagination Formula.true_
-       >|=| Score.list_erase)
-  in
-  let section = Table.Section.create ~rows t.page in
-  Table.replace_bodies t.table (Lwt.return [section])
 
 let create page =
   let document = Page.document page in
+  let content = Html.createDiv document in
 
   document##.title := js "All Sets | Dancelor";
 
-  let content = Html.createDiv document in
-  let title = Html.createH2 document in
-  title##.textContent := Js.some (js "All Sets");
-  title##.classList##add (js "title");
-  Dom.appendChild content title;
+  let pagination =
+    PageNavNewAPI.create
+      (* ~entries: (Set.count Formula.true_) *)
+      ~entries_per_page: 25
+  in
 
-  Dom.appendChild content (Html.createHr document);
-  Dom.appendChild content (Html.createBr document);
-  let header =
-    Table.Row.create
-      ~cells:[
-        Table.Cell.header_text ~width:"45%" ~alt:(Lwt.return "Sets") ~text:(Lwt.return "Name") page;
-        Table.Cell.header_text ~text:(Lwt.return "Deviser") page;
-        Table.Cell.header_text ~text:(Lwt.return "Kind") page;
-        Table.Cell.header_text ~text:(Lwt.return "Actions") page]
-      page
-  in
-  let table = Table.create
-      ~header
-      ~kind:Table.Kind.Separated
-      page
-  in
-  Dom.appendChild content (Table.root table);
-  let page_nav = PageNav.create ~entries:0 ~entries_per_page:25 page in
-  Dom.appendChild content (PageNav.root page_nav);
-  let t = {page; content; table; page_nav} in
-  PageNav.connect_on_page_change page_nav (fun _ ->
-      PageNav.rebuild page_nav;
-      update_table t);
-  Lwt.on_success (Set.count Formula.true_) (fun entries ->
-      PageNav.set_entries page_nav entries);
-  update_table t;
-  t
+  (
+    let open Dancelor_client_html.NewAPI in
+    Dom.appendChild content @@ To_dom.of_div @@ div [
+      h2 ~a:[a_class ["title"]] [txt "All sets"];
+
+      tablex
+        ~a:[a_class ["FIXME-separated-table"]]
+        ~thead:(
+          thead [
+            tr [
+              th [txt "Name"]; (* FIXME: alt text “Sets” when collapsed *)
+              th [txt "Deviser"];
+              th [txt "Kind"];
+              th [txt "Actions"];
+            ]
+          ]
+        )
+        [
+          R.tbody (
+            S.bind pagination.signal @@ fun _pagination ->
+            S.from' [] @@ Lwt.map
+              (List.map
+                 (fun set ->
+                    let href =
+                      let%lwt slug = Set.slug set in
+                      Lwt.return PageRouter.(path (Set slug))
+                    in
+                    let open Lwt in
+                    Dancelor_client_tables.TheNewAPI.clickable_row ~href [
+                      (Formatters.SetNewAPI.name_and_tunes ~link:false set);
+                      (Set.deviser set >>= Formatters.CreditNewAPI.line);
+                      Lwt.return [L.txt (Set.kind set >|= Kind.Dance.to_string)];
+                      Lwt.return [txt ""];
+                    ]
+                 ))
+              (* (Set.search ~pagination Formula.true_ >|=| Score.list_erase) *)
+              (Set.search Formula.true_ >|=| Score.list_erase)
+          )
+        ];
+
+      PageNavNewAPI.render pagination;
+    ]
+  );
+
+  {page; content}
 
 let contents t =
   t.content

--- a/src/client/views/set/setExplorer.ml
+++ b/src/client/views/set/setExplorer.ml
@@ -23,7 +23,7 @@ let create page =
 
   let pagination =
     PageNavNewAPI.create
-      (* ~entries: (Set.count Formula.true_) *)
+      ~number_of_entries: (Set.count Formula.true_)
       ~entries_per_page: 25
   in
 

--- a/src/client/views/set/setExplorer.ml
+++ b/src/client/views/set/setExplorer.ml
@@ -53,7 +53,7 @@ let create page =
           R.tbody (
             S.bind pagination.signal @@ fun pagination ->
             S.from' [] @@
-            flip Lwt.map
+            Fun.flip Lwt.map
               (Set.search ~pagination:(PageNavNewAPI.current_pagination pagination) Formula.true_ >|=| Score.list_erase)
               (List.map
                  (fun set ->

--- a/src/common/model/pagination.ml
+++ b/src/common/model/pagination.ml
@@ -1,3 +1,4 @@
+(** Start is inclusive; end is non-inclusive. *)
 type t =
   { start : int ;
     end_ : int }


### PR DESCRIPTION
Builds on top of #235. To be merged after.

To be squashed.

This PR rewrites `src/client/views/set/setExplorer.ml` using the new API introduced by #235. Contrary to #235, this is a full rewrite of something that was previously using the old API (not the HTML one). This involves rewriting a whole `PageNav` element as well in the new API. I am very happy about how this new API is so far. I think that the new page nav is much more understandable than the previous one. This is due to some extent to better documentation, but this also have to do with the use of reactive programming. Of course, as time goes on, we will think of the appropriate helpers and will clean the code even further.