### PR TITLE
Select-based PDF dialogs

### DIFF
--- a/lib/nes/nesOption.ml
+++ b/lib/nes/nesOption.ml
@@ -58,3 +58,12 @@ let compare_lwt cmp o0 o1 =
   | None, None -> Lwt.return 0
   | None, Some _ -> Lwt.return (-1)
   | Some _, None -> Lwt.return 1
+
+let concat conc o1 o2 =
+  match (o1, o2) with
+  | (None, None) -> None
+  | (Some v1, None) -> Some v1
+  | (None, Some v2) -> Some v2
+  | (Some v1, Some v2) -> Some (conc v1 v2)
+
+let concat_l conc = List.fold_left (concat conc) None

--- a/lib/nes/nesOption.mli
+++ b/lib/nes/nesOption.mli
@@ -44,3 +44,9 @@ val assert_some : 'a t -> 'a t
 
 val assert_ : bool -> unit t
 (** [None] if [false], [Some ()] if [true]. *)
+
+val concat : ('a -> 'a -> 'a) -> 'a option -> 'a option -> 'a option
+(** Concatenation of the monoid given the concatenation of the embedded one. *)
+
+val concat_l : ('a -> 'a -> 'a) -> 'a option list -> 'a option
+(** Same as {!concat} but for a list of options. *)

--- a/share/static/style/components.scss
+++ b/share/static/style/components.scss
@@ -1,3 +1,4 @@
 @import "components/switch";
 @import "components/search-bar";
 @import "components/modal-box";
+@import "components/choices";

--- a/share/static/style/components/choices.scss
+++ b/share/static/style/components/choices.scss
@@ -1,0 +1,39 @@
+.choices {
+  display: inline-block;
+
+  label {
+    display: inline-block;
+    padding: 0.8em 1.5em;
+    margin: 0.2em;
+    cursor: pointer;
+    border-radius: 0.25em;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2),
+      inset 0 -3px 0 rgba(0, 0, 0, 0.22);
+    transition: 0.3s;
+    user-select: none;
+    font-size: 1em;
+    &:hover {
+      box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2),
+        inset 0 -3px 0 rgba(0, 0, 0, 0.32);
+    }
+    &:active {
+      transform: translateY(2px);
+      box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2),
+        inset 0px -1px 0 rgba(0, 0, 0, 0.22);
+    }
+  }
+
+  input:checked + label {
+    background: #960010;
+    color: white;
+    font-weight: bolder;
+    &:hover {
+      background: darken(#960010, 5%);
+      color: darken(white, 5%);
+    }
+  }
+
+  input {
+    display: none;
+  }
+}

--- a/share/static/style/components/modal-box.scss
+++ b/share/static/style/components/modal-box.scss
@@ -29,7 +29,7 @@
   margin: 15% auto; /* 15% from the top and centered */
   padding: 20px;
   border: 1px solid #888;
