### PR TITLE
Crop in pure LilyPond

### DIFF
--- a/.nix/app-dancelor.nix
+++ b/.nix/app-dancelor.nix
@@ -5,14 +5,7 @@
       program = let
         dancelor = pkgs.writeShellApplication {
           name = "dancelor";
-          runtimeInputs = with pkgs; [
-            timidity
-            freepats
-            inkscape
-            lilypond
-            sassc
-            xvfb-run
-          ];
+          runtimeInputs = with pkgs; [ timidity freepats lilypond sassc ];
           text = ''
             ${self'.packages.dancelor}/bin/dancelor-server "$@"
           '';

--- a/dancelor.opam
+++ b/dancelor.opam
@@ -50,10 +50,10 @@ build: [
 ]
 dev-repo: "git+https://github.com/paris-branch/dancelor.git"
 depexts: [
-  [ "timidity++" "freepats-general-midi" "inkscape" "lilypond" "sassc" "xorg-server-xvfb" ]
+  [ "timidity++" "freepats-general-midi" "lilypond" "sassc" ]
     { os-distribution = "archlinux" }
   [ "sassc" ]
     { os-distribution = "alpine" }
-  [ "timidity" "freepats" "inkscape" "lilypond" "sassc" "xvfb" ]
+  [ "timidity" "freepats" "lilypond" "sassc" ]
     { os-distribution = "debian" }
 ]

--- a/dancelor.opam.template
+++ b/dancelor.opam.template
@@ -1,8 +1,8 @@
 depexts: [
-  [ "timidity++" "freepats-general-midi" "inkscape" "lilypond" "sassc" "xorg-server-xvfb" ]
+  [ "timidity++" "freepats-general-midi" "lilypond" "sassc" ]
     { os-distribution = "archlinux" }
   [ "sassc" ]
     { os-distribution = "alpine" }
-  [ "timidity" "freepats" "inkscape" "lilypond" "sassc" "xvfb" ]
+  [ "timidity" "freepats" "lilypond" "sassc" ]
     { os-distribution = "debian" }
 ]

--- a/src/lilypond/lilyPond.ml
+++ b/src/lilypond/lilyPond.ml
@@ -1,23 +1,6 @@
 open Nes
 module Log = (val Logs.(src_log (Src.create "lilypond")) : Logs.LOG)
 
-module Inkscape = struct
-  let crop ?(inkscape_bin="inkscape") ~exec_path ~output file =
-    let cmd = [
-      "xvfb-run"; inkscape_bin;
-      "--export-area-drawing"; "--export-plain-svg"; "--export-filename="^output; file
-    ]
-    in
-    try%lwt
-      NesProcess.run_ignore
-        ~cwd:exec_path
-        ~on_wrong_status:Logs.Error
-        ~on_nonempty_stdout:Logs.Warning ~on_nonempty_stderr:Logs.Warning
-        cmd
-    with
-      Failure _ -> Lwt.return_unit
-end
-
 let run ?(lilypond_bin="lilypond") ?(exec_path=".") ?(options=[]) filename =
   try%lwt
     NesProcess.run_ignore
@@ -31,11 +14,9 @@ let run ?(lilypond_bin="lilypond") ?(exec_path=".") ?(options=[]) filename =
   with
     Failure _ -> Lwt.return_unit
 
-let cropped_svg ?lilypond_bin ?inkscape_bin ?(exec_path=".") filename =
-  run ?lilypond_bin ~exec_path ~options:["-dbackend=svg"] filename;%lwt
-  Inkscape.crop ?inkscape_bin ~exec_path
-    ((Filename.chop_extension filename) ^ ".svg")
-    ~output:((Filename.chop_extension filename) ^ ".cropped.svg")
+(** Alias of {!run} for SVG generation. *)
+let svg ?lilypond_bin ?exec_path ?(options=[]) filename =
+  run ?lilypond_bin ?exec_path ~options:("-dbackend=svg" :: options) filename
 
 let ogg ?lilypond_bin ?(exec_path=".") filename =
   run ?lilypond_bin ~exec_path filename;%lwt

--- a/src/server/controller/template/cropped.ly
+++ b/src/server/controller/template/cropped.ly
@@ -1,0 +1,10 @@
+\paper {
+  page-breaking = #ly:one-page-breaking
+  top-margin = 0
+  left-margin = 0
+  right-margin = 0
+
+  %% Not sure exactly where the bottom margin comes from but this hack removes
+  %% the biggest part of it.
+  bottom-margin = -1\cm
+}

--- a/src/server/controller/template/version.ly
+++ b/src/server/controller/template/version.ly
@@ -22,3 +22,7 @@
     }
   }
 }
+
+%% The following is important for the cropped SVG output; otherwise the last
+%% line of chords causes troubles.
+\markup\null

--- a/src/server/controller/version.ml
+++ b/src/server/controller/version.ml
@@ -73,6 +73,7 @@ let prepare_ly_file ?(parameters=Model.VersionParameters.none) ?(show_meta=false
     fpf fmt "#(load \"%s\")\n\n" (Filename.basename fname_scm);
     fpf fmt [%blob "template/layout.ly"];
     fpf fmt [%blob "template/paper.ly"];
+    fpf fmt [%blob "template/cropped.ly"];
     fpf fmt [%blob "template/repeat-volta-fancy.ly"];
     fpf fmt [%blob "template/bar-numbering/repeat-aware.ly"];
     fpf fmt [%blob "template/bar-numbering/bar-number-in-instrument-name-engraver.ly"];
@@ -145,15 +146,15 @@ module Svg = struct
     let%lwt (fname_ly, fname_svg) =
       let%lwt slug = Model.Version.slug version in
       let fname = aspf "%a-%a" Slug.pp slug StorageCache.pp_hash hash in
-      Lwt.return (fname^".ly", fname^".cropped.svg")
+      Lwt.return (fname^".ly", fname^".svg")
     in
     Log.debug (fun m -> m "LilyPond file name: %s" fname_ly);
     Log.debug (fun m -> m "SVG file name: %s" fname_svg);
     let path = Filename.concat !Dancelor_server_config.cache "version" in
     Log.debug (fun m -> m "Preparing lilypond file");
     prepare_ly_file ?parameters ~show_meta:false ~fname:(Filename.concat path fname_ly) version;%lwt
-    Log.debug (fun m -> m "Generate score and crop");
-    LilyPond.cropped_svg ~exec_path:path fname_ly;%lwt
+    Log.debug (fun m -> m "Generate score");
+    LilyPond.svg ~exec_path:path fname_ly;%lwt
     Log.debug (fun m -> m "done!");
     Lwt.return (Filename.concat path fname_svg)
 


### PR DESCRIPTION
Builds on top of #258.

This PR introduces SVG cropping in pure LilyPond. This allows getting rid of Inkscape and xfvb. This will:

- make SVG generation approximately twice faster; it is cached, so this should not really be noticeable, but it is still nice, and it will still matter for new tunes and future features such as previsualisation while adding tune or transposition of the previsualisation

- allow compiling SVGs on MacOS, which was blocked by the use of xvfb,

- allow packaging in a sandbox (eg. with Nix) which was blocked by Inkscape,

- simplify the code of the `LilyPond` module; not so much, but still a bit and that's nice,

- simplify drastically the environment in general.

The cropping in itself is not perfect and I used a bit of a hack (negative margin FTW) to make it better, but I think this is definitely worth it.

closes https://github.com/paris-branch/dancelor/issues/189
closes https://github.com/paris-branch/dancelor/issues/89

WDYT @R1kM?