### PR TITLE
Convert index search to new API

### DIFF
--- a/lib/madge/madge_router.ml
+++ b/lib/madge/madge_router.ml
@@ -7,6 +7,9 @@ type request =
     path : string ;
     query : Madge_query.t }
 
+let request_to_uri { path; query; _ } =
+  Uri.make ~path ~query:(Madge_query.to_strings query) ()
+
 type 'resource route =
   { request_to_resource : request -> 'resource option ;
     resource_to_request : 'resource -> request option }

--- a/lib/madge/madge_router.mli
+++ b/lib/madge/madge_router.mli
@@ -8,6 +8,7 @@ type request =
   { method_ : Cohttp.Code.meth ;
     path : string ;
     query : Madge_query.t }
+(* FIXME: should be made abstract *)
 
 val request_to_uri : request -> Uri.t
 

--- a/lib/madge/madge_router.mli
+++ b/lib/madge/madge_router.mli
@@ -2,14 +2,20 @@
 
 open Nes
 
+(** {2 Requests} *)
+
 type request =
   { method_ : Cohttp.Code.meth ;
     path : string ;
     query : Madge_query.t }
 
+val request_to_uri : request -> Uri.t
+
+(** {2 Routes} *)
+
 type 'resource route
 
-(** {2 Building Routes} *)
+(** {3 Building Routes} *)
 
 val direct : Cohttp.Code.meth -> string -> 'resource -> 'resource route
 
@@ -30,13 +36,13 @@ val with_query :
   ('resource -> Madge_query.t option) ->
   'resource route
 
-(** {2 Using Routes} *)
+(** {3 Using Routes} *)
 
 val request_to_resource : request -> 'resource route list -> 'resource option
 
 val resource_to_request : 'resource -> 'resource route list -> request
 
-(** {2 Wrapping Routes} *)
+(** {3 Wrapping Routes} *)
 
 (* FIXME: support adding prefixes *)
 

--- a/share/static/style/components.scss
+++ b/share/static/style/components.scss
@@ -1,1 +1,2 @@
 @import "components/switch";
+@import "components/search-bar";

--- a/share/static/style/components/search-bar.scss
+++ b/share/static/style/components/search-bar.scss
@@ -1,0 +1,60 @@
+/******************************************************************************/
+/*             ____                      _       ____                         */
+/*            / ___|  ___  __ _ _ __ ___| |__   | __ )  __ _ _ __             */
+/*            \___ \ / _ \/ _` | '__/ __| '_ \  |  _ \ / _` | '__|            */
+/*             ___) |  __/ (_| | | | (__| | | | | |_) | (_| | |               */
+/*            |____/ \___|\__,_|_|  \___|_| |_| |____/ \__,_|_|               */
+/*                                                                            */
+/*   This file contains the style for the search bar components. Such         */
+/*   components are complex and require quite a bit of JavaScript to          */
+/*   function. In term of HTML, they must look like:                          */
+/*                                                                            */
+/*       <div class="search-bar">                                             */
+/*           <div></div>                                                      */
+/*           <input ... />                                                    */
+/*           <table ...>...</table>                                           */
+/*       </div>                                                               */
+/*                                                                            */
+/******************************************************************************/
+
+// FIXME: Problem with the current state of this is that the `div` that serves
+// as background takes a lot of space and therefore triggers overflows.
+
+div.search-bar {
+  div {
+    transform: scale(100000, 100000);
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: none;
+  }
+
+  div.visible {
+    display: block;
+  }
+
+  input {
+    position: relative;
+  }
+
+  table {
+    width: 100%;
+    border: 1px solid #ced4da;
+    margin-top: 4pt;
+    position: absolute;
+    background-color: #ffffff;
+    box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+
+    tbody {
+      border: 0;
+    }
+
+    display: none;
+  }
+
+  table.visible {
+    display: table;
+  }
+}

--- a/share/static/style/sandbox.scss
+++ b/share/static/style/sandbox.scss
@@ -112,6 +112,9 @@ li:not(:first-child):not(:last-child) button {
   border-left: 0;
 }
 
+// REVIEW: Get rid of `.dropdown-table`, now renamed `quick-results` in the
+// `search-bar` component?
+
 .dropdown-table {
   width: 100%;
   border: 1px solid #ced4da;

--- a/src/client/elements/searchBarNewAPI.ml
+++ b/src/client/elements/searchBarNewAPI.ml
@@ -1,0 +1,85 @@
+open Nes
+open Js_of_ocaml
+open Dancelor_client_html
+
+(** Row for when the search returned no results. *)
+let no_results_row =
+  tr [
+    td [txt "⚠️"];
+    td [txt "Your search returned no results."];
+  ]
+
+(** Rows for when the search returned error messages. *)
+let error_rows messages =
+  Fun.flip List.map messages @@ fun message ->
+  tr [
+    td [txt "❌"];
+    td [txt message];
+  ]
+
+let make ~placeholder ~search ~make_result ~max_results ~on_enter =
+  let (search_text, set_search_text) = S.create "" in
+  let (table_visible, set_table_visible) = S.create false in
+
+  div [
+    input ~a:[
+      a_input_type `Text;
+      a_placeholder placeholder;
+      a_oninput (fun event ->
+          (
+            Js.Opt.iter event##.target @@ fun elt ->
+            Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
+            set_search_text (Js.to_string input##.value)
+          );
+          false
+        );
+      a_autofocus ();
+      a_onfocus (fun _ -> set_table_visible true; false);
+      a_onblur (fun _ -> set_table_visible false; false);
+      a_onkeyup (fun event ->
+          if Js.Optdef.to_option event##.key = Some (Js.string "Enter") then
+            (
+              Js.Opt.iter event##.target @@ fun elt ->
+              Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
+              on_enter (Js.to_string input##.value)
+            );
+          true
+        );
+    ] ();
+
+    tablex
+      ~a:[
+        R.a_class (
+          Fun.flip S.map table_visible @@ function
+          | false -> ["dropdown-table"]
+          | true -> ["dropdown-table"; "visible"]
+        );
+      ]
+      [
+        R.tbody (
+          S.bind search_text @@ fun search_text ->
+          S.from' [] @@
+          if String.length search_text < 3 then
+            (
+              let message =
+                if search_text = ""
+                then "Start typing to search."
+                else "Type at least three characters."
+              in
+              Lwt.return [
+                tr [
+                  td [txt "👉"];
+                  td [txt message];
+                ]
+              ]
+            )
+          else
+            Fun.flip Lwt.map (search search_text) @@ function
+            | Error messages -> error_rows messages
+            | Ok [] -> [no_results_row]
+            | Ok results ->
+              List.map make_result (List.sub max_results results)
+              @ [tr [td [txt "👉"]; td ~a:[a_colspan 4] [txt "Press enter for more results."]]]
+        );
+      ]
+  ]

--- a/src/client/elements/searchBarNewAPI.ml
+++ b/src/client/elements/searchBarNewAPI.ml
@@ -21,7 +21,16 @@ let make ~placeholder ~search ~make_result ~max_results ~on_enter =
   let (search_text, set_search_text) = S.create "" in
   let (table_visible, set_table_visible) = S.create false in
 
-  div [
+  div ~a:[a_class ["search-bar"]] [
+    div ~a:[
+      R.a_class (
+        Fun.flip S.map table_visible @@ function
+        | false -> []
+        | true -> ["visible"]
+      );
+      a_onclick (fun _ -> set_table_visible false; false);
+    ] [];
+
     input ~a:[
       a_input_type `Text;
       a_placeholder placeholder;
@@ -35,7 +44,6 @@ let make ~placeholder ~search ~make_result ~max_results ~on_enter =
         );
       a_autofocus ();
       a_onfocus (fun _ -> set_table_visible true; false);
-      a_onblur (fun _ -> set_table_visible false; false);
       a_onkeyup (fun event ->
           if Js.Optdef.to_option event##.key = Some (Js.string "Enter") then
             (

--- a/src/client/utils/anyResultNewAPI.ml
+++ b/src/client/utils/anyResultNewAPI.ml
@@ -1,0 +1,107 @@
+open Lwt.Infix
+open Js_of_ocaml
+open Dancelor_common
+open Dancelor_client_model
+module Formatters = Dancelor_client_formatters
+open Dancelor_client_html
+
+module Html = Dom_html
+
+let js = Js.string
+
+let clickable_row ~href =
+  tr
+    ~a:[
+      a_class ["clickable"];
+      a_onclick
+        (fun _ ->
+           let open Js_of_ocaml in
+           Lwt.on_success href (fun href ->
+               Dom_html.window##.location##.href := Js.string href);
+           true
+        );
+    ]
+
+let make_credit_result ~prefix credit =
+  clickable_row
+    ~href:(Credit.slug credit >|= fun slug -> PageRouter.(path (Credit slug)))
+    (
+      prefix @ [
+        L.td ~a:[a_colspan 3] (Formatters.Credit.line (Some credit));
+      ]
+    )
+
+let make_dance_result ~prefix dance =
+  clickable_row
+    ~href:(Dance.slug dance >|= fun slug -> PageRouter.(path (Dance slug)))
+    (
+      prefix @ [
+        td [L.txt (Dance.name dance)];
+        td [L.txt (Kind.Dance.to_string =|< Dance.kind dance)];
+        L.td (Formatters.Credit.line =<< Dance.deviser dance);
+      ]
+    )
+
+let make_book_result ~prefix book =
+  clickable_row
+    ~href:(Book.slug book >|= fun slug -> PageRouter.(path (Book slug)))
+    (
+      prefix @ [
+        L.td ~a:[a_colspan 3] (Formatters.Book.title_and_subtitle book);
+      ]
+    )
+
+let make_set_result ~prefix set =
+  clickable_row
+    ~href:(Set.slug set >|= fun slug -> PageRouter.(path (Set slug)))
+    (
+      prefix @ [
+        td [L.txt (Set.name set)];
+        td [L.txt (Kind.Dance.to_string =|< Set.kind set)];
+        L.td (Formatters.Credit.line =<< Set.deviser set);
+      ]
+    )
+
+let make_tune_result ~prefix tune =
+  clickable_row
+    ~href:(Tune.slug tune >|= fun slug -> PageRouter.(path (Tune slug)))
+    (
+      prefix @ [
+        td [L.txt (Tune.name tune)];
+        td [L.txt (Kind.Base.to_pretty_string ~capitalised:true =|< Tune.kind tune)];
+        L.td (Formatters.Credit.line =<< Tune.author tune);
+      ]
+    )
+
+let make_version_result ~prefix version =
+  clickable_row
+    ~href:(Version.slug version >|= fun slug -> PageRouter.(path (Version slug)))
+    (
+      prefix @ [
+        L.td (Formatters.Version.name_and_disambiguation ~link:false version);
+        td [
+          L.txt (
+            let%lwt bars = Version.bars version in
+            let%lwt kind = Tune.kind =<< Version.tune version in
+            let%lwt structure = Version.structure version in
+            Lwt.return (Kind.Version.to_string (bars, kind) ^ " (" ^ structure ^ ")")
+          )
+        ];
+        L.td (Formatters.Version.author_and_arranger version);
+      ]
+    )
+
+let make_result score =
+  let any = Score.value score in
+  let prefix = [
+    td [txt (Score.score_to_string score)];
+    td [txt (any |> Any.type_of |> Any.Type.to_string)];
+  ]
+  in
+  match any with
+  | Credit credit   -> make_credit_result  ~prefix credit
+  | Dance dance     -> make_dance_result   ~prefix dance
+  | Book book       -> make_book_result    ~prefix book
+  | Set set         -> make_set_result     ~prefix set
+  | Tune tune       -> make_tune_result    ~prefix tune
+  | Version version -> make_version_result ~prefix version

--- a/src/client/utils/dune
+++ b/src/client/utils/dune
@@ -6,4 +6,5 @@
  (preprocess
   (pps lwt_ppx js_of_ocaml-ppx))
  (libraries js_of_ocaml-lwt cohttp-lwt-jsoo dancelor.nes
-   dancelor.client.formatters dancelor.client.elements dancelor.common))
+   dancelor.client.formatters dancelor.client.elements dancelor.common
+   dancelor.client.tables))

--- a/src/client/views/index.ml
+++ b/src/client/views/index.ml
@@ -64,7 +64,16 @@ let create page =
             );
           a_onfocus (fun _ -> set_table_visible true; false);
           a_onblur (fun _ -> set_table_visible false; false);
-          (* FIXME: on enter redirect to search. *)
+          a_onkeyup (fun event ->
+              if Js.Optdef.to_option event##.key = Some (js "Enter") then
+                (
+                  Js.Opt.iter event##.target @@ fun elt ->
+                  Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
+                  let query = Yojson.Safe.to_string (`String (Js.to_string input##.value)) in
+                  Dom_html.window##.location##.href := js (spf "/search?q=%s" query);
+                );
+              true
+            );
           (* FIXME: make focused at the beginning. *)
         ] ();
 

--- a/src/client/views/index.ml
+++ b/src/client/views/index.ml
@@ -63,6 +63,7 @@ let create page =
               );
               false
             );
+          a_autofocus ();
           a_onfocus (fun _ -> set_table_visible true; false);
           a_onblur (fun _ -> set_table_visible false; false);
           a_onkeyup (fun event ->
@@ -75,7 +76,6 @@ let create page =
                 );
               true
             );
-          (* FIXME: make focused at the beginning. *)
         ] ();
 
         tablex

--- a/src/client/views/index.ml
+++ b/src/client/views/index.ml
@@ -4,7 +4,6 @@ open Dancelor_common
 open Dancelor_client_elements
 open Dancelor_client_utils
 open Dancelor_client_model
-open Dancelor_client_html
 module Formatters = Dancelor_client_formatters
 
 module Html = Dom_html
@@ -25,95 +24,22 @@ let search input =
   let%lwt results = Any.search ~threshold ~pagination filter in
   Lwt.return_ok results
 
-(** Row for when the search returned no results. *)
-let no_results_row =
-  tr [
-    td [txt "⚠️"];
-    td [txt "Your search returned no results."];
-  ]
-
-(** Rows for when the search returned error messages. *)
-let error_rows messages =
-  flip List.map messages @@ fun message ->
-  tr [
-    td [txt "❌"];
-    td [txt message];
-  ]
-
 let create page =
   let document = Html.window##.document in
   let content = Html.createDiv document in
-
-  let (search_text, set_search_text) = S.create "" in
-  let (table_visible, set_table_visible) = S.create false in
 
   (
     let open Dancelor_client_html in
     Dom.appendChild content @@ To_dom.of_div @@ div [
 
-      div [
-        input ~a:[
-          a_input_type `Text;
-          a_placeholder "Search for anything (it's magic!)";
-          a_oninput (fun event ->
-              (
-                Js.Opt.iter event##.target @@ fun elt ->
-                Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
-                set_search_text (Js.to_string input##.value)
-              );
-              false
-            );
-          a_autofocus ();
-          a_onfocus (fun _ -> set_table_visible true; false);
-          a_onblur (fun _ -> set_table_visible false; false);
-          a_onkeyup (fun event ->
-              if Js.Optdef.to_option event##.key = Some (js "Enter") then
-                (
-                  Js.Opt.iter event##.target @@ fun elt ->
-                  Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
-                  let search_text = Js.to_string input##.value in
-                  Dom_html.window##.location##.href := js PageRouter.(path (Search (Some search_text)))
-                );
-              true
-            );
-        ] ();
-
-        tablex
-          ~a:[
-            R.a_class (
-              flip S.map table_visible @@ function
-              | false -> ["dropdown-table"]
-              | true -> ["dropdown-table"; "visible"]
-            );
-          ]
-          [
-            R.tbody (
-              S.bind search_text @@ fun search_text ->
-              S.from' [] @@
-              if String.length search_text < 3 then
-                (
-                  let message =
-                    if search_text = ""
-                    then "Start typing to search."
-                    else "Type at least three characters."
-                  in
-                  Lwt.return [
-                    tr [
-                      td [txt "👉"];
-                      td [txt message];
-                    ]
-                  ]
-                )
-              else
-                flip Lwt.map (search search_text) @@ function
-                | Error messages -> error_rows messages
-                | Ok [] -> [no_results_row]
-                | Ok results ->
-                  List.map AnyResultNewAPI.make_result (List.sub 10 results)
-                  @ [tr [td [txt "👉"]; td ~a:[a_colspan 4] [txt "Press enter for more results."]]]
-            );
-          ]
-      ]
+      SearchBarNewAPI.make
+        ~placeholder:"Search for anything (it's magic!)"
+        ~search
+        ~make_result:AnyResultNewAPI.make_result
+        ~max_results:10
+        ~on_enter:(fun search_text ->
+            Dom_html.window##.location##.href := js PageRouter.(path (Search (Some search_text)))
+          )
     ]
   );
 

--- a/src/client/views/index.ml
+++ b/src/client/views/index.ml
@@ -44,6 +44,7 @@ let create page =
   let content = Html.createDiv document in
 
   let (search_text, set_search_text) = S.create "" in
+  let (table_visible, set_table_visible) = S.create false in
 
   (
     let open Dancelor_client_html in
@@ -61,13 +62,20 @@ let create page =
               );
               false
             );
-          (* FIXME: onfocus make table visible. *)
+          a_onfocus (fun _ -> set_table_visible true; false);
+          a_onblur (fun _ -> set_table_visible false; false);
           (* FIXME: on enter redirect to search. *)
           (* FIXME: make focused at the beginning. *)
         ] ();
 
         tablex
-          ~a:[a_class ["dropdown-table"; "visible"]]
+          ~a:[
+            R.a_class (
+              flip S.map table_visible @@ function
+              | false -> ["dropdown-table"]
+              | true -> ["dropdown-table"; "visible"]
+            );
+          ]
           [
             R.tbody (
               S.bind search_text @@ fun search_text ->

--- a/src/client/views/index.ml
+++ b/src/client/views/index.ml
@@ -1,5 +1,6 @@
 open Nes
 open Js_of_ocaml
+open Dancelor_common
 open Dancelor_client_elements
 open Dancelor_client_utils
 open Dancelor_client_model
@@ -69,8 +70,8 @@ let create page =
                 (
                   Js.Opt.iter event##.target @@ fun elt ->
                   Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
-                  let query = Yojson.Safe.to_string (`String (Js.to_string input##.value)) in
-                  Dom_html.window##.location##.href := js (spf "/search?q=%s" query);
+                  let search_text = Js.to_string input##.value in
+                  Dom_html.window##.location##.href := js PageRouter.(path (Search (Some search_text)))
                 );
               true
             );

--- a/src/common/dancelor_common_pageRouter.ml
+++ b/src/common/dancelor_common_pageRouter.ml
@@ -74,4 +74,7 @@ let routes =
     with_slug `GET "/version"        (version, unVersion) ;
   ]
 
-let path page = Madge_router.((resource_to_request page routes).path)
+let path page =
+  Madge_router.resource_to_request page routes
+  |> Madge_router.request_to_uri
+  |> Uri.to_string


### PR DESCRIPTION
This PR rewrites the quick search on the index page using the new API. It introduces a new component `SearchBarNewAPI` that is supposed to mature into replacing the old `SearchBar`. This PR introduces it; later PRs will start using it everywhere to replace the old one, potentially improving it on the fly.