### PR TITLE
Simple PDF dialog

### DIFF
--- a/share/static/style/components.scss
+++ b/share/static/style/components.scss
@@ -1,2 +1,3 @@
 @import "components/switch";
 @import "components/search-bar";
+@import "components/modal-box";

--- a/share/static/style/components/modal-box.scss
+++ b/share/static/style/components/modal-box.scss
@@ -1,0 +1,47 @@
+/******************************************************************************/
+/*                         __  __           _       _                         */
+/*                        |  \/  | ___   __| | __ _| |                        */
+/*                        | |\/| |/ _ \ / _` |/ _` | |                        */
+/*                        | |  | | (_) | (_| | (_| | |                        */
+/*                        |_|  |_|\___/ \__,_|\__,_|_|                        */
+/*                                                                            */
+/******************************************************************************/
+
+.modal {
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background: rgba(0, 0, 0, 0.5);
+
+  display: none;
+}
+
+.modal.visible {
+  display: block;
+}
+
+.modal-content {
+  background-color: #fefefe;
+  margin: 15% auto; /* 15% from the top and centered */
+  padding: 20px;
+  border: 1px solid #888;
+  width: 50%;
+}
+
+.close {
+  color: #aaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+}
+
+.close:hover,
+.close:focus {
+  color: black;
+  text-decoration: none;
+  cursor: pointer;
+}

--- a/src/client/components/modalBox.ml
+++ b/src/client/components/modalBox.ml
@@ -1,0 +1,63 @@
+let make content =
+  let open Dancelor_client_html in
+
+  (* Reactive signal that holds the information on whether the modal box should
+     be visible or not. *)
+  let (visible, set_visible) = S.create false in
+
+  (* The actual modal box. This looks like:
+
+         <div class="modal visible">
+           <div class="modal-content">
+             <span class="close">⨉</span>
+             ...content...
+           </div>
+         </div>
+  *)
+  let box =
+    div
+      ~a:[
+        R.a_class (
+          Fun.flip S.map visible @@ function
+          | false -> ["modal"]
+          | true -> ["modal"; "visible"]
+        );
+      ]
+      [
+        div
+          ~a:[
+            a_class ["modal-content"];
+          ]
+          (
+            span
+              ~a:[
+                a_class ["close"];
+                a_onclick (fun _ -> set_visible false; false);
+              ]
+              [
+                txt "⨉"
+              ]
+            :: content
+          )
+      ]
+  in
+
+  (* An event listener on the whole window such that if one clicks outside the
+     box then the box disappears. *)
+  ignore
+    (
+      let open Js_of_ocaml in
+      let open Dom_html in
+      addEventListener
+        window
+        Event.click
+        (handler @@ fun event ->
+         if event##.target = Js.some (To_dom.of_div box) then
+           set_visible false;
+         Js._true
+        )
+        Js._true
+    );
+
+  (* We return the box and a function to make it appear. *)
+  (box, (fun () -> set_visible true))

--- a/src/client/views/book/bookViewer.ml
+++ b/src/client/views/book/bookViewer.ml
@@ -1,6 +1,7 @@
 open Nes
 open Js_of_ocaml
 open Dancelor_common
+open Dancelor_client_components
 open Dancelor_client_model
 module Formatters = Dancelor_client_formatters
 
@@ -144,8 +145,71 @@ let create slug page =
       Lwt.return ()
     );
 
