### PR TITLE
Set order rendering parameter

### DIFF
--- a/src/common/model/set/setParameters.ml
+++ b/src/common/model/set/setParameters.ml
@@ -1,10 +1,17 @@
 open Nes
 
+(** How to render the order. [Default] prints the tunes as they appear in the
+    set. [Unfolded] follows the order, duplicating the tunes if they are to be
+    played several times. *)
+type order_type = Default | Unfolded
+[@@deriving yojson]
+
 module Self = struct
   type t =
     { forced_pages  : int    option [@default None] [@key "forced-pages"] ;
       show_deviser  : bool   option [@default None] [@key "show-deviser"] ;
       show_order    : bool   option [@default None] [@key "show-order"] ;
+      order_type    : order_type option [@default None] [@key "order-type"] ;
       display_name  : string option [@default None] [@key "display-name"] ;
 
       for_dance     : DanceCore.t Slug.t option [@default None] [@key "for-dance"] ;
@@ -30,6 +37,7 @@ let for_dance    p = p.for_dance
 let display_name p = p.display_name
 let show_deviser p = Option.unwrap p.show_deviser
 let show_order   p = Option.unwrap p.show_order
+let order_type   p = p.order_type
 
 let every_version p = p.every_version
 let instruments = VersionParameters.instruments % every_version
@@ -45,6 +53,7 @@ let default = {
   display_name = None ;
   show_deviser = Some true ;
   show_order = Some true ;
+  order_type = Some Default ;
 
   every_version = VersionParameters.default ;
 }
@@ -55,6 +64,7 @@ let compose first second =
     display_name  = Option.(choose ~tie:second) first.display_name second.display_name ;
     show_deviser  = Option.(choose ~tie:second) first.show_deviser second.show_deviser ;
     show_order    = Option.(choose ~tie:second) first.show_order   second.show_order ;
+    order_type    = Option.(choose ~tie:second) first.order_type   second.order_type ;
 
     every_version = VersionParameters.compose first.every_version second.every_version }
 


### PR DESCRIPTION
Builds on top of https://github.com/paris-branch/dancelor/pull/244.

This PR adds a new set parameter determining how to render the set order. The default remains to show the tunes as they appear in the set, but this add a new mode where the tunes are duplicated if they must be played several times. This can be practical when they are not to be printed on paper but shown or a table instead.

WDYT @R1kM?