### PR TITLE
Handle default parameters in a cleaner way

### DIFF
--- a/src/common/model/book/bookParameters.ml
+++ b/src/common/model/book/bookParameters.ml
@@ -36,12 +36,12 @@ let make ?front_page ?table_of_contents ?two_sided ?every_set ?running_header ?p
 
 (** {2 Getters} *)
 
-let front_page        p = Option.get p.front_page
-let table_of_contents p = Option.get p.table_of_contents
-let two_sided         p = Option.get p.two_sided
-let running_header    p = Option.get p.running_header
-let running_footer    p = Option.get p.running_footer
-let paper_size        p = Option.get p.paper_size
+let front_page p = p.front_page
+let table_of_contents p = p.table_of_contents
+let two_sided p = p.two_sided
+let running_header p = p.running_header
+let running_footer p = p.running_footer
+let paper_size p = p.paper_size
 
 let every_set         p = p.every_set
 let instruments = SetParameters.instruments % every_set
@@ -49,6 +49,13 @@ let instruments = SetParameters.instruments % every_set
 (** {2 Defaults} *)
 
 let none = `Assoc [] |> of_yojson |> Result.get_ok
+
+let front_page' = Option.value ~default:false % front_page
+let table_of_contents' = Option.value ~default:Nowhere % table_of_contents
+let two_sided' = Option.value ~default:false % two_sided
+let running_header' = Option.value ~default:true % running_header
+let running_footer' = Option.value ~default:true % running_footer
+let paper_size' = Option.value ~default:SetParameters.(paper_size' none) % paper_size
 
 let default = {
   front_page = Some false ;

--- a/src/common/model/book/bookParameters.ml
+++ b/src/common/model/book/bookParameters.ml
@@ -1,3 +1,8 @@
+(** {1 Book Parameters}
+
+    This module defines parameters that make sense at the level of a book. This
+    includes set parameters (which include version parameters) as well. *)
+
 open Nes
 
 type where = Beginning | End | Nowhere
@@ -29,6 +34,8 @@ include Self
 let make ?front_page ?table_of_contents ?two_sided ?every_set ?running_header ?paper_size () =
   make ~front_page ~table_of_contents ~two_sided ?every_set ~running_header ~paper_size ()
 
+(** {2 Getters} *)
+
 let front_page        p = Option.get p.front_page
 let table_of_contents p = Option.get p.table_of_contents
 let two_sided         p = Option.get p.two_sided
@@ -38,6 +45,8 @@ let paper_size        p = Option.get p.paper_size
 
 let every_set         p = p.every_set
 let instruments = SetParameters.instruments % every_set
+
+(** {2 Defaults} *)
 
 let none = `Assoc [] |> of_yojson |> Result.get_ok
 
@@ -51,6 +60,8 @@ let default = {
 
   every_set = SetParameters.none ;
 }
+
+(** {2 Composition} *)
 
 let compose first second =
   { front_page        = Option.(choose ~tie:second) first.front_page        second.front_page ;

--- a/src/common/model/book/bookParameters.ml
+++ b/src/common/model/book/bookParameters.ml
@@ -47,9 +47,9 @@ let default = {
   two_sided = Some false ;
   running_header = Some true ;
   running_footer = Some true ;
-  paper_size = SetParameters.default.paper_size ;
+  paper_size = Some SetParameters.(paper_size' none) ;
 
-  every_set = SetParameters.default ;
+  every_set = SetParameters.none ;
 }
 
 let compose first second =

--- a/src/common/model/book/bookParameters.ml
+++ b/src/common/model/book/bookParameters.ml
@@ -57,17 +57,6 @@ let running_header' = Option.value ~default:true % running_header
 let running_footer' = Option.value ~default:true % running_footer
 let paper_size' = Option.value ~default:SetParameters.(paper_size' none) % paper_size
 
-let default = {
-  front_page = Some false ;
-  table_of_contents = Some Nowhere ;
-  two_sided = Some false ;
-  running_header = Some true ;
-  running_footer = Some true ;
-  paper_size = Some SetParameters.(paper_size' none) ;
-
-  every_set = SetParameters.none ;
-}
-
 (** {2 Composition} *)
 
 let compose first second =
@@ -79,5 +68,3 @@ let compose first second =
     paper_size        = Option.(choose ~tie:second) first.paper_size        second.paper_size ;
 
     every_set = SetParameters.compose first.every_set second.every_set }
-
-let fill = compose default

--- a/src/common/model/book/bookParameters.ml
+++ b/src/common/model/book/bookParameters.ml
@@ -21,7 +21,6 @@ module Self = struct
     running_header    : bool   option [@default None] [@key "running-header"] ;
     running_footer    : bool   option [@default None] [@key "running-footer"] ;
     paper_size        : SetParameters.paper_size option [@default None] [@key "paper-size"] ;
-
     every_set : SetParameters.t [@default SetParameters.none] [@key "every-set"] ;
   }
   [@@deriving make, yojson]