+  let open Dancelor_client_html in
+
+  let (pdf_dialog, show_pdf_dialog) =
+    let booklet_parameters =
+      BookParameters.(
+        make
+          ~front_page:true
+          ~table_of_contents:End
+          ~two_sided:true
+          ~every_set:SetParameters.(
+              make
+                ~forced_pages:2
+                ()
+            )
+          ()
+      )
+    in
+    let bass_parameters =
+      BookParameters.(
+        make ~every_set:SetParameters.(
+            make ~every_version:VersionParameters.(
+                make
+                  ~clef:Music.Bass
+                  ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1)))
+                  ()
+              )
+              ()
+          )
+          ()
+      )
+    in
+    let b_parameters = BookParameters.make_instrument (Music.make_pitch B Flat (-1)) in
+    let e_parameters = BookParameters.make_instrument (Music.make_pitch E Flat 0) in
+    let c_pdf_href,         b_pdf_href,         e_pdf_href,         bass_pdf_href,
+        c_booklet_pdf_href, b_booklet_pdf_href, e_booklet_pdf_href, bass_booklet_pdf_href =
+      ApiRouter.(path @@ bookPdf slug @@ Option.none),
+      ApiRouter.(path @@ bookPdf slug @@ Option.some @@                           b_parameters),
+      ApiRouter.(path @@ bookPdf slug @@ Option.some @@                           e_parameters),
+      ApiRouter.(path @@ bookPdf slug @@ Option.some @@                        bass_parameters),
+      ApiRouter.(path @@ bookPdf slug @@ Option.some @@                                        booklet_parameters),
+      ApiRouter.(path @@ bookPdf slug @@ Option.some @@ BookParameters.compose    b_parameters booklet_parameters),
+      ApiRouter.(path @@ bookPdf slug @@ Option.some @@ BookParameters.compose    e_parameters booklet_parameters),
+      ApiRouter.(path @@ bookPdf slug @@ Option.some @@ BookParameters.compose bass_parameters booklet_parameters)
+    in
+    let pdf_button href text =
+      a ~a:[a_class ["button"]; a_href href; a_target "blank"] [
+        i ~a:[a_class ["fas"; "fa-file-pdf"]] [];
+        txt (" " ^ text)
+      ]
+    in
+    ModalBox.make [
+      h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
+      pdf_button c_pdf_href    "PDF";
+      pdf_button b_pdf_href    "PDF (B♭)";
+      pdf_button e_pdf_href    "PDF (E♭)";
+      pdf_button bass_pdf_href "PDF (𝄢)";
+      br ();
+      pdf_button c_booklet_pdf_href    "PDF (book)";
+      pdf_button b_booklet_pdf_href    "PDF (B♭, book)";
+      pdf_button e_booklet_pdf_href    "PDF (E♭, book)";
+      pdf_button bass_booklet_pdf_href "PDF (𝄢, book)";
+    ]
+  in
+
   (
-    let open Dancelor_client_html in
     Dom.appendChild content @@ To_dom.of_div @@ div [
       h2 ~a:[a_class ["title"]] [L.txt (book_lwt >>=| Book.title)];
       h3 ~a:[a_class ["title"]] [L.txt (book_lwt >>=| Book.subtitle)];
@@ -179,68 +243,18 @@ let create slug page =
         )
       ];
 
