### PR TITLE
Handle SVG margins in a cleaner way

### DIFF
--- a/src/server/controller/template/cropped.ly
+++ b/src/server/controller/template/cropped.ly
@@ -1,10 +1,19 @@
 \paper {
+  %% Make the page as big as its content
   page-breaking = #ly:one-page-breaking
+
+  %% Remove all margins
   top-margin = 0
   left-margin = 0
   right-margin = 0
+  bottom-margin = 0
 
-  %% Not sure exactly where the bottom margin comes from but this hack removes
-  %% the biggest part of it.
-  bottom-margin = -1\cm
+  %% Remove most other flexible vertical spacing
+  score-system-spacing = 0
+  markup-system-spacing = 0
+  score-markup-spacing = 0
+  markup-markup-spacing = 0
+  top-system-spacing = 0
+  top-markup-spacing = 0
+  last-bottom-spacing = 0
 }

--- a/src/server/controller/template/cropped.ly
+++ b/src/server/controller/template/cropped.ly
@@ -2,10 +2,13 @@
   %% Make the page as big as its content
   page-breaking = #ly:one-page-breaking
 
-  %% Remove all margins
-  top-margin = 0
+  %% Remove horizontal margins; keep 1cm on the left for bar numbers
+  two-sided = #f
   left-margin = 0
-  right-margin = 0
+  right-margin = 1\cm
+
+  %% Remove all vertical margins
+  top-margin = 0
   bottom-margin = 0
 
   %% Remove most other flexible vertical spacing

--- a/src/style/sandbox.scss
+++ b/src/style/sandbox.scss
@@ -68,8 +68,13 @@ button.disabled {
 }
 
 .image-container object {
-  width: 100%;
-  margin: auto;
+  // Tune previews are generated on A4 paper -- 21cm wide -- with a left margin
+  // of 1cm for page numbers -- that is 5% of the whole page. Since we want page
+  // numbers to actually appear in the margin on the website, we make the image
+  // bigger but remove those 5% of margin on the left.
+  max-width: none;
+  width: 105%;
+  margin-left: -5%;
   display: block;
 }
 


### PR DESCRIPTION
This PR:

- gets rid of the hack for bottom margin of SVGs
- reintroduces bar numbers but make them appear in the website's “left margin”.