### PR TITLE
Merge `search` and `count` into one `search` function

### DIFF
--- a/src/client/formatters/version.ml
+++ b/src/client/formatters/version.ml
@@ -60,8 +60,7 @@ let name_disambiguation_and_sources ?link version =
           M.Formula.and_ (memVersionDeep version) isSource
         )
       in
-      M.Book.search filter
-      >|=| M.Score.list_erase
+      M.Book.search' filter >|=| M.Score.list_erase
     in
     Lwt.return @@
     match List.map Book.short_title sources with
@@ -86,8 +85,7 @@ let disambiguation_and_sources version =
           M.Formula.and_ (memVersionDeep version) isSource
         )
       in
-      M.Book.search filter
-      >|=| M.Score.list_erase
+      M.Book.search' filter >|=| M.Score.list_erase
     in
     Lwt.return @@
     match List.map Book.short_title sources with

--- a/src/client/model/any/any.ml
+++ b/src/client/model/any/any.ml
@@ -11,9 +11,8 @@ let search ?pagination ?threshold filter =
     a A.filter     filter
   )
 
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
+
 let count ?threshold filter =
-  Madge_client.(
-    call ~endpoint:E.count @@ fun {a} {o} ->
-    o A.threshold  threshold;
-    a A.filter     filter
-  )
+  Lwt.map fst @@ search ?threshold filter

--- a/src/client/model/book/book.ml
+++ b/src/client/model/book/book.ml
@@ -26,6 +26,12 @@ let search ?pagination ?threshold filter =
     a A.filter filter;
   )
 
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
+
+let count ?threshold filter =
+  Lwt.map fst @@ search ?threshold filter
+
 let update
     ?status ~slug ~title ?date ?contents ~modified_at ~created_at
     ()

--- a/src/client/model/dance/dance.ml
+++ b/src/client/model/dance/dance.ml
@@ -28,3 +28,9 @@ let search ?pagination ?threshold filter =
     o A.threshold threshold;
     a A.filter filter
   )
+
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
+
+let count ?threshold filter =
+  Lwt.map fst @@ search ?threshold filter

--- a/src/client/model/person/person.ml
+++ b/src/client/model/person/person.ml
@@ -20,3 +20,9 @@ let search ?pagination ?threshold filter =
     o A.threshold threshold;
     a A.filter filter
   )
+
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
+
+let count ?threshold filter =
+  Lwt.map fst @@ search ?threshold filter

--- a/src/client/model/set/set.ml
+++ b/src/client/model/set/set.ml
@@ -35,8 +35,8 @@ let search ?pagination ?threshold filter =
     a A.filter filter;
   )
 
-let count filter =
-  Madge_client.(
-    call ~endpoint:E.count @@ fun {a} _ ->
-    a A.filter filter;
-  )
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
+
+let count ?threshold filter =
+  Lwt.map fst @@ search ?threshold filter

--- a/src/client/model/tune/tune.ml
+++ b/src/client/model/tune/tune.ml
@@ -28,3 +28,9 @@ let search ?pagination ?threshold filter =
     o A.threshold threshold;
     a A.filter filter;
   )
+
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
+
+let count ?threshold filter =
+  Lwt.map fst @@ search ?threshold filter

--- a/src/client/model/version/version.ml
+++ b/src/client/model/version/version.ml
@@ -31,12 +31,11 @@ let search ?pagination ?threshold filter =
     a A.filter filter;
   )
 
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
+
 let count ?threshold filter =