-      div ~a:[a_class ["buttons"]] (
-        let booklet_parameters =
-          BookParameters.(
-            make
-              ~front_page:true
-              ~table_of_contents:End
-              ~two_sided:true
-              ~every_set:SetParameters.(
-                  make
-                    ~forced_pages:2
-                    ()
-                )
-              ()
-          )
-        in
-        let bass_parameters =
-          BookParameters.(
-            make ~every_set:SetParameters.(
-                make ~every_version:VersionParameters.(
-                    make
-                      ~clef:Music.Bass
-                      ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1)))
-                      ()
-                  )
-                  ()
-              )
-              ()
-          )
-        in
-        let b_parameters = BookParameters.make_instrument (Music.make_pitch B Flat (-1)) in
-        let e_parameters = BookParameters.make_instrument (Music.make_pitch E Flat 0) in
-
-        let c_pdf_href,         b_pdf_href,         e_pdf_href,         bass_pdf_href,
-            c_booklet_pdf_href, b_booklet_pdf_href, e_booklet_pdf_href, bass_booklet_pdf_href =
-          ApiRouter.(path @@ bookPdf slug @@ Option.none),
-          ApiRouter.(path @@ bookPdf slug @@ Option.some @@                           b_parameters),
-          ApiRouter.(path @@ bookPdf slug @@ Option.some @@                           e_parameters),
-          ApiRouter.(path @@ bookPdf slug @@ Option.some @@                        bass_parameters),
-          ApiRouter.(path @@ bookPdf slug @@ Option.some @@                                        booklet_parameters),
-          ApiRouter.(path @@ bookPdf slug @@ Option.some @@ BookParameters.compose    b_parameters booklet_parameters),
-          ApiRouter.(path @@ bookPdf slug @@ Option.some @@ BookParameters.compose    e_parameters booklet_parameters),
-          ApiRouter.(path @@ bookPdf slug @@ Option.some @@ BookParameters.compose bass_parameters booklet_parameters)
-        in
-
-        let pdf_button href text =
-          a ~a:[a_class ["button"]; a_href href; a_target "blank"] [
-            i ~a:[a_class ["fas"; "fa-file-pdf"]] [];
-            txt (" " ^ text)
+      pdf_dialog;
+      div ~a:[a_class ["buttons"]] [
+        a
+          ~a:[
+            a_class ["button"];
+            a_onclick (fun _ -> show_pdf_dialog (); false);
           ]
-        in
-        [
-          pdf_button c_pdf_href    "PDF";
-          pdf_button b_pdf_href    "PDF (B♭)";
-          pdf_button e_pdf_href    "PDF (E♭)";
-          pdf_button bass_pdf_href "PDF (𝄢)";
-          br ();
-          pdf_button c_booklet_pdf_href    "PDF (book)";
-          pdf_button b_booklet_pdf_href    "PDF (B♭, book)";
-          pdf_button e_booklet_pdf_href    "PDF (E♭, book)";
-          pdf_button bass_booklet_pdf_href "PDF (𝄢, book)";
-        ]
-      );
+          [
+            i ~a:[a_class ["fas"; "fa-file-pdf"]] [];
+            txt " PDF";
+          ]
+      ];
 
       div ~a:[a_class ["section"]] [
         h3 [txt "Contents"];

--- a/src/client/views/book/bookViewer.ml
+++ b/src/client/views/book/bookViewer.ml
@@ -253,6 +253,16 @@ let create slug page =
           [
             i ~a:[a_class ["fas"; "fa-file-pdf"]] [];
             txt " PDF";
+          ];
+
+        a
+          ~a:[
+            a_class ["button"];
+            a_href PageRouter.(path (BookEdit slug))
+          ]
+          [
+            i ~a:[a_class ["fas"; "fa-edit"]] [];
+            txt " Edit"
           ]
       ];
 
@@ -261,12 +271,6 @@ let create slug page =
 
         table_contents (Lwt.bind book_lwt Book.contents)
       ];
-
-      div ~a:[a_class ["buttons"]] [
-        a ~a:[a_class ["button"]; a_href PageRouter.(path (BookEdit slug))] [
-          txt "Edit book"
-        ]
-      ]
     ]);
 
   {page; content}

--- a/src/client/views/set/setViewer.ml
+++ b/src/client/views/set/setViewer.ml
@@ -1,6 +1,7 @@
 open Nes
 open Js_of_ocaml
 open Dancelor_common
+open Dancelor_client_components
 open Dancelor_client_model
 module Formatters = Dancelor_client_formatters
 
@@ -24,9 +25,44 @@ let create slug page =
       Lwt.return ()
     );
 