-  width: 50%;
+  max-width: 50%;
 }
 
 .close {

--- a/src/client/components/choices.ml
+++ b/src/client/components/choices.ml
@@ -1,0 +1,45 @@
+open Dancelor_client_html
+
+let unique =
+  let counter = ref 0 in
+  fun () ->
+    incr counter;
+    "choices-" ^ string_of_int !counter
+
+let make choices =
+  let name = unique () in
+  let (value, set_value) = S.create None in
+  let box =
+    div
+      ~a:[
+        a_class ["choices"];
+        a_onchange (fun event ->
+            (
+              let open Js_of_ocaml in
+              Js.Opt.iter event##.target @@ fun target ->
+              let id = target##.id in
+              let (_, value, _, _) = List.find (fun (id', _, _, _) -> id = Js.string id') choices in
+              set_value value
+            );
+            false
+          );
+      ]
+      (
+        Fun.flip List.concat_map choices @@ fun (id, _value, checked, content) ->
+        [
+          input ~a:(List.filter_map Fun.id [
+              Some (a_input_type `Radio);
+              Some (a_name name);
+              Some (a_id id);
+              (if checked then Some (a_checked ()) else None);
+            ]) ();
+          label ~a:[a_label_for id] content;
+        ]
+      )
+  in
+  (box, value)
+
+let choice ?value ?(checked=false) content =
+  (* FIXME: it would be better as a record, but this would imply managing to
+     type the content part of this. *)
+  (unique (), value, checked, content)

--- a/src/client/components/modalBox.ml
+++ b/src/client/components/modalBox.ml
@@ -1,3 +1,5 @@
+(* REVIEW: Should we use the <dialog> HTML tag? *)
+
 let make content =
   let open Dancelor_client_html in
 

--- a/src/client/views/book/bookDownloadDialog.ml
+++ b/src/client/views/book/bookDownloadDialog.ml
@@ -5,55 +5,58 @@ open Dancelor_client_html
 open Dancelor_client_components
 open Js_of_ocaml
 
-let create slug =
+(* REVIEW: This is close to `VersionDownloadDialog.t`; there is room for
+   factorisation here. *)
+type t =
+  {
+    choice_rows : Html_types.tr elt list;
+    parameters_signal : BookParameters.t option React.signal;
+  }
+
+let lift_set_parameters every_set =
+  BookParameters.make ~every_set ()
+
+let create () =
+  let set_dialog = SetDownloadDialog.create () in
+
+  let (booklet_choices, booklet_choices_signal) =
+    Choices.(make [
+        choice [txt "Normal"] ~checked:true;
+
+        choice [txt "Booklet"]
+          ~value:(BookParameters.make
+                    ~front_page:true
+                    ~table_of_contents:End
+                    ~two_sided:true
+                    ~every_set:SetParameters.(make ~forced_pages:2 ())
+                    ());
+      ])
+  in
+
+  {
+    choice_rows =
+      (
+        set_dialog.choice_rows
+        @ [
+          tr [td [label [txt "Mode:"]]; td [booklet_choices]]
+        ]
+      );
+
+    parameters_signal =
+      S.merge (Option.concat BookParameters.compose) None [
+        S.map (Option.map lift_set_parameters) set_dialog.parameters_signal;
+        booklet_choices_signal;
+      ]
+  }
+
+(* REVIEW: This is extremely close to `VersionDownloadDialog.render` (apart for
+   one line and one type, really); there is room for factorisation here. *)
+let render slug dialog =
   ModalBox.make [
     h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
 
-
-    let (key_choices, key_choices_signal) =
-      Choices.(make [
-          choice [txt "C"] ~checked:true;
-
-          choice [txt "B♭"]
-            ~value:(BookParameters.make_instrument (Music.make_pitch B Flat (-1)));
-
-          choice [txt "E♭"]
-            ~value:(BookParameters.make_instrument (Music.make_pitch E Flat 0));
-        ])
-    in
-
-    let (clef_choices, clef_choices_signal) =
-      Choices.(make [
-          choice [txt "𝄞"] ~checked:true;
-
-          choice [txt "𝄢"]
-            ~value:(BookParameters.(make ~every_set:SetParameters.(
-                make ~every_version:VersionParameters.(
-                    make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ()
-                  ) ()) ()));
-        ])
-    in
-
-    let (booklet_choices, booklet_choices_signal) =
-      Choices.(make [
-          choice [txt "Normal"] ~checked:true;
-
-          choice [txt "Booklet"]
-            ~value:(BookParameters.make
-                      ~front_page:true
-                      ~table_of_contents:End
-                      ~two_sided:true
-                      ~every_set:SetParameters.(make ~forced_pages:2 ())
-                      ());
-        ])
-    in
-
     form [
-      table [
-        tr [td [label [txt "Key:"]]; td [key_choices]];
-        tr [td [label [txt "Clef:"]]; td [clef_choices]];
-        tr [td [label [txt "Mode:"]]; td [booklet_choices]];
-      ];
+      table dialog.choice_rows;
 
       input
         ~a:[
@@ -61,11 +64,7 @@ let create slug =
           a_input_type `Submit;
           a_value "Download";
           a_onclick (fun _event ->
-              let parameters = Option.concat_l BookParameters.compose [
-                  S.value key_choices_signal;
-                  S.value clef_choices_signal;
-                  S.value booklet_choices_signal;
-                ] in
+              let parameters = S.value dialog.parameters_signal in
               let href = ApiRouter.(path @@ bookPdf slug parameters) in
               ignore (Dom_html.window##open_ (Js.string href) (Js.string "_blank") Js.null);
               false
@@ -73,3 +72,5 @@ let create slug =
         ] ();
     ];
   ]
+
+let create_and_render slug = render slug (create ())

--- a/src/client/views/book/bookDownloadDialog.ml
+++ b/src/client/views/book/bookDownloadDialog.ml
@@ -1,0 +1,75 @@
+open Nes
+open Dancelor_common
+open Dancelor_client_model
+open Dancelor_client_html
+open Dancelor_client_components
+open Js_of_ocaml
+
+let create slug =
+  ModalBox.make [
+    h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
+
+
+    let (key_choices, key_choices_signal) =
+      Choices.(make [
+          choice [txt "C"] ~checked:true;
+
+          choice [txt "B♭"]
+            ~value:(BookParameters.make_instrument (Music.make_pitch B Flat (-1)));
+
+          choice [txt "E♭"]
+            ~value:(BookParameters.make_instrument (Music.make_pitch E Flat 0));
+        ])
+    in
+
+    let (clef_choices, clef_choices_signal) =
+      Choices.(make [
+          choice [txt "𝄞"] ~checked:true;
+
+          choice [txt "𝄢"]
+            ~value:(BookParameters.(make ~every_set:SetParameters.(
+                make ~every_version:VersionParameters.(
+                    make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ()
+                  ) ()) ()));
+        ])
+    in
+
+    let (booklet_choices, booklet_choices_signal) =
+      Choices.(make [
+          choice [txt "Normal"] ~checked:true;
+
+          choice [txt "Booklet"]
+            ~value:(BookParameters.make
+                      ~front_page:true
+                      ~table_of_contents:End
+                      ~two_sided:true
+                      ~every_set:SetParameters.(make ~forced_pages:2 ())
+                      ());
+        ])
+    in
+
+    form [
+      table [
+        tr [td [label [txt "Key:"]]; td [key_choices]];
+        tr [td [label [txt "Clef:"]]; td [clef_choices]];
+        tr [td [label [txt "Mode:"]]; td [booklet_choices]];
+      ];
+
+      input
+        ~a:[
+          a_class ["button"];
+          a_input_type `Submit;
+          a_value "Download";
+          a_onclick (fun _event ->
+              let parameters = Option.concat_l BookParameters.compose [
+                  S.value key_choices_signal;
+                  S.value clef_choices_signal;
+                  S.value booklet_choices_signal;
+                ] in
+              let href = ApiRouter.(path @@ bookPdf slug parameters) in
+              ignore (Dom_html.window##open_ (Js.string href) (Js.string "_blank") Js.null);
+              false
+            );
+        ] ();
+    ];
+  ]

--- a/src/client/views/book/bookViewer.ml
+++ b/src/client/views/book/bookViewer.ml
@@ -148,64 +148,72 @@ let create slug page =
   let open Dancelor_client_html in
 
   let (pdf_dialog, show_pdf_dialog) =
-    let booklet_parameters =
-      BookParameters.(
-        make
-          ~front_page:true
-          ~table_of_contents:End
-          ~two_sided:true
-          ~every_set:SetParameters.(
-              make
-                ~forced_pages:2
-                ()
-            )
-          ()
-      )
-    in
-    let bass_parameters =
-      BookParameters.(
-        make ~every_set:SetParameters.(
-            make ~every_version:VersionParameters.(
-                make
-                  ~clef:Music.Bass
-                  ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1)))
-                  ()
-              )
-              ()
-          )
-          ()
-      )
-    in
-    let b_parameters = BookParameters.make_instrument (Music.make_pitch B Flat (-1)) in
-    let e_parameters = BookParameters.make_instrument (Music.make_pitch E Flat 0) in
-    let c_pdf_href,         b_pdf_href,         e_pdf_href,         bass_pdf_href,
-        c_booklet_pdf_href, b_booklet_pdf_href, e_booklet_pdf_href, bass_booklet_pdf_href =
-      ApiRouter.(path @@ bookPdf slug @@ Option.none),
-      ApiRouter.(path @@ bookPdf slug @@ Option.some @@                           b_parameters),
-      ApiRouter.(path @@ bookPdf slug @@ Option.some @@                           e_parameters),
-      ApiRouter.(path @@ bookPdf slug @@ Option.some @@                        bass_parameters),
-      ApiRouter.(path @@ bookPdf slug @@ Option.some @@                                        booklet_parameters),
-      ApiRouter.(path @@ bookPdf slug @@ Option.some @@ BookParameters.compose    b_parameters booklet_parameters),
-      ApiRouter.(path @@ bookPdf slug @@ Option.some @@ BookParameters.compose    e_parameters booklet_parameters),
-      ApiRouter.(path @@ bookPdf slug @@ Option.some @@ BookParameters.compose bass_parameters booklet_parameters)
-    in
-    let pdf_button href text =
-      a ~a:[a_class ["button"]; a_href href; a_target "blank"] [
-        i ~a:[a_class ["fas"; "fa-file-pdf"]] [];
-        txt (" " ^ text)
-      ]
-    in
     ModalBox.make [
       h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
-      pdf_button c_pdf_href    "PDF";
-      pdf_button b_pdf_href    "PDF (B♭)";
-      pdf_button e_pdf_href    "PDF (E♭)";
-      pdf_button bass_pdf_href "PDF (𝄢)";
-      br ();
-      pdf_button c_booklet_pdf_href    "PDF (book)";
-      pdf_button b_booklet_pdf_href    "PDF (B♭, book)";
-      pdf_button e_booklet_pdf_href    "PDF (E♭, book)";
-      pdf_button bass_booklet_pdf_href "PDF (𝄢, book)";
+
+
+      let (key_choices, key_choices_signal) =
+        Choices.(make [
+            choice [txt "C"] ~checked:true;
+
+            choice [txt "B♭"]
+              ~value:(BookParameters.make_instrument (Music.make_pitch B Flat (-1)));
+
+            choice [txt "E♭"]
+              ~value:(BookParameters.make_instrument (Music.make_pitch E Flat 0));
+          ])
+      in
+
+      let (clef_choices, clef_choices_signal) =
+        Choices.(make [
+            choice [txt "𝄞"] ~checked:true;
+
+            choice [txt "𝄢"]
+              ~value:(BookParameters.(make ~every_set:SetParameters.(
+                  make ~every_version:VersionParameters.(
+                      make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ()
+                    ) ()) ()));
+          ])
+      in
+
+      let (booklet_choices, booklet_choices_signal) =
+        Choices.(make [
+            choice [txt "Normal"] ~checked:true;
+
+            choice [txt "Booklet"]
+              ~value:(BookParameters.make
+                        ~front_page:true
+                        ~table_of_contents:End
+                        ~two_sided:true
+                        ~every_set:SetParameters.(make ~forced_pages:2 ())
+                        ());
+          ])
+      in
+
+      form [
+        table [
+          tr [td [label [txt "Key:"]]; td [key_choices]];
+          tr [td [label [txt "Clef:"]]; td [clef_choices]];
+          tr [td [label [txt "Mode:"]]; td [booklet_choices]];
+        ];
+
+        input
+          ~a:[
+            a_class ["button"];
+            a_input_type `Submit;
+            a_value "Download";
+            a_onclick (fun _event ->
+                let parameters = Option.concat_l BookParameters.compose [
+                    S.value key_choices_signal;
+                    S.value clef_choices_signal;
+                    S.value booklet_choices_signal;
+                  ] in
+                let href = ApiRouter.(path @@ bookPdf slug parameters) in
+                ignore (Dom_html.window##open_ (Js.string href) (Js.string "_blank") Js.null);
+                false
+              );
+          ] ();
+      ];
     ]
   in
 

--- a/src/client/views/book/bookViewer.ml
+++ b/src/client/views/book/bookViewer.ml
@@ -146,7 +146,7 @@ let create slug page =
 
   let open Dancelor_client_html in
 
-  let (download_dialog, show_download_dialog) = BookDownloadDialog.create slug in
+  let (download_dialog, show_download_dialog) = BookDownloadDialog.create_and_render slug in
 
   (
     Dom.appendChild content @@ To_dom.of_div @@ div [

--- a/src/client/views/book/bookViewer.ml
+++ b/src/client/views/book/bookViewer.ml
@@ -1,7 +1,6 @@
 open Nes
 open Js_of_ocaml
 open Dancelor_common
-open Dancelor_client_components
 open Dancelor_client_model
 module Formatters = Dancelor_client_formatters
 
@@ -147,75 +146,7 @@ let create slug page =
 
   let open Dancelor_client_html in
 
-  let (pdf_dialog, show_pdf_dialog) =
-    ModalBox.make [
-      h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
-
-
-      let (key_choices, key_choices_signal) =
-        Choices.(make [
-            choice [txt "C"] ~checked:true;
-
-            choice [txt "B♭"]
-              ~value:(BookParameters.make_instrument (Music.make_pitch B Flat (-1)));
-
-            choice [txt "E♭"]
-              ~value:(BookParameters.make_instrument (Music.make_pitch E Flat 0));
-          ])
-      in
-
-      let (clef_choices, clef_choices_signal) =
-        Choices.(make [
-            choice [txt "𝄞"] ~checked:true;
-
-            choice [txt "𝄢"]
-              ~value:(BookParameters.(make ~every_set:SetParameters.(
-                  make ~every_version:VersionParameters.(
-                      make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ()
-                    ) ()) ()));
-          ])
-      in
-
-      let (booklet_choices, booklet_choices_signal) =
-        Choices.(make [
-            choice [txt "Normal"] ~checked:true;
-
-            choice [txt "Booklet"]
-              ~value:(BookParameters.make
-                        ~front_page:true
-                        ~table_of_contents:End
-                        ~two_sided:true
-                        ~every_set:SetParameters.(make ~forced_pages:2 ())
-                        ());
-          ])
-      in
-
-      form [
-        table [
-          tr [td [label [txt "Key:"]]; td [key_choices]];
-          tr [td [label [txt "Clef:"]]; td [clef_choices]];
-          tr [td [label [txt "Mode:"]]; td [booklet_choices]];
-        ];
-
-        input
-          ~a:[
-            a_class ["button"];
-            a_input_type `Submit;
-            a_value "Download";
-            a_onclick (fun _event ->
-                let parameters = Option.concat_l BookParameters.compose [
-                    S.value key_choices_signal;
-                    S.value clef_choices_signal;
-                    S.value booklet_choices_signal;
-                  ] in
-                let href = ApiRouter.(path @@ bookPdf slug parameters) in
-                ignore (Dom_html.window##open_ (Js.string href) (Js.string "_blank") Js.null);
-                false
-              );
-          ] ();
-      ];
-    ]
-  in
+  let (download_dialog, show_download_dialog) = BookDownloadDialog.create slug in
 
   (
     Dom.appendChild content @@ To_dom.of_div @@ div [
@@ -251,12 +182,13 @@ let create slug page =
         )
       ];
 
-      pdf_dialog;
+      download_dialog;
+
       div ~a:[a_class ["buttons"]] [
         a
           ~a:[
             a_class ["button"];
-            a_onclick (fun _ -> show_pdf_dialog (); false);
+            a_onclick (fun _ -> show_download_dialog (); false);
           ]
           [
             i ~a:[a_class ["fas"; "fa-file-pdf"]] [];

--- a/src/client/views/set/setDownloadDialog.ml
+++ b/src/client/views/set/setDownloadDialog.ml
@@ -5,38 +5,37 @@ open Dancelor_client_html
 open Dancelor_client_components
 open Js_of_ocaml
 
-let create slug =
+(* REVIEW: This is close to `VersionDownloadDialog.t`; there is room for
+   factorisation here. *)
+type t =
+  {
+    choice_rows : Html_types.tr elt list;
+    parameters_signal : SetParameters.t option React.signal;
+  }
+
+let lift_version_parameters every_version =
+  SetParameters.make ~every_version ()
+
+let create () =
+  let version_dialog = VersionDownloadDialog.create () in
+
+  {
+    choice_rows = version_dialog.choice_rows;
+    parameters_signal =
+      S.merge (Option.concat SetParameters.compose) None [
+        S.map (Option.map lift_version_parameters) version_dialog.parameters_signal;
+        (* fills a bit silly at this point but will make more sense once we have set-specific options *)
+      ];
+  }
+
+(* REVIEW: This is extremely close to `VersionDownloadDialog.render` (apart for
+   one line and one type, really); there is room for factorisation here. *)
+let render slug dialog =
   ModalBox.make [
     h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
 
-    let (key_choices, key_choices_signal) =
-      Choices.(make [
-          choice [txt "C"] ~checked:true;
-
-          choice [txt "B♭"]
-            ~value:(SetParameters.make_instrument (Music.make_pitch B Flat (-1)));
-
-          choice [txt "E♭"]
-            ~value:(SetParameters.make_instrument (Music.make_pitch E Flat 0));
-        ])
-    in
-
-    let (clef_choices, clef_choices_signal) =
-      Choices.(make [
-          choice [txt "𝄞"] ~checked:true;
-
-          choice [txt "𝄢"]
-            ~value:(SetParameters.(make ~every_version:VersionParameters.(
-                make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ()
-              ) ()));
-        ])
-    in
-
     form [
-      table [
-        tr [td [label [txt "Key:"]]; td [key_choices]];
-        tr [td [label [txt "Clef:"]]; td [clef_choices]];
-      ];
+      table dialog.choice_rows;
 
       input
         ~a:[
@@ -44,10 +43,7 @@ let create slug =
           a_input_type `Submit;
           a_value "Download";
           a_onclick (fun _event ->
-              let parameters = Option.concat_l SetParameters.compose [
-                  S.value key_choices_signal;
-                  S.value clef_choices_signal;
-                ] in
+              let parameters = S.value dialog.parameters_signal in
               let href = ApiRouter.(path @@ setPdf slug parameters) in
               ignore (Dom_html.window##open_ (Js.string href) (Js.string "_blank") Js.null);
               false
@@ -55,3 +51,5 @@ let create slug =
         ] ();
     ];
   ]
+
+let create_and_render slug = render slug (create ())

--- a/src/client/views/set/setDownloadDialog.ml
+++ b/src/client/views/set/setDownloadDialog.ml
@@ -1,0 +1,57 @@
+open Nes
+open Dancelor_common
+open Dancelor_client_model
+open Dancelor_client_html
+open Dancelor_client_components
+open Js_of_ocaml
+
+let create slug =
+  ModalBox.make [
+    h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
+
+    let (key_choices, key_choices_signal) =
+      Choices.(make [
+          choice [txt "C"] ~checked:true;
+
+          choice [txt "B♭"]
+            ~value:(SetParameters.make_instrument (Music.make_pitch B Flat (-1)));
+
+          choice [txt "E♭"]
+            ~value:(SetParameters.make_instrument (Music.make_pitch E Flat 0));
+        ])
+    in
+
+    let (clef_choices, clef_choices_signal) =
+      Choices.(make [
+          choice [txt "𝄞"] ~checked:true;
+
+          choice [txt "𝄢"]
+            ~value:(SetParameters.(make ~every_version:VersionParameters.(
+                make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ()
+              ) ()));
+        ])
+    in
+
+    form [
+      table [
+        tr [td [label [txt "Key:"]]; td [key_choices]];
+        tr [td [label [txt "Clef:"]]; td [clef_choices]];
+      ];
+
+      input
+        ~a:[
+          a_class ["button"];
+          a_input_type `Submit;
+          a_value "Download";
+          a_onclick (fun _event ->
+              let parameters = Option.concat_l SetParameters.compose [
+                  S.value key_choices_signal;
+                  S.value clef_choices_signal;
+                ] in
+              let href = ApiRouter.(path @@ setPdf slug parameters) in
+              ignore (Dom_html.window##open_ (Js.string href) (Js.string "_blank") Js.null);
+              false
+            );
+        ] ();
+    ];
+  ]

--- a/src/client/views/set/setViewer.ml
+++ b/src/client/views/set/setViewer.ml
@@ -28,37 +28,54 @@ let create slug page =
   let open Dancelor_client_html in
 
   let (pdf_dialog, show_pdf_dialog) =
-    let bass_parameters =
-      SetParameters.(
-        make ~every_version:VersionParameters.(
-            make
-              ~clef:Music.Bass
-              ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1)))
-              ()
-          )
-          ()
-      )
-    in
-    let b_parameters = SetParameters.make_instrument (Music.make_pitch B Flat (-1)) in
-    let e_parameters = SetParameters.make_instrument (Music.make_pitch E Flat 0) in
-    let c_pdf_href, b_pdf_href, e_pdf_href, bass_pdf_href =
-      ApiRouter.(path @@ setPdf slug @@ Option.none),
-      ApiRouter.(path @@ setPdf slug @@ Option.some    b_parameters),
-      ApiRouter.(path @@ setPdf slug @@ Option.some    e_parameters),
-      ApiRouter.(path @@ setPdf slug @@ Option.some bass_parameters)
-    in
-    let pdf_button href text =
-      a ~a:[a_class ["button"]; a_href href; a_target "blank"] [
-        i ~a:[a_class ["fas"; "fa-file-pdf"]] [];
-        txt (" " ^ text)
-      ]
-    in
     ModalBox.make [
       h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
-      pdf_button c_pdf_href    "PDF";
-      pdf_button b_pdf_href    "PDF (B♭)";
-      pdf_button e_pdf_href    "PDF (E♭)";
-      pdf_button bass_pdf_href "PDF (𝄢)";
+
+      let (key_choices, key_choices_signal) =
+        Choices.(make [
+            choice [txt "C"] ~checked:true;
+
+            choice [txt "B♭"]
+              ~value:(SetParameters.make_instrument (Music.make_pitch B Flat (-1)));
+
+            choice [txt "E♭"]
+              ~value:(SetParameters.make_instrument (Music.make_pitch E Flat 0));
+          ])
+      in
+
+      let (clef_choices, clef_choices_signal) =
+        Choices.(make [
+            choice [txt "𝄞"] ~checked:true;
+
+            choice [txt "𝄢"]
+              ~value:(SetParameters.(make ~every_version:VersionParameters.(
+                  make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ()
+                ) ()));
+          ])
+      in
+
+      form [
+        table [
+          tr [td [label [txt "Key:"]]; td [key_choices]];
+          tr [td [label [txt "Clef:"]]; td [clef_choices]];
+        ];
+
+        input
+          ~a:[
+            a_class ["button"];
+            a_input_type `Submit;
+            a_value "Download";
+            a_onclick (fun _event ->
+                let parameters = Option.concat_l SetParameters.compose [
+                    S.value key_choices_signal;
+                    S.value clef_choices_signal;
+                  ] in
+                let href = ApiRouter.(path @@ setPdf slug parameters) in
+                ignore (Dom_html.window##open_ (Js.string href) (Js.string "_blank") Js.null);
+                false
+              );
+          ] ();
+      ];
     ]
   in
 

--- a/src/client/views/set/setViewer.ml
+++ b/src/client/views/set/setViewer.ml
@@ -26,7 +26,7 @@ let create slug page =
 
   let open Dancelor_client_html in
 
-  let (download_dialog, show_download_dialog) = SetDownloadDialog.create slug in
+  let (download_dialog, show_download_dialog) = SetDownloadDialog.create_and_render slug in
 
   (
     Dom.appendChild content @@ To_dom.of_div @@ div [

--- a/src/client/views/set/setViewer.ml
+++ b/src/client/views/set/setViewer.ml
@@ -1,7 +1,6 @@
 open Nes
 open Js_of_ocaml
 open Dancelor_common
-open Dancelor_client_components
 open Dancelor_client_model
 module Formatters = Dancelor_client_formatters
 
@@ -27,57 +26,7 @@ let create slug page =
 
   let open Dancelor_client_html in
 
-  let (pdf_dialog, show_pdf_dialog) =
-    ModalBox.make [
-      h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
-
-      let (key_choices, key_choices_signal) =
-        Choices.(make [
-            choice [txt "C"] ~checked:true;
-
-            choice [txt "B♭"]
-              ~value:(SetParameters.make_instrument (Music.make_pitch B Flat (-1)));
-
-            choice [txt "E♭"]
-              ~value:(SetParameters.make_instrument (Music.make_pitch E Flat 0));
-          ])
-      in
-
-      let (clef_choices, clef_choices_signal) =
-        Choices.(make [
-            choice [txt "𝄞"] ~checked:true;
-
-            choice [txt "𝄢"]
-              ~value:(SetParameters.(make ~every_version:VersionParameters.(
-                  make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ()
-                ) ()));
-          ])
-      in
-
-      form [
-        table [
-          tr [td [label [txt "Key:"]]; td [key_choices]];
-          tr [td [label [txt "Clef:"]]; td [clef_choices]];
-        ];
-
-        input
-          ~a:[
-            a_class ["button"];
-            a_input_type `Submit;
-            a_value "Download";
-            a_onclick (fun _event ->
-                let parameters = Option.concat_l SetParameters.compose [
-                    S.value key_choices_signal;
-                    S.value clef_choices_signal;
-                  ] in
-                let href = ApiRouter.(path @@ setPdf slug parameters) in
-                ignore (Dom_html.window##open_ (Js.string href) (Js.string "_blank") Js.null);
-                false
-              );
-          ] ();
-      ];
-    ]
-  in
+  let (download_dialog, show_download_dialog) = SetDownloadDialog.create slug in
 
   (
     Dom.appendChild content @@ To_dom.of_div @@ div [
@@ -96,7 +45,7 @@ let create slug page =
           Lwt.return (txt "Set devised by " :: line_block)
       );
 
-      pdf_dialog;
+      download_dialog;
 
       div ~a:[a_class ["buttons"]] (
 
@@ -104,7 +53,7 @@ let create slug page =
           a
             ~a:[
               a_class ["button"];
-              a_onclick (fun _ -> show_pdf_dialog (); false);
+              a_onclick (fun _ -> show_download_dialog (); false);
             ]
             [
               i ~a:[a_class ["fas"; "fa-file-pdf"]] [];

--- a/src/client/views/version/versionDownloadDialog.ml
+++ b/src/client/views/version/versionDownloadDialog.ml
@@ -17,10 +17,10 @@ let create () =
         choice [txt "C"] ~checked:true;
 
         choice [txt "B♭"]
-          ~value:(VersionParameters.make ~transposition:(Transposition.relative (Music.make_pitch B Flat (-1)) Music.pitch_c) ());
+          ~value:(VersionParameters.make_instrument (Music.make_pitch B Flat (-1)));
 
         choice [txt "E♭"]
-          ~value:(VersionParameters.make ~transposition:(Transposition.relative (Music.make_pitch E Flat 0) Music.pitch_c) ());
+          ~value:(VersionParameters.make_instrument (Music.make_pitch E Flat 0));
       ])
   in
 

--- a/src/client/views/version/versionDownloadDialog.ml
+++ b/src/client/views/version/versionDownloadDialog.ml
@@ -1,0 +1,55 @@
+open Nes
+open Dancelor_common
+open Dancelor_client_model
+open Dancelor_client_html
+open Dancelor_client_components
+open Js_of_ocaml
+
+let create slug =
+  ModalBox.make [
+    h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
+
+    let (key_choices, key_choices_signal) =
+      Choices.(make [
+          choice [txt "C"] ~checked:true;
+
+          choice [txt "B♭"]
+            ~value:(VersionParameters.make ~transposition:(Transposition.relative (Music.make_pitch B Flat (-1)) Music.pitch_c) ());
+
+          choice [txt "E♭"]
+            ~value:(VersionParameters.make ~transposition:(Transposition.relative (Music.make_pitch E Flat 0) Music.pitch_c) ());
+        ])
+    in
+
+    let (clef_choices, clef_choices_signal) =
+      Choices.(make [
+          choice [txt "𝄞"] ~checked:true;
+
+          choice [txt "𝄢"]
+            ~value:(VersionParameters.make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ());
+        ])
+    in
+
+    form [
+      table [
+        tr [td [label [txt "Key:"]]; td [key_choices]];
+        tr [td [label [txt "Clef:"]]; td [clef_choices]];
+      ];
+
+      input
+        ~a:[
+          a_class ["button"];
+          a_input_type `Submit;
+          a_value "Download";
+          a_onclick (fun _event ->
+              let parameters = Option.concat_l VersionParameters.compose [
+                  S.value key_choices_signal;
+                  S.value clef_choices_signal;
+                ] in
+              let href = ApiRouter.(path @@ versionPdf slug parameters) in
+              ignore (Dom_html.window##open_ (Js.string href) (Js.string "_blank") Js.null);
+              false
+            );
+        ] ();
+    ];
+  ]

--- a/src/client/views/version/versionDownloadDialog.ml
+++ b/src/client/views/version/versionDownloadDialog.ml
@@ -5,36 +5,56 @@ open Dancelor_client_html
 open Dancelor_client_components
 open Js_of_ocaml
 
-let create slug =
+type t =
+  {
+    choice_rows : Html_types.tr elt list;
+    parameters_signal : VersionParameters.t option React.signal;
+  }
+
+let create () =
+  let (key_choices, key_choices_signal) =
+    Choices.(make [
+        choice [txt "C"] ~checked:true;
+
+        choice [txt "B♭"]
+          ~value:(VersionParameters.make ~transposition:(Transposition.relative (Music.make_pitch B Flat (-1)) Music.pitch_c) ());
+
+        choice [txt "E♭"]
+          ~value:(VersionParameters.make ~transposition:(Transposition.relative (Music.make_pitch E Flat 0) Music.pitch_c) ());
+      ])
+  in
+
+  let (clef_choices, clef_choices_signal) =
+    Choices.(make [
+        choice [txt "𝄞"] ~checked:true;
+
+        choice [txt "𝄢"]
+          ~value:(VersionParameters.make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ());
+      ])
+  in
+
+  (* A signal containing the composition of all the parameters. *)
+  let parameters_signal =
+    S.merge (Option.concat VersionParameters.compose) None [
+      key_choices_signal;
+      clef_choices_signal;
+    ]
+  in
+
+  {
+    choice_rows = [
+      tr [td [label [txt "Key:"]]; td [key_choices]];
+      tr [td [label [txt "Clef:"]]; td [clef_choices]];
+    ];
+    parameters_signal;
+  }
+
+let render slug dialog =
   ModalBox.make [
     h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
 
-    let (key_choices, key_choices_signal) =
-      Choices.(make [
-          choice [txt "C"] ~checked:true;
-
-          choice [txt "B♭"]
-            ~value:(VersionParameters.make ~transposition:(Transposition.relative (Music.make_pitch B Flat (-1)) Music.pitch_c) ());
-
-          choice [txt "E♭"]
-            ~value:(VersionParameters.make ~transposition:(Transposition.relative (Music.make_pitch E Flat 0) Music.pitch_c) ());
-        ])
-    in
-
-    let (clef_choices, clef_choices_signal) =
-      Choices.(make [
-          choice [txt "𝄞"] ~checked:true;
-
-          choice [txt "𝄢"]
-            ~value:(VersionParameters.make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ());
-        ])
-    in
-
     form [
-      table [
-        tr [td [label [txt "Key:"]]; td [key_choices]];
-        tr [td [label [txt "Clef:"]]; td [clef_choices]];
-      ];
+      table dialog.choice_rows;
 
       input
         ~a:[
@@ -42,10 +62,7 @@ let create slug =
           a_input_type `Submit;
           a_value "Download";
           a_onclick (fun _event ->
-              let parameters = Option.concat_l VersionParameters.compose [
-                  S.value key_choices_signal;
-                  S.value clef_choices_signal;
-                ] in
+              let parameters = S.value dialog.parameters_signal in
               let href = ApiRouter.(path @@ versionPdf slug parameters) in
               ignore (Dom_html.window##open_ (Js.string href) (Js.string "_blank") Js.null);
               false
@@ -53,3 +70,5 @@ let create slug =
         ] ();
     ];
   ]
+
+let create_and_render slug = render slug (create ())

--- a/src/client/views/version/versionViewer.ml
+++ b/src/client/views/version/versionViewer.ml
@@ -40,7 +40,7 @@ let create slug page =
 
   let open Dancelor_client_html in
 
-  let (download_dialog, show_download_dialog) = VersionDownloadDialog.create slug in
+  let (download_dialog, show_download_dialog) = VersionDownloadDialog.create_and_render slug in
 
   (
     Dom.appendChild content @@ To_dom.of_div @@ div [

--- a/src/client/views/version/versionViewer.ml
+++ b/src/client/views/version/versionViewer.ml
@@ -1,7 +1,6 @@
 open Nes
 open Js_of_ocaml
 open Dancelor_common
-open Dancelor_client_components
 open Dancelor_client_model
 module Formatters = Dancelor_client_formatters
 
@@ -41,55 +40,7 @@ let create slug page =
 
   let open Dancelor_client_html in
 
-  let (pdf_dialog, show_pdf_dialog) =
-    ModalBox.make [
-      h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
-
-      let (key_choices, key_choices_signal) =
-        Choices.(make [
-            choice [txt "C"] ~checked:true;
-
-            choice [txt "B♭"]
-              ~value:(VersionParameters.make ~transposition:(Transposition.relative (Music.make_pitch B Flat (-1)) Music.pitch_c) ());
-
-            choice [txt "E♭"]
-              ~value:(VersionParameters.make ~transposition:(Transposition.relative (Music.make_pitch E Flat 0) Music.pitch_c) ());
-          ])
-      in
-
-      let (clef_choices, clef_choices_signal) =
-        Choices.(make [
-            choice [txt "𝄞"] ~checked:true;
-
-            choice [txt "𝄢"]
-              ~value:(VersionParameters.make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ());
-          ])
-      in
-
-      form [
-        table [
-          tr [td [label [txt "Key:"]]; td [key_choices]];
-          tr [td [label [txt "Clef:"]]; td [clef_choices]];
-        ];
-
-        input
-          ~a:[
-            a_class ["button"];
-            a_input_type `Submit;
-            a_value "Download";
-            a_onclick (fun _event ->
-                let parameters = Option.concat_l VersionParameters.compose [
-                    S.value key_choices_signal;
-                    S.value clef_choices_signal;
-                  ] in
-                let href = ApiRouter.(path @@ versionPdf slug parameters) in
-                ignore (Dom_html.window##open_ (Js.string href) (Js.string "_blank") Js.null);
-                false
-              );
-          ] ();
-      ];
-    ]
-  in
+  let (download_dialog, show_download_dialog) = VersionDownloadDialog.create slug in
 
   (
     Dom.appendChild content @@ To_dom.of_div @@ div [
@@ -111,15 +62,15 @@ let create slug page =
           ]
       );
 
-      pdf_dialog;
+      download_dialog;
 
       div ~a:[a_class ["buttons"]] (
 
-        let pdf_dialog_button =
+        let download_dialog_button =
           a
             ~a:[
               a_class ["button"];
-              a_onclick (fun _ -> show_pdf_dialog (); false);
+              a_onclick (fun _ -> show_download_dialog (); false);
             ]
             [
               i ~a:[a_class ["fas"; "fa-file-pdf"]] [];
@@ -157,7 +108,7 @@ let create slug page =
         in
 
         [
-          pdf_dialog_button;
+          download_dialog_button;
           ly_download_button;
           add_to_current_set_button;
         ]

--- a/src/client/views/version/versionViewer.ml
+++ b/src/client/views/version/versionViewer.ml
@@ -42,43 +42,52 @@ let create slug page =
   let open Dancelor_client_html in
 
   let (pdf_dialog, show_pdf_dialog) =
-    let bass_parameters =
-      VersionParameters.(
-        make ~clef:Music.Bass
-          ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1)))
-          ()
-      )
-    in
-    let b_pitch = Music.make_pitch B Flat (-1) in
-    let b_parameters = VersionParameters.(
-        make ~transposition:(Transposition.relative b_pitch Music.pitch_c)
-          ()
-      )
-    in
-    let e_pitch = Music.make_pitch E Flat 0 in
-    let e_parameters = VersionParameters.(
-        make ~transposition:(Transposition.relative e_pitch Music.pitch_c)
-          ()
-      )
-    in
-    let c_pdf_href, b_pdf_href, e_pdf_href, bass_pdf_href =
-      ApiRouter.(path @@ versionPdf slug @@ Option.none),
-      ApiRouter.(path @@ versionPdf slug @@ Option.some    b_parameters),
-      ApiRouter.(path @@ versionPdf slug @@ Option.some    e_parameters),
-      ApiRouter.(path @@ versionPdf slug @@ Option.some bass_parameters)
-    in
-    let pdf_button href text =
-      a ~a:[a_class ["button"]; a_href href; a_target "blank"] [
-        i ~a:[a_class ["fas"; "fa-file-pdf"]] [];
-        txt (" " ^ text)
-      ]
-    in
     ModalBox.make [
       h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
-      pdf_button c_pdf_href    "PDF";
-      pdf_button b_pdf_href    "PDF (B♭)";
-      pdf_button e_pdf_href    "PDF (E♭)";
-      pdf_button bass_pdf_href "PDF (𝄢)";
+
+      let (key_choices, key_choices_signal) =
+        Choices.(make [
+            choice [txt "C"] ~checked:true;
+
+            choice [txt "B♭"]
+              ~value:(VersionParameters.make ~transposition:(Transposition.relative (Music.make_pitch B Flat (-1)) Music.pitch_c) ());
+
+            choice [txt "E♭"]
+              ~value:(VersionParameters.make ~transposition:(Transposition.relative (Music.make_pitch E Flat 0) Music.pitch_c) ());
+          ])
+      in
+
+      let (clef_choices, clef_choices_signal) =
+        Choices.(make [
+            choice [txt "𝄞"] ~checked:true;
+
+            choice [txt "𝄢"]
+              ~value:(VersionParameters.make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ());
+          ])
+      in
+
+      form [
+        table [
+          tr [td [label [txt "Key:"]]; td [key_choices]];
+          tr [td [label [txt "Clef:"]]; td [clef_choices]];
+        ];
+
+        input
+          ~a:[
+            a_class ["button"];
+            a_input_type `Submit;
+            a_value "Download";
+            a_onclick (fun _event ->
+                let parameters = Option.concat_l VersionParameters.compose [
+                    S.value key_choices_signal;
+                    S.value clef_choices_signal;
+                  ] in
+                let href = ApiRouter.(path @@ versionPdf slug parameters) in
+                ignore (Dom_html.window##open_ (Js.string href) (Js.string "_blank") Js.null);
+                false
+              );
+          ] ();
+      ];
     ]
   in
 

--- a/src/common/model/book/bookParameters.ml
+++ b/src/common/model/book/bookParameters.ml
@@ -5,7 +5,6 @@ type where = Beginning | End | Nowhere
 
 module Self = struct
   type t = {
-    instruments       : string option [@default None] ;
     front_page        : bool   option [@default None] [@key "front-page"] ;
     table_of_contents : where  option [@default None] [@key "table-of-contents"] ;
     two_sided         : bool   option [@default None] [@key "two-sided"] ;
@@ -20,27 +19,20 @@ end
 include Self
 
 (* FIXME: see remark in VersionParameters *)
-let make ?instruments ?front_page ?table_of_contents ?two_sided ?every_set () =
-  make ~instruments ~front_page ~table_of_contents ~two_sided ?every_set ()
+let make ?front_page ?table_of_contents ?two_sided ?every_set () =
+  make ~front_page ~table_of_contents ~two_sided ?every_set ()
 
-let make_instrument pitch =
-  make
-    ~instruments:(Music.pitch_to_pretty_string pitch ^ " instruments")
-    ~every_set:(SetParameters.make_instrument pitch)
-    ()
-
-let instruments       p = Option.unwrap p.instruments
 let front_page        p = Option.unwrap p.front_page
 let table_of_contents p = Option.unwrap p.table_of_contents
 let two_sided         p = Option.unwrap p.two_sided
 let running_header    p = Option.unwrap p.running_header
 
 let every_set         p = p.every_set
+let instruments = SetParameters.instruments % every_set
 
 let none = `Assoc [] |> of_yojson |> Result.get_ok
 
 let default = {
-  instruments = Some "" ;
   front_page = Some false ;
   table_of_contents = Some Nowhere ;
   two_sided = Some false ;
@@ -50,8 +42,7 @@ let default = {
 }
 
 let compose first second =
-  { instruments       = Option.(choose ~tie:second) first.instruments       second.instruments ;
-    front_page        = Option.(choose ~tie:second) first.front_page        second.front_page ;
+  { front_page        = Option.(choose ~tie:second) first.front_page        second.front_page ;
     table_of_contents = Option.(choose ~tie:second) first.table_of_contents second.table_of_contents ;
     two_sided         = Option.(choose ~tie:second) first.two_sided         second.two_sided ;
     running_header    = Option.(choose ~tie:second) first.running_header    second.running_header ;

--- a/src/common/model/set/setParameters.ml
+++ b/src/common/model/set/setParameters.ml
@@ -2,8 +2,7 @@ open Nes
 
 module Self = struct
   type t =
-    { instruments   : string option [@default None] ;
-      forced_pages  : int    option [@default None] [@key "forced-pages"] ;
+    { forced_pages  : int    option [@default None] [@key "forced-pages"] ;
       show_deviser  : bool   option [@default None] [@key "show-deviser"] ;
       show_order    : bool   option [@default None] [@key "show-order"] ;
       display_name  : string option [@default None] [@key "display-name"] ;
@@ -19,24 +18,13 @@ include Self
 
 (* FIXME: see remark in VersionParameters *)
 let make
-    ?instruments ?forced_pages ?show_deviser ?show_order
+    ?forced_pages ?show_deviser ?show_order
     ?display_name ?for_dance ?every_version ()
   =
   make
-    ~instruments ~forced_pages ~show_deviser ~show_order
+    ~forced_pages ~show_deviser ~show_order
     ~display_name ~for_dance ?every_version ()
 
-let make_instrument pitch =
-  make
-    ~instruments:(Music.pitch_to_pretty_string pitch ^ " instruments")
-    ~every_version:(
-      VersionParameters.make
-        ~transposition:(Transposition.relative pitch Music.pitch_c)
-        ()
-    )
-    ()
-
-let instruments  p = Option.unwrap p.instruments
 let forced_pages p = Option.unwrap p.forced_pages
 let for_dance    p = p.for_dance
 let display_name p = p.display_name
@@ -44,6 +32,7 @@ let show_deviser p = Option.unwrap p.show_deviser
 let show_order   p = Option.unwrap p.show_order
 
 let every_version p = p.every_version
+let instruments = VersionParameters.instruments % every_version
 
 let set_show_order show_order p =
   { p with show_order = Some show_order }
@@ -51,7 +40,6 @@ let set_show_order show_order p =
 let none = `Assoc [] |> of_yojson |> Result.get_ok
 
 let default = {
-  instruments = Some "" ;
   forced_pages = Some 0 ;
   for_dance = None ;
   display_name = None ;
@@ -62,8 +50,7 @@ let default = {
 }
 
 let compose first second =
-  { instruments   = Option.(choose ~tie:second) first.instruments  second.instruments ;
-    forced_pages  = Option.(choose ~tie:second) first.forced_pages second.forced_pages ;
+  { forced_pages  = Option.(choose ~tie:second) first.forced_pages second.forced_pages ;
     for_dance     = Option.(choose ~tie:fail)   first.for_dance    second.for_dance ;
     display_name  = Option.(choose ~tie:second) first.display_name second.display_name ;
     show_deviser  = Option.(choose ~tie:second) first.show_deviser second.show_deviser ;

--- a/src/common/model/version/versionParameters.ml
+++ b/src/common/model/version/versionParameters.ml
@@ -5,7 +5,7 @@ module Self = struct
     { transposition  : Transposition.t option [@default None] ;
       first_bar      : int             option [@default None] [@key "first-bar"] ;
       for_dance      : DanceCore.t Slug.t option [@default None] [@key "for-dance"] ;
-
+      instruments    : string          option [@default None] ;
       clef           : Music.clef      option [@default None] ;
       trivia         : string          option [@default None] ;
       display_name   : string          option [@default None] [@key "display-name"] ;
@@ -22,12 +22,18 @@ include Self
    [@yojson.default]. Current version of [@@deriving yojson] (3.5.3) does not,
    however, seem to recognise this option anymore. In the meantime, we use
    [@default] and we add a dirty fix for [@@deriving make]: *)
-let make ?transposition ?clef ?first_bar ?display_name ?display_author () =
-  make ~transposition ~clef ~first_bar ~display_name ~display_author ()
+let make ?instruments ?transposition ?clef ?first_bar ?display_name ?display_author () =
+  make ~instruments ~transposition ~clef ~first_bar ~display_name ~display_author ()
+
+let make_instrument pitch =
+  make
+    ~instruments:(Music.pitch_to_pretty_string pitch ^ " instruments")
+    ~transposition:(Transposition.relative pitch Music.pitch_c)
+    ()
 
 let transposition  p = Option.unwrap p.transposition
 let first_bar      p = Option.unwrap p.first_bar
-
+let instruments    p = p.instruments
 let for_dance      p = p.for_dance
 let clef           p = p.clef
 let trivia         p = p.trivia
@@ -40,6 +46,7 @@ let set_display_name display_name p =
 let none = `Assoc [] |> of_yojson |> Result.get_ok
 
 let default = {
+  instruments    = None ;
   transposition  = Some Transposition.identity ;
   first_bar      = Some 1 ;
   for_dance      = None ;
@@ -50,7 +57,8 @@ let default = {
 }
 
 let compose first second =
-  { transposition  = Option.choose ~tie:Transposition.compose first.transposition second.transposition ;
+  { instruments    = Option.(choose ~tie:fail)   first.instruments    second.instruments ;
+    transposition  = Option.choose ~tie:Transposition.compose first.transposition second.transposition ;
     clef           = Option.(choose ~tie:second) first.clef           second.clef ;
     first_bar      = Option.(choose ~tie:second) first.first_bar      second.first_bar ;
     for_dance      = Option.(choose ~tie:fail)   first.for_dance      second.for_dance ;

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -54,7 +54,7 @@ module Ly = struct
       fpf fmt [%blob "template/book/macros.ly"];
       fpf fmt [%blob "template/layout.ly"];
       fpf fmt [%blob "template/book/globals.ly"]
-        title (Option.unwrap_or ~default:"" parameters.instruments);
+        title (Option.unwrap_or ~default:"" (BookParameters.instruments parameters));
       fpf fmt [%blob "template/paper.ly"];
 
       fpf fmt [%blob "template/book/paper.ly"];

--- a/src/server/controller/set.ml
+++ b/src/server/controller/set.ml
@@ -25,7 +25,7 @@ module Ly = struct
       fpf fmt [%blob "template/bar-numbering/beginning-of-line.ly"];
       fpf fmt [%blob "template/set/header.ly"]
         title (Kind.Dance.to_string kind)
-        (SetParameters.instruments parameters);
+        (Option.unwrap_or ~default:"" (SetParameters.instruments parameters));
       Lwt_list.iter_s
         (fun (version, version_parameters) ->
            let version_parameters = VersionParameters.compose (SetParameters.every_version parameters) version_parameters in

--- a/src/server/model/set/setParameters.ml
+++ b/src/server/model/set/setParameters.ml
@@ -7,7 +7,7 @@ let for_dance p =
   Lwt.return_some dance
 
 let make
-    ?instruments ?forced_pages ?show_deviser ?show_order
+    ?forced_pages ?show_deviser ?show_order
     ?display_name ?for_dance ?every_version ()
   =
   let%lwt for_dance =
@@ -15,5 +15,5 @@ let make
     let%lwt dance = Dance.slug dance in
     Lwt.return_some dance
   in
-  Lwt.return (make ?instruments ?forced_pages ?show_deviser ?show_order
+  Lwt.return (make ?forced_pages ?show_deviser ?show_order
                 ?display_name ?for_dance ?every_version ())


### PR DESCRIPTION
closes https://github.com/paris-branch/dancelor/issues/80

This PR builds on top of https://github.com/paris-branch/dancelor/pull/241. Since we now have a dialog for downloading a PDF, we can use the extra space to give many more options to the user. For instance, for books:

![image](https://github.com/paris-branch/dancelor/assets/5920602/c8d78fbe-aa94-41d0-affa-ab6bb53122a6)

All those options were available before but each of them had their own button. The number of buttons in the code and in the interface would grow exponentially with the number of options exposed to the user. Not anymore!

This PR first adds a `choices` component for nice multi-choice buttons. I wanted to use an HTML `select` but after much Googling I concluded that this was not meant to be used for this. The solution is quite dirty with, in particular, names and ids given randomly. I am not pleased with that but at least it is not seen from the outside.

With this component in mind, we can write a full dialog that gives the options to the user.