### PR TITLE
Improve search bar

### DIFF
--- a/lib/nes/nesList.ml
+++ b/lib/nes/nesList.ml
@@ -149,3 +149,5 @@ let sort_count_lwt compare l =
 let sort_uniq_lwt compare l =
   let%lwt l = sort_count_lwt compare l in
   Lwt.return (List.map fst l)
+
+let snoc l x = l @ [x]

--- a/lib/nes/nesList.mli
+++ b/lib/nes/nesList.mli
@@ -74,3 +74,6 @@ val compare_lwt : ('a -> 'a -> int Lwt.t) -> 'a t -> 'a t -> int Lwt.t
 
 val singleton : 'a -> 'a list
 (** [singleton x] is [[x]]. *)
+
+val snoc : 'a list -> 'a -> 'a list
+(** Append at the end. [snoc l x] is [l @ \[x\]]*)

--- a/lib/nes/nesLwt.ml
+++ b/lib/nes/nesLwt.ml
@@ -3,6 +3,20 @@ include Lwt
 let compose f g =
   fun x -> bind (f x) g
 
+(** Poor man's sleep: same as {!Lwt_unix.sleep} except that it is less efficient
+    but it does not depend on [lwt.unix], which matters when compiling to eg.
+    JavaScript. *)
+let pmsleep duration =
+  let target = Unix.gettimeofday () +. duration in
+  let rec loop () =
+    Lwt.pause ();%lwt
+    if Unix.gettimeofday () >= target then
+      Lwt.return_unit
+    else
+      loop ()
+  in
+  loop ()
+
 module Syntax = struct
   let (>>=|) = bind
   let (>=>|) = compose

--- a/src/client/components/searchBar.ml
+++ b/src/client/components/searchBar.ml
@@ -79,29 +79,34 @@ let make ~placeholder ~search ~make_result ~max_results ?on_enter () =
       a_onclick (fun _ -> set_table_visible false; false);
     ] [];
 
-    input ~a:[
-      a_input_type `Text;
-      a_placeholder placeholder;
-      a_oninput (fun event ->
-          (
-            Js.Opt.iter event##.target @@ fun elt ->
-            Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
-            set_search_text (Js.to_string input##.value)
+    input
+      ~a:(List.filter_map Fun.id [
+          Some (a_input_type `Text);
+          Some (a_placeholder placeholder);
+          Some (
+            a_oninput (fun event ->
+                (
+                  Js.Opt.iter event##.target @@ fun elt ->
+                  Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
+                  set_search_text (Js.to_string input##.value)
+                );
+                false
+              )
           );
-          false
-        );
-      a_autofocus ();
-      a_onfocus (fun _ -> set_table_visible true; false);
-      a_onkeyup (fun event ->
-          if Js.Optdef.to_option event##.key = Some (Js.string "Enter") then
-            (
-              Js.Opt.iter event##.target @@ fun elt ->
-              Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
-              Option.value ~default:ignore on_enter (Js.to_string input##.value)
-            );
-          true
-        );
-    ] ();
+          Some (a_autofocus ());
+          Some (a_onfocus (fun _ -> set_table_visible true; false));
+          Some (
+            a_onkeyup (fun event ->
+                if Js.Optdef.to_option event##.key = Some (Js.string "Enter") then
+                  (
+                    Js.Opt.iter event##.target @@ fun elt ->
+                    Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
+                    Option.value ~default:ignore on_enter (Js.to_string input##.value)
+                  );
+                true
+              )
+          );
+        ]) ();
 
     tablex
       ~a:[

--- a/src/client/components/searchBar.ml
+++ b/src/client/components/searchBar.ml
@@ -113,12 +113,15 @@ let make ~placeholder ~search ~make_result ~max_results ~on_enter =
       ]
       [
         R.tbody (
-          Fun.flip S.map search_bar_state @@ function
-          | StartTyping -> [emoji_row "👉" "Start typing to search."]
-          | ContinueTyping -> [emoji_row "👉" (spf "Type at least %s characters." min_characters_text)]
-          | NoResults -> [emoji_row "⚠️" "Your search returned no results."]
-          | Results results -> List.map make_result results @ [emoji_row "👉" "Press enter for more results."]
-          | Errors errors -> List.map (emoji_row "❌") errors
+          S.bind_s' search_bar_state [] @@ function
+          | StartTyping -> Lwt.return [emoji_row "👉" "Start typing to search."]
+          | ContinueTyping -> Lwt.return [emoji_row "👉" (spf "Type at least %s characters." min_characters_text)]
+          | NoResults -> Lwt.return [emoji_row "⚠️" "Your search returned no results."]
+          | Errors errors -> Lwt.return @@ List.map (emoji_row "❌") errors
+          | Results results ->
+            Lwt.map
+              (Fun.flip List.snoc (emoji_row "👉" "Press enter for more results."))
+              (Lwt_list.map_p make_result results)
         );
       ]
   ]

