### PR TITLE
Improve and cleanup `PageNav`

### DIFF
--- a/src/client/components/pageNav.mli
+++ b/src/client/components/pageNav.mli
@@ -11,11 +11,11 @@ type t
 (** The abstract type of a page navigation. *)
 
 val create :
-  number_of_entries: int React.signal ->
+  number_of_entries: int option React.signal ->
   entries_per_page: int ->
   t
-(** Create a page navigation. Takes a number of entries and a number of entries
-    per page. *)
+(** Create a page navigation. Takes a number of entries (or [None] if it is not
+    known at that point) and a number of entries per page. *)
 
 val render : t -> [> Html_types.div ] elt
 (** HTML rendering of a page navigation. *)

--- a/src/client/components/pageNav.mli
+++ b/src/client/components/pageNav.mli
@@ -1,0 +1,24 @@
+(** {1 Page Navigation} *)
+
+(* FIXME: rename this into [Pagination] (which it is); rename the current
+   [Pagination] into [Slice] or something, which describes it better. Maybe we
+   don't even need a type for that. *)
+
+open Dancelor_common_model
+open Dancelor_client_html
+
+type t
+(** The abstract type of a page navigation. *)
+
+val create :
+  number_of_entries: int React.signal ->
+  entries_per_page: int ->
+  t
+(** Create a page navigation. Takes a number of entries and a number of entries
+    per page. *)
+
+val render : t -> [> Html_types.div ] elt
+(** HTML rendering of a page navigation. *)
+
+val pagination : t -> Pagination.t React.signal
+(** Signal giving a {!Pagination} out of a page navigation. *)

--- a/src/client/views/set/setExplorer.ml
+++ b/src/client/views/set/setExplorer.ml
@@ -23,7 +23,7 @@ let create page =
 
   let pagination =
     PageNav.create
-      ~number_of_entries: (Set.count Formula.true_)
+      ~number_of_entries: (Dancelor_client_html.S.from' 0 @@ Set.count Formula.true_)
       ~entries_per_page: 25
   in
 
@@ -51,9 +51,9 @@ let create page =
         )
         [
           R.tbody (
-            S.bind_s' pagination.signal [] @@ fun pagination ->
+            S.bind_s' (PageNav.pagination pagination) [] @@ fun pagination ->
             Fun.flip Lwt.map
-              (Set.search' ~pagination:(PageNav.current_pagination pagination) Formula.true_ >|=| Score.list_erase)
+              (Set.search' ~pagination Formula.true_ >|=| Score.list_erase)
               (List.map
                  (fun set ->
                     let href = PageRouter.path @@ PageRouter.Set (Set.slug set) in

--- a/src/client/views/set/setExplorer.ml
+++ b/src/client/views/set/setExplorer.ml
@@ -23,7 +23,7 @@ let create page =
 
   let pagination =
     PageNav.create
-      ~number_of_entries: (Dancelor_client_html.S.from' 0 @@ Set.count Formula.true_)
+      ~number_of_entries: (Dancelor_client_html.S.from' None @@ Lwt.map Option.some @@ Set.count Formula.true_)
       ~entries_per_page: 25
   in
 


### PR DESCRIPTION
Builds on top of #267.

This PR cleans up `PageNav`, renaming a few fields and adding a `pageNav.mli` to wrap it cleanly. Additionally, it improves it by allowing the number of entries to be a signal, and not just an Lwt promise. This will be useful in the future to bind it more tightly to a search bar, for instance.