@@ -42,8 +41,7 @@ let two_sided p = p.two_sided
 let running_header p = p.running_header
 let running_footer p = p.running_footer
 let paper_size p = p.paper_size
-
-let every_set         p = p.every_set
+let every_set p = p.every_set
 let instruments = SetParameters.instruments % every_set
 
 (** {2 Defaults} *)
@@ -56,6 +54,7 @@ let two_sided' = Option.value ~default:false % two_sided
 let running_header' = Option.value ~default:true % running_header
 let running_footer' = Option.value ~default:true % running_footer
 let paper_size' = Option.value ~default:SetParameters.(paper_size' none) % paper_size
+let instruments' = Option.value ~default:"" % instruments
 
 (** {2 Composition} *)
 
@@ -66,5 +65,4 @@ let compose first second =
     running_header    = Option.(choose ~tie:second) first.running_header    second.running_header ;
     running_footer    = Option.(choose ~tie:second) first.running_footer    second.running_footer ;
     paper_size        = Option.(choose ~tie:second) first.paper_size        second.paper_size ;
-
     every_set = SetParameters.compose first.every_set second.every_set }

--- a/src/common/model/set/setParameters.ml
+++ b/src/common/model/set/setParameters.ml
@@ -47,21 +47,27 @@ let make
 
 (** {2 Getters} *)
 
-let forced_pages p = Option.get p.forced_pages
+let forced_pages p = p.forced_pages
 let for_dance    p = p.for_dance
 let display_name p = p.display_name
-let show_deviser p = Option.get p.show_deviser
-let show_order   p = Option.get p.show_order
+let show_deviser p = p.show_deviser
+let show_order   p = p.show_order
 let order_type   p = p.order_type
-let paper_size   p = Option.get p.paper_size
-let paper_size_opt p = p.paper_size
+let paper_size   p = p.paper_size
 
 let every_version p = p.every_version
 let instruments = VersionParameters.instruments % every_version
 