--- a/src/client/components/searchBar.ml
+++ b/src/client/components/searchBar.ml
@@ -95,13 +95,14 @@ let make ~placeholder ~search ~make_result ~max_results ?on_enter () =
           );
           Some (a_autofocus ());
           Some (a_onfocus (fun _ -> set_table_visible true; false));
-          Some (
+          (
+            Fun.flip Option.map on_enter @@ fun on_enter ->
             a_onkeyup (fun event ->
                 if Js.Optdef.to_option event##.key = Some (Js.string "Enter") then
                   (
                     Js.Opt.iter event##.target @@ fun elt ->
                     Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
-                    Option.value ~default:ignore on_enter (Js.to_string input##.value)
+                    on_enter (Js.to_string input##.value)
                   );
                 true
               )

--- a/src/client/components/searchBar.ml
+++ b/src/client/components/searchBar.ml
@@ -17,7 +17,7 @@ type 'a search_bar_state =
   | Results of 'a list (** when the search returned results; guaranteed to be non empty; otherwise [NoResults] *)
   | Errors of string list (** when the search returned an error; guaranteed to be non empty *)
 
-let make ~placeholder ~search ~make_result ~max_results ~on_enter =
+let make ~placeholder ~search ~make_result ~max_results ~on_enter () =
   let (search_text, set_search_text_immediately) = S.create "" in
   let (table_visible, set_table_visible) = S.create false in
 

--- a/src/client/components/searchBar.ml
+++ b/src/client/components/searchBar.ml
@@ -17,7 +17,7 @@ type 'a search_bar_state =
   | Results of 'a list (** when the search returned results; guaranteed to be non empty; otherwise [NoResults] *)
   | Errors of string list (** when the search returned an error; guaranteed to be non empty *)
 
-let make ~placeholder ~search ~make_result ~max_results ~on_enter () =
+let make ~placeholder ~search ~make_result ~max_results ?on_enter () =
   let (search_text, set_search_text_immediately) = S.create "" in
   let (table_visible, set_table_visible) = S.create false in
 
@@ -97,7 +97,7 @@ let make ~placeholder ~search ~make_result ~max_results ~on_enter () =
             (
               Js.Opt.iter event##.target @@ fun elt ->
               Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
-              on_enter (Js.to_string input##.value)
+              Option.value ~default:ignore on_enter (Js.to_string input##.value)
             );
           true
         );

--- a/src/client/components/searchBar.ml
+++ b/src/client/components/searchBar.ml
@@ -9,6 +9,21 @@ let no_results_row =
     td [txt "Your search returned no results."];
   ]
 
+(** Row for when the user has not even started typing. *)
+let start_typing_row =
+  tr [
+    td [txt "👉"];
+    td [txt "Start typing to search."];
+  ]
+
+(** Row for when the user started typing but did not give enough characters to
+    trigger a meaningful search. *)
+let continue_typing_row =
+  tr [
+    td [txt "👉"];
+    td [txt "Type at least three characters."];
+  ]
+
 (** Rows for when the search returned error messages. *)
 let error_rows messages =
   Fun.flip List.map messages @@ fun message ->
@@ -68,17 +83,10 @@ let make ~placeholder ~search ~make_result ~max_results ~on_enter =
           S.bind_s' search_text [] @@ fun search_text ->
           if String.length search_text < 3 then
             (
-              let message =
-                if search_text = ""
-                then "Start typing to search."
-                else "Type at least three characters."
-              in
-              Lwt.return [
-                tr [
-                  td [txt "👉"];
-                  td [txt message];
-                ]
-              ]
+              if search_text = "" then
+                Lwt.return [start_typing_row]
+              else
+                Lwt.return [continue_typing_row]
             )
           else
             Fun.flip Lwt.map (search search_text) @@ function

--- a/src/client/components/searchBar.ml
+++ b/src/client/components/searchBar.ml
@@ -48,7 +48,6 @@ let make ~placeholder ~search ~make_result ~max_results ?on_enter ?(autofocus=fa
 
   (** Minimum number of characters for the search to fire. *)
   let min_characters = 3 in
-  let min_characters_text = "three" in
 
   (** A signal that provides a [search_bar_state] view based on
       [search_text]. *)
@@ -126,7 +125,7 @@ let make ~placeholder ~search ~make_result ~max_results ?on_enter ?(autofocus=fa
         R.tbody (
           S.bind_s' search_bar_state [] @@ function
           | StartTyping -> Lwt.return [emoji_row "👉" "Start typing to search."]
-          | ContinueTyping -> Lwt.return [emoji_row "👉" (spf "Type at least %s characters." min_characters_text)]
+          | ContinueTyping -> Lwt.return [emoji_row "👉" (spf "Type at least %s characters." (Int.to_english_string min_characters))]
           | NoResults -> Lwt.return [emoji_row "⚠️" "Your search returned no results."]
           | Errors errors -> Lwt.return @@ List.map (emoji_row "❌") errors
           | Results results ->

--- a/src/client/components/searchBar.ml
+++ b/src/client/components/searchBar.ml
@@ -18,8 +18,33 @@ type 'a search_bar_state =
   | Errors of string list (** when the search returned an error; guaranteed to be non empty *)
 
 let make ~placeholder ~search ~make_result ~max_results ~on_enter =
-  let (search_text, set_search_text) = S.create "" in
+  let (search_text, set_search_text_immediately) = S.create "" in
   let (table_visible, set_table_visible) = S.create false in
+
+  (* REVIEW: maybe this should become a generic signal helper to delay signals
+     by a certain time? *)
+  (** The following is a mechanism to only set the search text in a delayed
+      fashion. The [search_text_setter] signal contains an Lwt promise whose job
+      is to set the search text after a delayed time. The [set_search_text]
+      function cancels the current Lwt promise (which does nothing if it already
+      resolved) and creates a new one in its place. *)
+  let (search_text_setter, set_search_text_setter) = S.create Lwt.return_unit in
+  let set_search_text text =
+    (* try cancelling the current search text setter *)
+    Lwt.cancel (S.value search_text_setter);
+    (* prepare the new search text setter *)
+    let new_search_text_setter =
+      (* FIXME: here, we need to delay by something like 100ms but [Lwt_unix]
+         does not seem to be the answer. *)
+      Lwt.pmsleep 0.30;%lwt
+      set_search_text_immediately text;
+      Lwt.return_unit
+    in
+    (* register it in the signal *)
+    set_search_text_setter new_search_text_setter;
+    (* fire it asynchronously *)
+    Lwt.async (fun () -> new_search_text_setter)
+  in
 
   (** Minimum number of characters for the search to fire. *)
   let min_characters = 3 in

--- a/src/client/components/searchBar.ml
+++ b/src/client/components/searchBar.ml
@@ -119,9 +119,12 @@ let make ~placeholder ~search ~make_result ~max_results ?on_enter () =
           | NoResults -> Lwt.return [emoji_row "⚠️" "Your search returned no results."]
           | Errors errors -> Lwt.return @@ List.map (emoji_row "❌") errors
           | Results results ->
-            Lwt.map
-              (Fun.flip List.snoc (emoji_row "👉" "Press enter for more results."))
-              (Lwt_list.map_p make_result results)
+            let%lwt results = Lwt_list.map_p make_result results in
+            Lwt.return @@
+            if on_enter = None then
+              results
+            else
+              results @ [emoji_row "👉" "Press enter for more results."]
         );
       ]
   ]

--- a/src/client/components/searchBar.ml
+++ b/src/client/components/searchBar.ml
@@ -17,7 +17,7 @@ type 'a search_bar_state =
   | Results of 'a list (** when the search returned results; guaranteed to be non empty; otherwise [NoResults] *)
   | Errors of string list (** when the search returned an error; guaranteed to be non empty *)
 
-let make ~placeholder ~search ~make_result ~max_results ?on_enter () =
+let make ~placeholder ~search ~make_result ~max_results ?on_enter ?(autofocus=false) () =
   let (search_text, set_search_text_immediately) = S.create "" in
   let (table_visible, set_table_visible) = S.create false in
 
@@ -93,7 +93,12 @@ let make ~placeholder ~search ~make_result ~max_results ?on_enter () =
                 false
               )
           );
-          Some (a_autofocus ());
+          (
+            if autofocus then
+              Some (a_autofocus ())
+            else
+              None
+          );
           Some (a_onfocus (fun _ -> set_table_visible true; false));
           (
             Fun.flip Option.map on_enter @@ fun on_enter ->

--- a/src/client/components/searchBar.ml
+++ b/src/client/components/searchBar.ml
@@ -21,11 +21,15 @@ let make ~placeholder ~search ~make_result ~max_results ~on_enter =
   let (search_text, set_search_text) = S.create "" in
   let (table_visible, set_table_visible) = S.create false in
 
+  (** Minimum number of characters for the search to fire. *)
+  let min_characters = 3 in
+  let min_characters_text = "three" in
+
   (** A signal that provides a [search_bar_state] view based on
       [search_text]. *)
   let search_bar_state =
     S.bind_s' search_text StartTyping @@ fun search_text ->
-    if String.length search_text < 3 then
+    if String.length search_text < min_characters then
       (
         Lwt.return @@
         if search_text = "" then
@@ -86,7 +90,7 @@ let make ~placeholder ~search ~make_result ~max_results ~on_enter =
         R.tbody (
           Fun.flip S.map search_bar_state @@ function
           | StartTyping -> [emoji_row "👉" "Start typing to search."]
-          | ContinueTyping -> [emoji_row "👉" "Type at least three characters."]
+          | ContinueTyping -> [emoji_row "👉" (spf "Type at least %s characters." min_characters_text)]
           | NoResults -> [emoji_row "⚠️" "Your search returned no results."]
           | Results results -> List.map make_result results @ [emoji_row "👉" "Press enter for more results."]
           | Errors errors -> List.map (emoji_row "❌") errors

--- a/src/client/components/searchBar.ml
+++ b/src/client/components/searchBar.ml
@@ -2,34 +2,11 @@ open Nes
 open Js_of_ocaml
 open Dancelor_client_html
 
-(** Row for when the search returned no results. *)
-let no_results_row =
+(** Generic row showing an emoji on the left and a message on the right. *)
+let emoji_row emoji message =
   tr [
-    td [txt "⚠️"];
-    td [txt "Your search returned no results."];
-  ]
-
-(** Row for when the user has not even started typing. *)
-let start_typing_row =
-  tr [
-    td [txt "👉"];
-    td [txt "Start typing to search."];
-  ]
-
-(** Row for when the user started typing but did not give enough characters to
-    trigger a meaningful search. *)
-let continue_typing_row =
-  tr [
-    td [txt "👉"];
-    td [txt "Type at least three characters."];
-  ]
-
-(** Rows for when the search returned error messages. *)
-let error_rows messages =
-  Fun.flip List.map messages @@ fun message ->
-  tr [
-    td [txt "❌"];
-    td [txt message];
+    td [txt emoji];
+    td ~a:[a_colspan 4] [txt message];
   ]
 
 (** Abstraction of the possible states of the search bar. *)
@@ -108,11 +85,11 @@ let make ~placeholder ~search ~make_result ~max_results ~on_enter =
       [
         R.tbody (
           Fun.flip S.map search_bar_state @@ function
-          | StartTyping -> [start_typing_row]
-          | ContinueTyping -> [continue_typing_row]
-          | NoResults -> [no_results_row]
-          | Results results -> List.map make_result results @ [tr [td [txt "👉"]; td ~a:[a_colspan 4] [txt "Press enter for more results."]]]
-          | Errors errors -> error_rows errors
+          | StartTyping -> [emoji_row "👉" "Start typing to search."]
+          | ContinueTyping -> [emoji_row "👉" "Type at least three characters."]
+          | NoResults -> [emoji_row "⚠️" "Your search returned no results."]
+          | Results results -> List.map make_result results @ [emoji_row "👉" "Press enter for more results."]
+          | Errors errors -> List.map (emoji_row "❌") errors
         );
       ]
   ]

--- a/src/client/components/searchBar.mli
+++ b/src/client/components/searchBar.mli
@@ -5,7 +5,7 @@ open Js_of_ocaml_tyxml.Tyxml_js
 val make :
   placeholder:string ->
   search:(string -> ('result list, string list) result Lwt.t) ->
-  make_result:('result -> Html_types.tr Html.elt) ->
+  make_result:('result -> Html_types.tr Html.elt Lwt.t) ->
   max_results:int ->
   on_enter:(string -> unit) ->
   [> Html_types.div] Html.elt

--- a/src/client/components/searchBar.mli
+++ b/src/client/components/searchBar.mli
@@ -8,6 +8,7 @@ val make :
   make_result:('result -> Html_types.tr Html.elt Lwt.t) ->
   max_results:int ->
   ?on_enter:(string -> unit) ->
+  ?autofocus:bool ->
   unit ->
   [> Html_types.div] Html.elt
 (** Makes a search bar:
@@ -23,6 +24,9 @@ val make :
     - [max_results] is a threshold on the number of results to display;
 
     - [on_enter] is a function that triggers when the user presses Enter.
+
+    - [autofocus] is a boolean that indicates whether the search bar should grab
+      the focus when the page loads.
 
     A search bar is simply a <div> element.
 *)

--- a/src/client/components/searchBar.mli
+++ b/src/client/components/searchBar.mli
@@ -26,7 +26,7 @@ val make :
     - [on_enter] is a function that triggers when the user presses Enter.
 
     - [autofocus] is a boolean that indicates whether the search bar should grab
-      the focus when the page loads.
+      the focus when the page loads. It is [false] by default.
 
     A search bar is simply a <div> element.
 *)

--- a/src/client/components/searchBar.mli
+++ b/src/client/components/searchBar.mli
@@ -8,6 +8,7 @@ val make :
   make_result:('result -> Html_types.tr Html.elt Lwt.t) ->
   max_results:int ->
   on_enter:(string -> unit) ->
+  unit ->
   [> Html_types.div] Html.elt
 (** Makes a search bar:
 

--- a/src/client/components/searchBar.mli
+++ b/src/client/components/searchBar.mli
@@ -7,7 +7,7 @@ val make :
   search:(string -> ('result list, string list) result Lwt.t) ->
   make_result:('result -> Html_types.tr Html.elt Lwt.t) ->
   max_results:int ->
-  on_enter:(string -> unit) ->
+  ?on_enter:(string -> unit) ->
   unit ->
   [> Html_types.div] Html.elt
 (** Makes a search bar:

--- a/src/client/components/searchBar.mli
+++ b/src/client/components/searchBar.mli
@@ -1,0 +1,27 @@
+(** {1 SearchBar} *)
+
+open Js_of_ocaml_tyxml.Tyxml_js
+
+val make :
+  placeholder:string ->
+  search:(string -> ('result list, string list) result Lwt.t) ->
+  make_result:('result -> Html_types.tr Html.elt) ->
+  max_results:int ->
+  on_enter:(string -> unit) ->
+  [> Html_types.div] Html.elt
+(** Makes a search bar:
+
+    - [placeholder] shows in the bar when no text is entered yet;
+
+    - [search] is an Lwt function that returns either a list of results or a
+      list of error messages to display;
+
+    - [make_result] is a function that, from a result, returns a table line
+      displaying that result;
+
+    - [max_results] is a threshold on the number of results to display;
+
+    - [on_enter] is a function that triggers when the user presses Enter.
+
+    A search bar is simply a <div> element.
+*)

--- a/src/client/views/book/bookEditorInterface.ml
+++ b/src/client/views/book/bookEditorInterface.ml
@@ -135,7 +135,7 @@ let create ?on_save page =
       Dancelor_client_components.SearchBar.make
         ~placeholder:"Add set (Magic Search)"
         ~search
-        ~make_result:(make_set_result editor page)
+        ~make_result:(Lwt.return % make_set_result editor page)
         ~max_results:10
         ~on_enter:(fun _ -> ())
     ]
@@ -222,7 +222,7 @@ let update slug ?on_save page =
       Dancelor_client_components.SearchBar.make
         ~placeholder:"Add set (Magic Search)"
         ~search
-        ~make_result:(make_set_result editor page)
+        ~make_result:(Lwt.return % make_set_result editor page)
         ~max_results:10
         ~on_enter:(fun _ -> ())
     ]

--- a/src/client/views/book/bookEditorInterface.ml
+++ b/src/client/views/book/bookEditorInterface.ml
@@ -138,6 +138,7 @@ let create ?on_save page =
         ~make_result:(Lwt.return % make_set_result editor page)
         ~max_results:10
         ~on_enter:(fun _ -> ())
+        ()
     ]
   in
 
@@ -225,6 +226,7 @@ let update slug ?on_save page =
         ~make_result:(Lwt.return % make_set_result editor page)
         ~max_results:10
         ~on_enter:(fun _ -> ())
+        ()
     ]
   in
 

--- a/src/client/views/book/bookEditorInterface.ml
+++ b/src/client/views/book/bookEditorInterface.ml
@@ -137,7 +137,6 @@ let create ?on_save page =
         ~search
         ~make_result:(Lwt.return % make_set_result editor page)
         ~max_results:10
-        ~on_enter:(fun _ -> ())
         ()
     ]
   in
@@ -225,7 +224,6 @@ let update slug ?on_save page =
         ~search
         ~make_result:(Lwt.return % make_set_result editor page)
         ~max_results:10
-        ~on_enter:(fun _ -> ())
         ()
     ]
   in

--- a/src/client/views/index.ml
+++ b/src/client/views/index.ml
@@ -37,6 +37,7 @@ let create page =
         ~search
         ~make_result:(Lwt.return % AnyResultNewAPI.make_result)
         ~max_results:10
+        ~autofocus:true
         ~on_enter:(fun search_text ->
             Dom_html.window##.location##.href := js PageRouter.(path (Search (Some search_text)))
           )

--- a/src/client/views/index.ml
+++ b/src/client/views/index.ml
@@ -35,7 +35,7 @@ let create page =
       SearchBar.make
         ~placeholder:"Search for anything (it's magic!)"
         ~search
-        ~make_result:AnyResultNewAPI.make_result
+        ~make_result:(Lwt.return % AnyResultNewAPI.make_result)
         ~max_results:10
         ~on_enter:(fun search_text ->
             Dom_html.window##.location##.href := js PageRouter.(path (Search (Some search_text)))

--- a/src/client/views/index.ml
+++ b/src/client/views/index.ml
@@ -40,6 +40,7 @@ let create page =
         ~on_enter:(fun search_text ->
             Dom_html.window##.location##.href := js PageRouter.(path (Search (Some search_text)))
           )
+        ()
     ]
   );
 


### PR DESCRIPTION
Builds on top of #254.

This PR brings multiple improvements to the search bar. Specifically, it:
- cleans up the code of the search bar (https://github.com/paris-branch/dancelor/pull/255/commits/da97dcc780aeb12ef16613a2bdb3f46fb5793d1d, https://github.com/paris-branch/dancelor/pull/255/commits/3e7d1a6a17c9be77986f9727fed3a7d5ee1877a7, https://github.com/paris-branch/dancelor/pull/255/commits/7bf11c41da9d90293b15318bb28d56001d77783f, https://github.com/paris-branch/dancelor/pull/255/commits/2bdbd7f4e796adc3506a75c150995faf16e4b5fd)
- adds an interface and some documentation (https://github.com/paris-branch/dancelor/pull/255/commits/3dbca5505665dde8e3eac419c4f5729d4af8da3f, should improve [on this](https://paris-branch.github.io/dancelor/dancelor/Dancelor_client_components/SearchBar/index.html))
- adds a delay to trigger the search only once the user stopped typing (https://github.com/paris-branch/dancelor/pull/255/commits/d762a8172d30d0cef78dfead09bb08b8d409481f, https://github.com/paris-branch/dancelor/pull/255/commits/030d7099fd51aa9767644c69b9e22f4af26e7832)
- changes the `make_result` argument to return a promise (https://github.com/paris-branch/dancelor/pull/255/commits/32997200e3f8c82f45fc0dfd1c8331c02e22029d, https://github.com/paris-branch/dancelor/pull/255/commits/9fa3306cf6b9052617439a9efebd58536b4163a9)
- makes the `on_enter` argument optional (https://github.com/paris-branch/dancelor/pull/255/commits/7f6f209a2649681ae20d4c12c980a6dabc5c8af1, https://github.com/paris-branch/dancelor/pull/255/commits/8fa78453a902aec0aa745d863c26109db4c9f3a0, https://github.com/paris-branch/dancelor/pull/255/commits/63360cc7d9c7b1cf21711f7ab0c41bec9702eb6e, https://github.com/paris-branch/dancelor/pull/255/commits/abc71d3449cb023dba444b71f4c6d2e8262ca428)
- makes the autofocus optional; enabled in the index but not in the book editor (https://github.com/paris-branch/dancelor/pull/255/commits/ab8d384c46b26a6bec73e9c1df90c5fcb720386e, https://github.com/paris-branch/dancelor/pull/255/commits/06e4e336075ab9b6f8212f5493c5462167cf15ad)