+  let open Dancelor_client_html in
+
+  let (pdf_dialog, show_pdf_dialog) =
+    let bass_parameters =
+      SetParameters.(
+        make ~every_version:VersionParameters.(
+            make
+              ~clef:Music.Bass
+              ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1)))
+              ()
+          )
+          ()
+      )
+    in
+    let b_parameters = SetParameters.make_instrument (Music.make_pitch B Flat (-1)) in
+    let e_parameters = SetParameters.make_instrument (Music.make_pitch E Flat 0) in
+    let c_pdf_href, b_pdf_href, e_pdf_href, bass_pdf_href =
+      ApiRouter.(path @@ setPdf slug @@ Option.none),
+      ApiRouter.(path @@ setPdf slug @@ Option.some    b_parameters),
+      ApiRouter.(path @@ setPdf slug @@ Option.some    e_parameters),
+      ApiRouter.(path @@ setPdf slug @@ Option.some bass_parameters)
+    in
+    let pdf_button href text =
+      a ~a:[a_class ["button"]; a_href href; a_target "blank"] [
+        i ~a:[a_class ["fas"; "fa-file-pdf"]] [];
+        txt (" " ^ text)
+      ]
+    in
+    ModalBox.make [
+      h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
+      pdf_button c_pdf_href    "PDF";
+      pdf_button b_pdf_href    "PDF (B♭)";
+      pdf_button e_pdf_href    "PDF (E♭)";
+      pdf_button bass_pdf_href "PDF (𝄢)";
+    ]
+  in
 
   (
-    let open Dancelor_client_html in
     Dom.appendChild content @@ To_dom.of_div @@ div [
       h2 ~a:[a_class ["title"]] [L.txt (set_lwt >>=| Set.name)];
       L.h3 ~a:[a_class ["title"]] (set_lwt >>=| Formatters.Set.works);
@@ -43,47 +79,37 @@ let create slug page =
           Lwt.return (txt "Set devised by " :: line_block)
       );
 
+      pdf_dialog;
+
       div ~a:[a_class ["buttons"]] (
-        let bass_parameters =
-          SetParameters.(
-            make ~every_version:VersionParameters.(
-                make
-                  ~clef:Music.Bass
-                  ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1)))
-                  ()
-              )
-              ()
-          )
-        in
-        let b_parameters = SetParameters.make_instrument (Music.make_pitch B Flat (-1)) in
-        let e_parameters = SetParameters.make_instrument (Music.make_pitch E Flat 0) in
 
-        let c_pdf_href, b_pdf_href, e_pdf_href, bass_pdf_href,
-            ly_href
-          =
-          ApiRouter.(path @@ setPdf slug @@ Option.none),
-          ApiRouter.(path @@ setPdf slug @@ Option.some    b_parameters),
-          ApiRouter.(path @@ setPdf slug @@ Option.some    e_parameters),
-          ApiRouter.(path @@ setPdf slug @@ Option.some bass_parameters),
-          ApiRouter.(path @@ setLy  slug @@ Option.none)
+        let pdf_dialog_button =
+          a
+            ~a:[
+              a_class ["button"];
+              a_onclick (fun _ -> show_pdf_dialog (); false);
+            ]
+            [
+              i ~a:[a_class ["fas"; "fa-file-pdf"]] [];
+              txt " PDF";
+            ]
         in
 
-        let pdf_button href text =
-          a ~a:[a_class ["button"]; a_href href; a_target "blank"] [
-            i ~a:[a_class ["fas"; "fa-file-pdf"]] [];
-            txt (" " ^ text)
-          ]
+        let ly_download_button =
+          a
+            ~a:[
+              a_class ["button"];
+              a_href ApiRouter.(path @@ setLy slug @@ Option.none);
+            ]
+            [
+              i ~a:[a_class ["fas"; "fa-file-alt"]] [];
+              txt " LilyPond"
+            ]
         in
+
         [
-          pdf_button c_pdf_href    "PDF";
-          pdf_button b_pdf_href    "PDF (B♭)";
-          pdf_button e_pdf_href    "PDF (E♭)";
-          pdf_button bass_pdf_href "PDF (𝄢)";
-          br ();
-          a ~a:[a_class ["button"]; a_href ly_href] [
-            i ~a:[a_class ["fas"; "fa-file-alt"]] [];
-            txt " LilyPond";
-          ];
+          pdf_dialog_button;
+          ly_download_button;
         ]
       );
 


### PR DESCRIPTION
closes https://github.com/paris-branch/dancelor/issues/79

Builds on top of https://github.com/paris-branch/dancelor/pull/240

This PR implements a notion of [modal boxes](https://www.w3schools.com/howto/howto_css_modals.asp) using the new API. Once we have that, it is fairly easy to use it in version, set and book viewers to unclutter the buttons at the top. We only provide one “PDF” button opening a modal that allows to click on another button. So far, this is not a huge change. It is to be seen as a change on the way to https://github.com/paris-branch/dancelor/issues/80 and https://github.com/paris-branch/dancelor/issues/81 though.