-(** {2 Defaults} *)
+(** {2 Defaults}
+
+    Getters that end with a quote are getters that have a default value. *)
 
 let none = `Assoc [] |> of_yojson |> Result.get_ok
+
+let forced_pages' = Option.value ~default:0 % forced_pages
+let show_deviser' = Option.value ~default:true % show_deviser
+let show_order' = Option.value ~default:true % show_order
+let paper_size' = Option.value ~default:(A 4) % paper_size
 
 let default = {
   forced_pages = Some 0 ;

--- a/src/common/model/set/setParameters.ml
+++ b/src/common/model/set/setParameters.ml
@@ -69,18 +69,6 @@ let show_deviser' = Option.value ~default:true % show_deviser
 let show_order' = Option.value ~default:true % show_order
 let paper_size' = Option.value ~default:(A 4) % paper_size
 
-let default = {
-  forced_pages = Some 0 ;
-  for_dance = None ;
-  display_name = None ;
-  show_deviser = Some true ;
-  show_order = Some true ;
-  order_type = Some Default ;
-  paper_size = Some (A 4) ;
-
-  every_version = VersionParameters.none ;
-}
-
 (** {2 Setters} *)
 
 let set_show_order show_order p =
@@ -98,5 +86,3 @@ let compose first second =
     paper_size    = Option.(choose ~tie:second) first.paper_size   second.paper_size ;
 
     every_version = VersionParameters.compose first.every_version second.every_version }
-
-let fill = compose default

--- a/src/common/model/set/setParameters.ml
+++ b/src/common/model/set/setParameters.ml
@@ -68,6 +68,8 @@ let forced_pages' = Option.value ~default:0 % forced_pages
 let show_deviser' = Option.value ~default:true % show_deviser
 let show_order' = Option.value ~default:true % show_order
 let paper_size' = Option.value ~default:(A 4) % paper_size
+let order_type' = Option.value ~default:Default % order_type
+let display_name' ~default = Option.value ~default % display_name
 
 (** {2 Setters} *)
 

--- a/src/common/model/set/setParameters.ml
+++ b/src/common/model/set/setParameters.ml
@@ -1,3 +1,8 @@
+(** {1 Set Parameters}
+
+    This module defines parameters that make sense at the level of a set. This
+    includes version parameters as well. *)
+
 open Nes
 
 (** How to render the order. [Default] prints the tunes as they appear in the
@@ -40,6 +45,8 @@ let make
     ~forced_pages ~show_deviser ~show_order
     ~display_name ~for_dance ?every_version ()
 
+(** {2 Getters} *)
+
 let forced_pages p = Option.get p.forced_pages
 let for_dance    p = p.for_dance
 let display_name p = p.display_name
@@ -52,8 +59,7 @@ let paper_size_opt p = p.paper_size
 let every_version p = p.every_version
 let instruments = VersionParameters.instruments % every_version
 
-let set_show_order show_order p =
-  { p with show_order = Some show_order }
+(** {2 Defaults} *)
 
 let none = `Assoc [] |> of_yojson |> Result.get_ok
 
@@ -68,6 +74,13 @@ let default = {
 
   every_version = VersionParameters.none ;
 }
