### PR TITLE
Rewrite search page to use the new API

### DIFF
--- a/src/client/dispatcher.ml
+++ b/src/client/dispatcher.ml
@@ -29,8 +29,8 @@ let dispatch url =
   match Option.get page with
   | PageRouter.Index ->
     pack (module Index) Index.create
-  | Search q ->
-    pack (module Search) (Search.create q)
+  | Search query ->
+    pack (module Search) (Search.create ?query)
   | VersionAdd ->
     pack (module VersionEditorInterface) VersionEditorInterface.create
   | VersionAll ->

--- a/src/style/default.scss
+++ b/src/style/default.scss
@@ -61,3 +61,7 @@ tr {
 th {
   text-align: inherit;
 }
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
Builds on top of #275.

To be squashed.

This PR rewrites entirely the search page using the new API. The goal is ultimately to make it a very fancy “complex search” page with buttons to help build text formulas, etc. However, I think it makes sense to first validate the feature-equivalent rewrite before proceeding further.