-  Madge_client.(
-    call ~endpoint:E.count @@ fun {a} {o} ->
-    o A.threshold threshold;
-    a A.filter filter
-  )
+  Lwt.map fst @@ search ?threshold filter
 
 let mark_fixed version =
   Madge_client.(

--- a/src/client/views/book/bookEditorInterface.ml
+++ b/src/client/views/book/bookEditorInterface.ml
@@ -103,7 +103,7 @@ let search input =
   let threshold = 0.4 in
   let pagination = Pagination.{ start = 0; end_ = 15 } in
   let%rlwt formula = Lwt.return @@ Result.map_error List.singleton @@ Set.Filter.from_string input in
-  let%lwt results = Set.search ~threshold ~pagination formula in
+  let%lwt results = Set.search' ~threshold ~pagination formula in
   Lwt.return_ok results
 
 let create ?on_save page =

--- a/src/client/views/book/bookExplorer.ml
+++ b/src/client/views/book/bookExplorer.ml
@@ -41,7 +41,7 @@ let create page =
         [
           L.tbody (
             Fun.flip Lwt.map
-              (Book.search Formula.true_ >|=| Score.list_erase)
+              (Book.search' Formula.true_ >|=| Score.list_erase)
               (List.map
                  (fun book ->
                     let href = PageRouter.path_book @@ Book.slug book in

--- a/src/client/views/dance/danceEditorInterface.ml
+++ b/src/client/views/dance/danceEditorInterface.ml
@@ -111,7 +111,7 @@ let create ?on_save page =
                     page)
         ~search:(fun input ->
             let%rlwt formula = Lwt.return @@ Result.map_error List.singleton @@ Person.Filter.from_string input in
-            let%lwt results = Person.search ~threshold:0.4 ~pagination:Pagination.{start = 0; end_ = 10} formula in
+            let%lwt results = Person.search' ~threshold:0.4 ~pagination:Pagination.{start = 0; end_ = 10} formula in
             Lwt.return_ok results)
         ~make_result:(fun score -> make_deviser_search_result editor page score)
         page

--- a/src/client/views/dance/danceViewer.ml
+++ b/src/client/views/dance/danceViewer.ml
@@ -64,8 +64,7 @@ let create slug page =
           let tunes_lwt =
             let%lwt dance = dance_lwt in
             let filter = Tune.Filter.existsDance (Dance.Filter.is dance) in
-            Tune.search filter
-            >|=| Score.list_erase
+            Tune.search' filter >|=| Score.list_erase
           in
           let%lwt tunes = tunes_lwt in
 

--- a/src/client/views/index.ml
+++ b/src/client/views/index.ml
@@ -21,7 +21,7 @@ let search input =
   let threshold = 0.4 in
   let pagination = Pagination.{ start = 0; end_ = 15 } in
   let%rlwt filter = Lwt.return (Any.Filter.from_string input) in (* FIXME: AnyFilter.from_string should return a result lwt *)
-  let%lwt results = Any.search ~threshold ~pagination filter in
+  let%lwt results = Any.search' ~threshold ~pagination filter in
   Lwt.return_ok results
 
 let create page =

--- a/src/client/views/person/personViewer.ml
+++ b/src/client/views/person/personViewer.ml
@@ -52,7 +52,7 @@ let create slug page =
           let%lwt tunes =
             let%lwt person = person_lwt in
             let filter = Tune.Filter.authorIs person in
-            Tune.search filter >|=| Score.list_erase
+            Tune.search' filter >|=| Score.list_erase
           in
 
           Lwt.return [
@@ -71,8 +71,7 @@ let create slug page =
           let%lwt sets =
             let%lwt person = person_lwt in
             let filter = Set.Filter.deviser (Person.Filter.is person) in
-            Set.search filter
-            >|=| Score.list_erase
+            Set.search' filter >|=| Score.list_erase
           in
 
           Lwt.return [
@@ -91,7 +90,7 @@ let create slug page =
           let%lwt dances =
             let%lwt person = person_lwt in
             let filter = Dance.Filter.deviser (Person.Filter.is person) in
-            Dance.search filter >|=| Score.list_erase
+            Dance.search' filter >|=| Score.list_erase
           in
 
           Lwt.return [

--- a/src/client/views/search.ml
+++ b/src/client/views/search.ml
@@ -27,7 +27,7 @@ let update_table t =
   (* we can afford the exception because we'll have checked before *)
   let filter = Any.Filter.from_string_exn input in
   let rows =
-    let%lwt results = Any.search ~pagination filter in
+    let%lwt results = Any.search' ~pagination filter in
     Lwt_list.map_s (AnyResult.make_result t.page) results
   in
   let section = Table.Section.create ~rows t.page in

--- a/src/client/views/set/setEditorInterface.ml
+++ b/src/client/views/set/setEditorInterface.ml
@@ -262,7 +262,7 @@ let create page =
         ~search:(fun input ->
             let%rlwt formula = Lwt.return @@ Result.map_error List.singleton @@ Person.Filter.from_string input in
             let%lwt results =
-              Person.search ~threshold:0.4
+              Person.search' ~threshold:0.4
                 ~pagination:Pagination.{start = 0; end_ = 10} formula
             in
             Lwt.return_ok results)
@@ -280,7 +280,7 @@ let create page =
         ~search:(fun input ->
             let%rlwt formula = Lwt.return @@ Result.map_error List.singleton @@ Book.Filter.from_string input in
             let%lwt results =
-              Book.search ~threshold:0.4
+              Book.search' ~threshold:0.4
                 ~pagination:Pagination.{start = 0; end_ = 10} formula
             in
             Lwt.return_ok results)
@@ -299,7 +299,7 @@ let create page =
         ~search:(fun input ->
             let%rlwt formula = Lwt.return @@ Result.map_error List.singleton @@ Version.Filter.from_string input in
             let%lwt results =
-              Version.search ~threshold:0.4
+              Version.search' ~threshold:0.4
                 ~pagination:Pagination.{start = 0; end_ = 10} formula
             in
             Lwt.return_ok results)

--- a/src/client/views/set/setExplorer.ml
+++ b/src/client/views/set/setExplorer.ml
@@ -53,7 +53,7 @@ let create page =
           R.tbody (
             S.bind_s' pagination.signal [] @@ fun pagination ->
             Fun.flip Lwt.map
-              (Set.search ~pagination:(PageNav.current_pagination pagination) Formula.true_ >|=| Score.list_erase)
+              (Set.search' ~pagination:(PageNav.current_pagination pagination) Formula.true_ >|=| Score.list_erase)
               (List.map
                  (fun set ->
                     let href = PageRouter.path @@ PageRouter.Set (Set.slug set) in

--- a/src/client/views/set/setViewer.ml
+++ b/src/client/views/set/setViewer.ml
@@ -95,8 +95,7 @@ let create slug page =
           let books_lwt =
             let%lwt set = set_lwt in
             let filter = Book.Filter.memSet set in
-            Book.search filter
-            >|=| Score.list_erase
+            Book.search' filter >|=| Score.list_erase
           in
           let%lwt books = books_lwt in
 

--- a/src/client/views/tune/tuneEditorInterface.ml
+++ b/src/client/views/tune/tuneEditorInterface.ml
@@ -183,7 +183,7 @@ let create ?on_save page =
                     page)
         ~search:(fun input ->
             let%rlwt formula = Lwt.return @@ Result.map_error List.singleton @@ Dance.Filter.from_string input in
-            let%lwt results = Dance.search ~threshold:0.4 ~pagination:Pagination.{start = 0; end_ = 10} formula in
+            let%lwt results = Dance.search' ~threshold:0.4 ~pagination:Pagination.{start = 0; end_ = 10} formula in
             Lwt.return_ok results)
         ~make_result:(fun score -> make_dance_search_result editor page score)
         page
@@ -206,7 +206,7 @@ let create ?on_save page =
         ~search:(fun input ->
             let%rlwt formula = Lwt.return @@ Result.map_error List.singleton @@ Person.Filter.from_string input in
             let%lwt results =
-              Person.search ~threshold:0.4
+              Person.search' ~threshold:0.4
                 ~pagination:Pagination.{start = 0; end_ = 10} formula
             in
             Lwt.return_ok results)

--- a/src/client/views/tune/tuneViewer.ml
+++ b/src/client/views/tune/tuneViewer.ml
@@ -50,8 +50,7 @@ let create slug page =
               let%lwt tune = tune_lwt in
               Lwt.return (Version.Filter.tuneIs tune)
             in
-            Version.search filter
-            >|=| Score.list_erase
+            Version.search' filter >|=| Score.list_erase
           in
           let%lwt versions = versions_lwt in
 
@@ -99,8 +98,7 @@ let create slug page =
           let sets_lwt =
             let%lwt tune = tune_lwt in
             let filter = Set.Filter.existsVersion (Version.Filter.tuneIs tune) in
-            Set.search filter
-            >|=| Score.list_erase
+            Set.search' filter >|=| Score.list_erase
           in
           let%lwt sets = sets_lwt in
 
@@ -120,8 +118,7 @@ let create slug page =
           let%lwt books =
             let%lwt tune = tune_lwt in
             let filter = Book.Filter.memTuneDeep tune in
-            Book.search filter
-            >|=| Score.list_erase
+            Book.search' filter >|=| Score.list_erase
           in
 
           Lwt.return [

--- a/src/client/views/version/versionBrokenExplorer.ml
+++ b/src/client/views/version/versionBrokenExplorer.ml
@@ -22,7 +22,7 @@ let create page =
       h2 ~a:[a_class ["title"]] [txt "List of broken versions"];
 
       L.div (
-        let%lwt versions = Version.search Version.Filter.broken >|=| Score.list_erase in
+        let%lwt versions = Version.search' Version.Filter.broken >|=| Score.list_erase in
 
         (* If there is no broken version, no need to print the table *)
         if List.length versions = 0 then

--- a/src/client/views/version/versionEditorInterface.ml
+++ b/src/client/views/version/versionEditorInterface.ml
@@ -164,7 +164,7 @@ let create page =
         ~search:(fun input ->
             let%rlwt formula = Lwt.return @@ Result.map_error List.singleton @@ Tune.Filter.from_string input in
             let%lwt results =
-              Tune.search ~threshold:0.4
+              Tune.search' ~threshold:0.4
                 ~pagination:Pagination.{start = 0; end_ = 10} formula
             in
             Lwt.return_ok results)
@@ -195,7 +195,7 @@ let create page =
         ~search:(fun input ->
             let%rlwt formula = Lwt.return @@ Result.map_error List.singleton @@ Person.Filter.from_string input in
             let%lwt results =
-              Person.search ~threshold:0.4
+              Person.search' ~threshold:0.4
                 ~pagination:Pagination.{start = 0; end_ = 10} formula
             in
             Lwt.return_ok results)

--- a/src/client/views/version/versionExplorer.ml
+++ b/src/client/views/version/versionExplorer.ml
@@ -139,8 +139,7 @@ let update_table t =
       let filter = t.search in
       let%lwt filter = filter_to_versionfilter filter in
       let pagination = PageNav.pagination t.page_nav in
-      Version.search ~pagination filter
-      >|=| Score.list_erase
+      Version.search' ~pagination filter >|=| Score.list_erase
     in
     Lwt.return (List.map (fun version ->
         let href = Lwt.return @@ PageRouter.path_version @@ Version.slug version in

--- a/src/client/views/version/versionViewer.ml
+++ b/src/client/views/version/versionViewer.ml
@@ -31,8 +31,7 @@ let create slug page =
           not_ (Version.Filter.is version);
         ])
     in
-    Version.search filter
-    >|=| Score.list_erase
+    Version.search' filter >|=| Score.list_erase
   in
 
   let open Dancelor_client_html in
@@ -199,8 +198,7 @@ let create slug page =
           let sets_lwt =
             let%lwt version = version_lwt in
             let filter = Set.Filter.memVersion version in
-            Set.search filter
-            >|=| Score.list_erase
+            Set.search' filter >|=| Score.list_erase
           in
           let%lwt sets = sets_lwt in
 
@@ -234,8 +232,7 @@ let create slug page =
           let%lwt books =
             let%lwt version = version_lwt in
             let filter = Book.Filter.memVersionDeep version in
-            Book.search filter
-            >|=| Score.list_erase
+            Book.search' filter >|=| Score.list_erase
           in
 
           Lwt.return [

--- a/src/common/model/any/anyEndpoints.ml
+++ b/src/common/model/any/anyEndpoints.ml
@@ -6,5 +6,4 @@ module Arguments = struct
   let threshold = optarg ~key:"threshold" (module MFloat)
 end
 
-let search = endpoint ~path:"/any/search" (module MList (Score.Make_Serialisable (AnyCore)))
-let count = endpoint ~path:"/any/count" (module MInteger)
+let search = endpoint ~path:"/any/search" (module MPair (MInteger) (MList (Score.Make_Serialisable (AnyCore))))

--- a/src/common/model/any/anySignature.mli
+++ b/src/common/model/any/anySignature.mli
@@ -23,9 +23,21 @@ val search :
   ?pagination:Pagination.t ->
   ?threshold:float ->
   Filter.t ->
+  (int * t Score.t list) Lwt.t
+(** [search ?pagination ?threshold filter] returns the list of all the objects
+    that match [filter] with a score higher than [threshold] (if any). The first
+    element of the pair is the number of objects. The second element of the pair
+    is a slice of the list, taken as per the [pagination] (if any). *)
+
+val search' :
+  ?pagination:Pagination.t ->
+  ?threshold:float ->
+  Filter.t ->
   t Score.t list Lwt.t
+(** Like {!search} but returns only the list. *)
 
 val count :
   ?threshold:float ->
   Filter.t ->
   int Lwt.t
+(** Like {!search} but returns only the number of items. *)

--- a/src/common/model/book/bookEndpoints.ml
+++ b/src/common/model/book/bookEndpoints.ml
@@ -19,7 +19,7 @@ end
 
 let get = endpoint ~path:"/book" (module BookCore)
 let make_and_save = endpoint ~path:"/book/save" (module BookCore)
-let search = endpoint ~path:"/book/search" (module MList(Score.Make_Serialisable(BookCore)))
+let search = endpoint ~path:"/book/search" (module MPair (MInteger) (MList(Score.Make_Serialisable(BookCore))))
 let update = endpoint ~path:"/book/update" (module MUnit)
 
 (* New-style Endpoints *)

--- a/src/common/model/book/bookSignature.mli
+++ b/src/common/model/book/bookSignature.mli
@@ -124,7 +124,24 @@ val search :
   ?pagination:Pagination.t ->
   ?threshold:float ->
   Filter.t ->
+  (int * t Score.t list) Lwt.t
+(** [search ?pagination ?threshold filter] returns the list of all the books
+    that match [filter] with a score higher than [threshold] (if any). The first
+    element of the pair is the number of books. The second element of the pair
+    is a slice of the list, taken as per the [pagination] (if any). *)
+
+val search' :
+  ?pagination:Pagination.t ->
+  ?threshold:float ->
+  Filter.t ->
   t Score.t list Lwt.t
+(** Like {!search} but returns only the list. *)
+
+val count :
+  ?threshold:float ->
+  Filter.t ->
+  int Lwt.t
+(** Like {!search} but returns only the number of items. *)
 
 val update :
   ?status:Status.t ->

--- a/src/common/model/dance/danceEndpoints.ml
+++ b/src/common/model/dance/danceEndpoints.ml
@@ -18,4 +18,4 @@ end
 
 let get = endpoint ~path:"/dance" (module DanceCore)
 let make_and_save = endpoint ~path:"/dance/save" (module DanceCore)
-let search = endpoint ~path:"/dance/search" (module MList(Score.Make_Serialisable(DanceCore)))
+let search = endpoint ~path:"/dance/search" (module MPair (MInteger) (MList(Score.Make_Serialisable(DanceCore))))

--- a/src/common/model/dance/danceSignature.mli
+++ b/src/common/model/dance/danceSignature.mli
@@ -57,4 +57,21 @@ val search :
   ?pagination:Pagination.t ->
   ?threshold:float ->
   Filter.t ->
+  (int * t Score.t list) Lwt.t
+(** [search ?pagination ?threshold filter] returns the list of all the dances
+    that match [filter] with a score higher than [threshold] (if any). The first
+    element of the pair is the number of dances. The second element of the pair
+    is a slice of the list, taken as per the [pagination] (if any). *)
+
+val search' :
+  ?pagination:Pagination.t ->
+  ?threshold:float ->
+  Filter.t ->
   t Score.t list Lwt.t
+(** Like {!search} but returns only the list. *)
+
+val count :
+  ?threshold:float ->
+  Filter.t ->
+  int Lwt.t
+(** Like {!search} but returns only the number of items. *)

--- a/src/common/model/person/personEndpoints.ml
+++ b/src/common/model/person/personEndpoints.ml
@@ -14,4 +14,4 @@ end
 
 let get = endpoint ~path:"/person" (module PersonCore)
 let make_and_save = endpoint ~path:"/person/save" (module PersonCore)
-let search = endpoint ~path:"/person/search" (module MList(Score.Make_Serialisable(PersonCore)))
+let search = endpoint ~path:"/person/search" (module MPair (MInteger) (MList(Score.Make_Serialisable(PersonCore))))

--- a/src/common/model/person/personSignature.mli
+++ b/src/common/model/person/personSignature.mli
@@ -58,4 +58,21 @@ val search :
   ?pagination:Pagination.t ->
   ?threshold:float ->
   Filter.t ->
+  (int * t Score.t list) Lwt.t
+(** [search ?pagination ?threshold filter] returns the list of all the persons
+    that match [filter] with a score higher than [threshold] (if any). The first
+    element of the pair is the number of persons. The second element of the pair
+    is a slice of the list, taken as per the [pagination] (if any). *)
+
+val search' :
+  ?pagination:Pagination.t ->
+  ?threshold:float ->
+  Filter.t ->
   t Score.t list Lwt.t
+(** Like {!search} but returns only the list. *)
+
+val count :
+  ?threshold:float ->
+  Filter.t ->
+  int Lwt.t
+(** Like {!search} but returns only the number of items. *)

--- a/src/common/model/set/setEndpoints.ml
+++ b/src/common/model/set/setEndpoints.ml
@@ -23,7 +23,7 @@ end
 let get = endpoint ~path:"/set" (module SetCore)
 let make_and_save = endpoint ~path:"/set/save" (module SetCore)
 let delete = endpoint ~path:"/set/delete" (module MUnit)
-let search = endpoint ~path:"/set/search" (module MList(Score.Make_Serialisable(SetCore)))
+let search = endpoint ~path:"/set/search" (module MPair (MInteger) (MList(Score.Make_Serialisable(SetCore))))
 let count = endpoint ~path:"/set/count" (module MInteger)
 
 (* New-style Endpoints *)

--- a/src/common/model/set/setSignature.mli
+++ b/src/common/model/set/setSignature.mli
@@ -93,7 +93,21 @@ val search :
   ?pagination:Pagination.t ->
   ?threshold:float ->
   Filter.t ->
-  t Score.t list Lwt.t
+  (int * t Score.t list) Lwt.t
+(** [search ?pagination ?threshold filter] returns the list of all the sets
+    that match [filter] with a score higher than [threshold] (if any). The first
+    element of the pair is the number of sets. The second element of the pair
+    is a slice of the list, taken as per the [pagination] (if any). *)
 
-val count: Filter.t -> int Lwt.t
-(** Number of sets in the database. *)
+val search' :
+  ?pagination:Pagination.t ->
+  ?threshold:float ->
+  Filter.t ->
+  t Score.t list Lwt.t
+(** Like {!search} but returns only the list. *)
+
+val count :
+  ?threshold:float ->
+  Filter.t ->
+  int Lwt.t
+(** Like {!search} but returns only the number of items. *)

--- a/src/common/model/tune/tuneEndpoints.ml
+++ b/src/common/model/tune/tuneEndpoints.ml
@@ -19,4 +19,4 @@ end
 
 let get = endpoint ~path:"/tune" (module TuneCore)
 let make_and_save = endpoint ~path:"/tune/save" (module TuneCore)
-let search = endpoint ~path:"/tune/search" (module MList(Score.Make_Serialisable(TuneCore)))
+let search = endpoint ~path:"/tune/search" (module MPair (MInteger) (MList(Score.Make_Serialisable(TuneCore))))

--- a/src/common/model/tune/tuneSignature.mli
+++ b/src/common/model/tune/tuneSignature.mli
@@ -76,4 +76,21 @@ val search :
   ?pagination:Pagination.t ->
   ?threshold:float ->
   Filter.t ->
+  (int * t Score.t list) Lwt.t
+(** [search ?pagination ?threshold filter] returns the list of all the tunes
+    that match [filter] with a score higher than [threshold] (if any). The first
+    element of the pair is the number of tunes. The second element of the pair
+    is a slice of the list, taken as per the [pagination] (if any). *)
+
+val search' :
+  ?pagination:Pagination.t ->
+  ?threshold:float ->
+  Filter.t ->
   t Score.t list Lwt.t
+(** Like {!search} but returns only the list. *)
+
+val count :
+  ?threshold:float ->
+  Filter.t ->
+  int Lwt.t
+(** Like {!search} but returns only the number of items. *)

--- a/src/common/model/version/versionEndpoints.ml
+++ b/src/common/model/version/versionEndpoints.ml
@@ -26,8 +26,7 @@ end
 
 let get = endpoint ~path:"/version" (module VersionCore)
 let make_and_save = endpoint ~path:"/version/save" (module VersionCore)
-let search = endpoint ~path:"/version/search" (module MList(Score.Make_Serialisable(VersionCore)))
-let count = endpoint ~path:"/version/count" (module MInteger)
+let search = endpoint ~path:"/version/search" (module MPair (MInteger) (MList(Score.Make_Serialisable(VersionCore))))
 
 let mark_fixed = endpoint ~path:"/version/mark-fixed" (module MUnit)
 let mark_broken = endpoint ~path:"/version/mark-broken" (module MUnit)

--- a/src/common/model/version/versionSignature.mli
+++ b/src/common/model/version/versionSignature.mli
@@ -73,12 +73,24 @@ val search :
   ?pagination:Pagination.t ->
   ?threshold:float ->
   Filter.t ->
+  (int * t Score.t list) Lwt.t
+(** [search ?pagination ?threshold filter] returns the list of all the versions
+    that match [filter] with a score higher than [threshold] (if any). The first
+    element of the pair is the number of versions. The second element of the pair
+    is a slice of the list, taken as per the [pagination] (if any). *)
+
+val search' :
+  ?pagination:Pagination.t ->
+  ?threshold:float ->
+  Filter.t ->
   t Score.t list Lwt.t
+(** Like {!search} but returns only the list. *)
 
 val count :
   ?threshold:float ->
   Filter.t ->
   int Lwt.t
+(** Like {!search} but returns only the number of items. *)
 
 val mark_broken : t -> unit Lwt.t
 

--- a/src/server/model/any/any.ml
+++ b/src/server/model/any/any.ml
@@ -21,7 +21,10 @@ let search ?pagination ?(threshold=Float.min_float) filter =
     >>=| (Score.list_filter_threshold threshold ||> Lwt.return)
     >>=| Score.(list_proj_sort_decreasing [])
   in
-  Lwt.return @@ Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  Lwt.return (
+    List.length results,
+    Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  )
 
 let () =
   Madge_server.(
@@ -32,12 +35,8 @@ let () =
       (a A.filter)
   )
 
-let count ?threshold filter =
-  let%lwt l = search ?threshold filter in
-  Lwt.return (List.length l)
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
 
-let () =
-  Madge_server.(
-    register ~endpoint:E.count @@ fun {a} {o} ->
-    count ?threshold:(o A.threshold) (a A.filter)
-  )
+let count ?threshold filter =
+  Lwt.map fst @@ search ?threshold filter

--- a/src/server/model/book/book.ml
+++ b/src/server/model/book/book.ml
@@ -45,7 +45,10 @@ let search ?pagination ?(threshold=Float.min_float) filter =
         increasing (Lwt.return % subtitle) String.compare_lengths ;
       ])
   in
-  Lwt.return @@ Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  Lwt.return (
+    List.length results,
+    Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  )
 (* FIXME: Simplify [list_proj_sort_decreasing] and [decreasing] and
    [increasing] because they probably don't need Lwt anymore. *)
 
@@ -57,6 +60,12 @@ let () =
       ?threshold: (o A.threshold)
       (a A.filter)
   )
+
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
+
+let count ?threshold filter =
+  Lwt.map fst @@ search ?threshold filter
 
 let update
     ?status ~slug ~title ?date ?contents ~modified_at ~created_at

--- a/src/server/model/dance/dance.ml
+++ b/src/server/model/dance/dance.ml
@@ -43,7 +43,10 @@ let search ?pagination ?(threshold=Float.min_float) filter =
         increasing (Lwt.return % name) String.Sensible.compare
       ])
   in
-  Lwt.return @@ Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  Lwt.return (
+    List.length results,
+    Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  )
 
 let () =
   Madge_server.(
@@ -53,3 +56,9 @@ let () =
       ?threshold: (o A.threshold)
       (a A.filter)
   )
+
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
+
+let count ?threshold filter =
+  Lwt.map fst @@ search ?threshold filter

--- a/src/server/model/person/person.ml
+++ b/src/server/model/person/person.ml
@@ -29,7 +29,10 @@ let search ?pagination ?(threshold=Float.min_float) filter =
         increasing (Lwt.return % name) String.Sensible.compare
       ])
   in
-  Lwt.return @@ Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  Lwt.return (
+    List.length results,
+    Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  )
 
 let () =
   Madge_server.(
@@ -39,3 +42,9 @@ let () =
       ?threshold: (o A.threshold)
       (a A.filter)
   )
+
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
+
+let count ?threshold filter =
+  Lwt.map fst @@ search ?threshold filter

--- a/src/server/model/set/set.ml
+++ b/src/server/model/set/set.ml
@@ -53,7 +53,10 @@ let search ?pagination ?(threshold=Float.min_float) filter =
         increasing (Lwt.return % name) String.compare_lengths;
       ])
   in
-  Lwt.return @@ Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  Lwt.return (
+    List.length results,
+    Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  )
 
 let () =
   Madge_server.(
@@ -64,10 +67,8 @@ let () =
       (a A.filter)
   )
 
-let count filter =
-  let%lwt l = search filter in
-  Lwt.return (List.length l)
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
 
-let () =
-  Madge_server.register ~endpoint:E.count @@ fun {a} _ ->
-  count (a A.filter)
+let count ?threshold filter =
+  Lwt.map fst @@ search ?threshold filter

--- a/src/server/model/tune/tune.ml
+++ b/src/server/model/tune/tune.ml
@@ -46,7 +46,10 @@ let search ?pagination ?(threshold=Float.min_float) filter =
         increasing (Lwt.return % name) String.compare_lengths;
       ])
   in
-  Lwt.return @@ Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  Lwt.return (
+    List.length results,
+    Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  )
 
 let () =
   Madge_server.(
@@ -56,3 +59,9 @@ let () =
       ?threshold: (o A.threshold)
       (a A.filter)
   )
+
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
+
+let count ?threshold filter =
+  Lwt.map fst @@ search ?threshold filter

--- a/src/server/model/version/version.ml
+++ b/src/server/model/version/version.ml
@@ -78,7 +78,10 @@ let search ?pagination ?(threshold=Float.min_float) filter =
         increasing (Lwt.map Tune.name % tune) String.Sensible.compare
       ])
   in
-  Lwt.return @@ Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  Lwt.return (
+    List.length results,
+    Option.fold ~none:Fun.id ~some:Common.Model.Pagination.apply pagination results
+  )
 
 let () =
   Madge_server.(
@@ -89,15 +92,11 @@ let () =
       (a A.filter)
   )
 
-let count ?threshold filter =
-  let%lwt l = search ?threshold filter in
-  Lwt.return (List.length l)
+let search' ?pagination ?threshold filter =
+  Lwt.map snd @@ search ?pagination ?threshold filter
 
-let () =
-  Madge_server.(
-    register ~endpoint:E.count @@ fun {a} {o} ->
-    count ?threshold:(o A.threshold) (a A.filter)
-  )
+let count ?threshold filter =
+  Lwt.map fst @@ search ?threshold filter
 
 let mark_fixed version =
   Database.Version.update (set_broken version false)


### PR DESCRIPTION
Builds on top of #266.

Old `search` returning the results (now `search'`) and old `count` are now just convenience wrappers around new `search`. The `count` helpers should basically just disappear eventually because they don't make that much sense. For now, though, we do need them. While rewriting the viewers, we should do our best to get rid of them.