+
+(** {2 Setters} *)
+
+let set_show_order show_order p =
+  { p with show_order = Some show_order }
+
+(** {2 Composition} *)
 
 let compose first second =
   { forced_pages  = Option.(choose ~tie:second) first.forced_pages second.forced_pages ;

--- a/src/common/model/set/setParameters.ml
+++ b/src/common/model/set/setParameters.ml
@@ -66,7 +66,7 @@ let default = {
   order_type = Some Default ;
   paper_size = Some (A 4) ;
 
-  every_version = VersionParameters.default ;
+  every_version = VersionParameters.none ;
 }
 
 let compose first second =

--- a/src/common/model/version/versionParameters.ml
+++ b/src/common/model/version/versionParameters.ml
@@ -50,6 +50,9 @@ let none = `Assoc [] |> of_yojson |> Result.get_ok
 
 let transposition' = Option.value ~default:Transposition.identity % transposition
 let first_bar' = Option.value ~default:1 % first_bar
+let display_name' ~default = Option.value ~default % display_name
+let display_author' ~default = Option.value ~default % display_author
+let trivia' ~default = Option.value ~default % trivia
 
 (* Setters *)
 

--- a/src/common/model/version/versionParameters.ml
+++ b/src/common/model/version/versionParameters.ml
@@ -1,3 +1,7 @@
+(** {1 Version Parameters}
+
+    This module defines parameters that make sense at the level of a version. *)
+
 open Nes
 
 module Self = struct
@@ -31,7 +35,7 @@ let make_instrument pitch =
     ~transposition:(Transposition.relative pitch Music.pitch_c)
     ()
 
-(* Getters *)
+(** {2 Getters} *)
 
 let transposition  p = p.transposition
 let first_bar      p = p.first_bar
@@ -54,12 +58,12 @@ let display_name' ~default = Option.value ~default % display_name
 let display_author' ~default = Option.value ~default % display_author
 let trivia' ~default = Option.value ~default % trivia
 
-(* Setters *)
+(** {2 Setters} *)
 
 let set_display_name display_name p =
   { p with display_name = Some display_name }
 
-(* Composition *)
+(** {2 Composition} *)
 
 let compose first second =
   { instruments    = Option.(choose ~tie:fail)   first.instruments    second.instruments ;

--- a/src/common/model/version/versionParameters.ml
+++ b/src/common/model/version/versionParameters.ml
@@ -31,8 +31,10 @@ let make_instrument pitch =
     ~transposition:(Transposition.relative pitch Music.pitch_c)
     ()
 
-let transposition  p = Option.get p.transposition
-let first_bar      p = Option.get p.first_bar
+(* Getters *)
+
+let transposition  p = p.transposition
+let first_bar      p = p.first_bar
 let instruments    p = p.instruments
 let for_dance      p = p.for_dance
 let clef           p = p.clef
@@ -40,21 +42,21 @@ let trivia         p = p.trivia
 let display_name   p = p.display_name
 let display_author p = p.display_author
 
-let set_display_name display_name p =
-  { p with display_name = Some display_name }
+(** {2 Defaults}
+
+    Getters that end with a quote are getters that have a default value. *)
 
 let none = `Assoc [] |> of_yojson |> Result.get_ok
 
-let default = {
-  instruments    = None ;
-  transposition  = Some Transposition.identity ;
-  first_bar      = Some 1 ;
-  for_dance      = None ;
-  clef           = None ;
-  trivia         = None ;
-  display_name   = None ;
-  display_author = None ;
-}
+let transposition' = Option.value ~default:Transposition.identity % transposition
+let first_bar' = Option.value ~default:1 % first_bar
+
+(* Setters *)
+
+let set_display_name display_name p =
+  { p with display_name = Some display_name }
+
+(* Composition *)
 
 let compose first second =
   { instruments    = Option.(choose ~tie:fail)   first.instruments    second.instruments ;
@@ -65,5 +67,3 @@ let compose first second =
     trivia         = Option.(choose ~tie:second) first.trivia         second.trivia ;
     display_name   = Option.(choose ~tie:second) first.display_name   second.display_name ;
     display_author = Option.(choose ~tie:second) first.display_author second.display_author }
-
-let fill = compose default

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -109,16 +109,8 @@ module Ly = struct
           Fun.flip Lwt_list.map_p contents @@ function
           | Model.Book.Version (version, parameters) ->
             let%lwt tune = Model.Version.tune version in
-            let name =
-              parameters
-              |> Model.VersionParameters.display_name
-              |> Option.value ~default:(Model.Tune.name tune)
-            in
-            let trivia =
-              parameters
-              |> Model.VersionParameters.trivia
-              |> Option.value ~default:" "
-            in
+            let name = Model.VersionParameters.display_name' ~default:(Model.Tune.name tune) parameters in
+            let trivia = Model.VersionParameters.trivia' ~default:" " parameters in
             let parameters = Model.VersionParameters.set_display_name trivia parameters in
             let%lwt set =
               Model.Set.make
@@ -172,7 +164,7 @@ module Ly = struct
           let version_parameters = Model.VersionParameters.compose (Model.SetParameters.every_version set_parameters) version_parameters in
           let%lwt content = Model.Version.content version in
           let content =
-            match version_parameters |> Model.VersionParameters.clef with
+            match Model.VersionParameters.clef version_parameters with
             | None -> content
             | Some clef_parameter ->
               let clef_regex = Str.regexp "\\\\clef *\"?[a-z]*\"?" in
@@ -180,19 +172,11 @@ module Ly = struct
           in
           let%lwt tune = Model.Version.tune version in
           let key = Model.Version.key version in
-          let name =
-            version_parameters
-            |> Model.VersionParameters.display_name
-            |> Option.value ~default:(Model.Tune.name tune)
-          in
+          let name = Model.VersionParameters.display_name' ~default:(Model.Tune.name tune) version_parameters in
           let%lwt author =
             Lwt.map (Option.fold ~none:"" ~some:Model.Person.name) (Model.Tune.author tune)
           in
-          let author =
-            version_parameters
-            |> Model.VersionParameters.display_author
-            |> Option.value ~default:author
-          in
+          let author = Model.VersionParameters.display_author' ~default:author version_parameters in
           let first_bar = Model.VersionParameters.first_bar' version_parameters in
           let source, target =
             match Model.VersionParameters.transposition' version_parameters with

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -193,14 +193,11 @@ module Ly = struct
             |> Model.VersionParameters.display_author
             |> Option.value ~default:author
           in
-          let first_bar =
-            version_parameters
-            |> Model.VersionParameters.first_bar
-          in
+          let first_bar = Model.VersionParameters.first_bar' version_parameters in
           let source, target =
-            match version_parameters |> Model.VersionParameters.transposition with
+            match Model.VersionParameters.transposition' version_parameters with
             | Relative (source, target) -> (source, target)
-            | Absolute target -> (key |> Model.Music.key_pitch, target) (* FIXME: probably an octave to fix here *)
+            | Absolute target -> (Model.Music.key_pitch key, target) (* FIXME: probably an octave to fix here *)
           in
           fpf fmt [%blob "template/book/version.ly"]
             name author

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -62,7 +62,7 @@ module Ly = struct
       fpf fmt [%blob "template/book/macros.ly"];
       fpf fmt [%blob "template/layout.ly"];
       fpf fmt [%blob "template/book/globals.ly"]
-        title (Option.value ~default:"" (Model.BookParameters.instruments parameters));
+        title (Model.BookParameters.instruments' parameters);
       fpf fmt [%blob "template/paper.ly"];
 
       fpf fmt [%blob "template/book/paper.ly"];

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -33,8 +33,8 @@ module Ly = struct
     Lwt.return (String.concat " — " (dance @ [kind] @ order @ chords))
 
   (** Rearrange the content of a set. [Default] will leave the content as-is,
-      while [Unfolded] will duplicated the tunes depending on the set order. *)
-  let rearrange_set_content ?(order_type=Model.SetParameters.Default) ~order content =
+      while [Unfolded] will duplicate the tunes depending on the set order. *)
+  let rearrange_set_content ~order_type ~order content =
     let module P = Model.SetParameters in
     let module O = Model.SetOrder in
     match order_type with
@@ -132,11 +132,7 @@ module Ly = struct
         in
         Fun.flip Lwt_list.iter_s sets_and_parameters @@ fun (set, set_parameters) ->
         let set_parameters = Model.SetParameters.compose (Model.BookParameters.every_set parameters) set_parameters in
-        let name =
-          set_parameters
-          |> Model.SetParameters.display_name
-          |> Option.value ~default:(Model.Set.name set)
-        in
+        let name = Model.SetParameters.display_name ~default:(Model.Set.name set) set_parameters in
         let%lwt deviser =
           if not (Model.SetParameters.show_deviser' set_parameters) then
             Lwt.return ""
@@ -157,7 +153,7 @@ module Ly = struct
           let versions_and_parameters =
             rearrange_set_content
               ~order:(Model.Set.order set)
-              ?order_type:(Model.SetParameters.order_type set_parameters)
+              ~order_type:(Model.SetParameters.order_type' set_parameters)
               versions_and_parameters
           in
           Fun.flip Lwt_list.iter_s versions_and_parameters @@ fun (version, version_parameters) ->

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -50,7 +50,6 @@ module Ly = struct
   let render ?(parameters=Model.BookParameters.none) book =
     let%lwt body = Model.Book.lilypond_contents_cache_key book in
     StorageCache.use ~cache ~key:(`Ly, book, parameters, body) @@ fun _hash ->
-    let parameters = Model.BookParameters.fill parameters in
     let (res, prom) =
       Format.with_formatter_to_string_gen @@ fun fmt ->
       let title = Model.Book.title book in (** FIXME: subtitle *)

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -56,7 +56,7 @@ module Ly = struct
       let title = Model.Book.title book in (** FIXME: subtitle *)
       fpf fmt [%blob "template/lyversion.ly"];
       (
-        match Model.BookParameters.paper_size parameters with
+        match Model.BookParameters.paper_size' parameters with
         | A n -> fpf fmt [%blob "template/paper-size/a.ly"] n;
         | Custom (width, height, unit) -> fpf fmt [%blob "template/paper-size/custom.ly"] width unit height unit;
       );
@@ -67,16 +67,16 @@ module Ly = struct
       fpf fmt [%blob "template/paper.ly"];
 
       fpf fmt [%blob "template/book/paper.ly"];
-      if parameters |> Model.BookParameters.two_sided then
+      if Model.BookParameters.two_sided' parameters then
         (
           fpf fmt [%blob "template/book/two-sided.ly"];
           fpf fmt
-            (if parameters |> Model.BookParameters.running_header then
+            (if Model.BookParameters.running_header' parameters then
                [%blob "template/book/header/two-sided.ly"]
              else
                [%blob "template/book/header/none.ly"]);
           fpf fmt
-            (if parameters |> Model.BookParameters.running_footer then
+            (if Model.BookParameters.running_footer' parameters then
                [%blob "template/book/footer/two-sided.ly"]
              else
                [%blob "template/book/footer/none.ly"])
@@ -84,12 +84,12 @@ module Ly = struct
       else
         (
           fpf fmt
-            (if parameters |> Model.BookParameters.running_header then
+            (if Model.BookParameters.running_header' parameters then
                [%blob "template/book/header/one-sided.ly"]
              else
                [%blob "template/book/header/none.ly"]);
           fpf fmt
-            (if parameters |> Model.BookParameters.running_footer then
+            (if Model.BookParameters.running_footer' parameters then
                [%blob "template/book/footer/one-sided.ly"]
              else
                [%blob "template/book/footer/none.ly"])
@@ -99,9 +99,9 @@ module Ly = struct
       fpf fmt [%blob "template/bar-numbering/bar-number-in-instrument-name-engraver.ly"];
       fpf fmt [%blob "template/bar-numbering/beginning-of-line.ly"];
       fpf fmt [%blob "template/book/book_beginning.ly"];
-      if parameters |> Model.BookParameters.front_page then
+      if Model.BookParameters.front_page' parameters then
         fpf fmt [%blob "template/book/book_front_page.ly"];
-      if parameters |> Model.BookParameters.table_of_contents |> (=) Model.BookParameters.Beginning then
+      if Model.BookParameters.(table_of_contents' parameters = Beginning) then
         fpf fmt [%blob "template/book/book_table_of_contents.ly"];
       let%lwt () =
         let%lwt sets_and_parameters =
@@ -191,7 +191,7 @@ module Ly = struct
         fpf fmt [%blob "template/book/set_end.ly"];
         Lwt.return ()
       in
-      if parameters |> Model.BookParameters.table_of_contents |> (=) Model.BookParameters.End then
+      if Model.BookParameters.(table_of_contents' parameters = End) then
         fpf fmt [%blob "template/book/book_table_of_contents.ly"];
       fpf fmt [%blob "template/book/book_end.ly"];
       Lwt.return ()

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -132,7 +132,7 @@ module Ly = struct
         in
         Fun.flip Lwt_list.iter_s sets_and_parameters @@ fun (set, set_parameters) ->
         let set_parameters = Model.SetParameters.compose (Model.BookParameters.every_set parameters) set_parameters in
-        let name = Model.SetParameters.display_name ~default:(Model.Set.name set) set_parameters in
+        let name = Model.SetParameters.display_name' ~default:(Model.Set.name set) set_parameters in
         let%lwt deviser =
           if not (Model.SetParameters.show_deviser' set_parameters) then
             Lwt.return ""

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -20,7 +20,7 @@ module Ly = struct
     in
     let%lwt kind = kind set set_parameters in
     let order =
-      if Model.SetParameters.show_order set_parameters then
+      if Model.SetParameters.show_order' set_parameters then
         [spf "Play %s" @@ Model.SetOrder.to_pretty_string @@ Model.Set.order set]
       else
         []
@@ -138,7 +138,7 @@ module Ly = struct
           |> Option.value ~default:(Model.Set.name set)
         in
         let%lwt deviser =
-          if not (set_parameters |> Model.SetParameters.show_deviser) then
+          if not (Model.SetParameters.show_deviser' set_parameters) then
             Lwt.return ""
           else
             Lwt.map
@@ -149,7 +149,7 @@ module Ly = struct
         let%lwt details_line = details_line set set_parameters in
         fpf fmt [%blob "template/book/set_beginning.ly"]
           name kind name deviser details_line;
-        (match set_parameters |> Model.SetParameters.forced_pages with
+        (match Model.SetParameters.forced_pages' set_parameters with
          | 0 -> ()
          | n -> fpf fmt [%blob "template/book/set-forced-pages.ly"] n);
         let%lwt () =

--- a/src/server/controller/set.ml
+++ b/src/server/controller/set.ml
@@ -16,7 +16,7 @@ module Pdf = struct
       (* FIXME: the fact that we need to transfer this is just wrong. see
          https://github.com/paris-branch/dancelor/issues/250 *)
       Model.BookParameters.make
-        ?paper_size:(Option.bind parameters Model.SetParameters.paper_size_opt)
+        ?paper_size:(Option.bind parameters Model.SetParameters.paper_size)
         ()
     in
     Book.Pdf.render book ~parameters

--- a/src/server/controller/version.ml
+++ b/src/server/controller/version.ml
@@ -9,7 +9,6 @@ let get_ly version =
 
 let prepare_ly_file ?(parameters=Model.VersionParameters.none) ?(show_meta=false) ?(meta_in_title=false) ~fname version =
   Log.debug (fun m -> m "Preparing Lilypond file");
-  let parameters = Model.VersionParameters.fill parameters in
 
   let fname_scm = Filename.chop_extension fname ^ ".scm" in
   let%lwt tune = Model.Version.tune version in
@@ -56,7 +55,7 @@ let prepare_ly_file ?(parameters=Model.VersionParameters.none) ?(show_meta=false
       Str.global_replace clef_regex ("\\clef " ^ Model.Music.clef_to_lilypond_string clef_parameter) content
   in
   let source, target =
-    match parameters |> Model.VersionParameters.transposition with
+    match Model.VersionParameters.transposition' parameters with
     | Relative (source, target) -> (source, target)
     | Absolute target -> (Model.Music.key_pitch key, target)
     (* FIXME: Similarly to version.ml, probably need to fix an octave in Absolue *)

--- a/src/server/controller/version.ml
+++ b/src/server/controller/version.ml
@@ -13,21 +13,13 @@ let prepare_ly_file ?(parameters=Model.VersionParameters.none) ?(show_meta=false
   let fname_scm = Filename.chop_extension fname ^ ".scm" in
   let%lwt tune = Model.Version.tune version in
   let key = Model.Version.key version in
-  let name =
-    parameters
-    |> Model.VersionParameters.display_name
-    |> Option.value ~default:(Model.Tune.name tune)
-  in
+  let name = Model.VersionParameters.display_name' ~default:(Model.Tune.name tune) parameters in
   let%lwt author =
     match%lwt Model.Tune.author tune with
     | None -> Lwt.return ""
     | Some author -> Lwt.return @@ Model.Person.name author
   in
-  let author =
-    parameters
-    |> Model.VersionParameters.display_author
-    |> Option.value ~default:author
-  in
+  let author = Model.VersionParameters.display_author' ~default:author parameters in
   let title, piece =
     if show_meta then
       if meta_in_title then name, " " else "", name
@@ -48,7 +40,7 @@ let prepare_ly_file ?(parameters=Model.VersionParameters.none) ?(show_meta=false
   (* Handle parameters *)
 
   let content =
-    match parameters |> Model.VersionParameters.clef with
+    match Model.VersionParameters.clef parameters with
     | None -> content
     | Some clef_parameter ->
       let clef_regex = Str.regexp "\\\\clef *\"?[a-z]*\"?" in


### PR DESCRIPTION
Parameters are annoying because there are two ways to look at them. When we process them at the end, each parameter should have a value. However, when we set them in an interface, we want to only change a bunch of them. Basically, there are parameters and parameter _diffs_ or something.

Anyhow; the current version decided to have a type `VersionParameters.t` (and same for sets and books) which is a record of options. `None` means “do not update” and “Some” means “replace by” (except for transpositions but OK). Then we provide a value `VersionParameters.default` that has all its fields to `Some` and a bunch of getters that assume that they work on a `Some`. This works but isn't very type-safe. A way to provide this in a type-safe way would be to actually have parameters and parameter diffs; and the former would not contain the options. One could imagine a PPX providing that but I don't know of one, and it is a bit heavy to provide manually.

Instead, this PR decides to give up on `VersionParameters.default` but to provide normal getters (returning an option) and fancy getters (returning a value, defaulting on something if need be). I think this is a good compromise. I use the opportunity to clean up a tiny bit. WDYT @R1kM?