### PR TITLE
Fix the way we detect “Enter”

### DIFF
--- a/src/client/components/searchBar.ml
+++ b/src/client/components/searchBar.ml
@@ -113,7 +113,10 @@ let render ~placeholder ?(autofocus=false) ?on_focus ?on_input ?on_enter search_
         (
           Fun.flip Option.map on_enter @@ fun on_enter ->
           a_onkeyup (fun event ->
-              if Js.Optdef.to_option event##.key = Some (Js.string "Enter") then
+              (* NOTE: Enter is decimal key code 13. One could also use
+                 event##.key and check that it is ["Enter"] but it is somehow
+                 sometimes not set (eg. in Selenium or on mobile phones). *)
+              if event##.keyCode = 13 then
                 (
                   Js.Opt.iter event##.target @@ fun elt ->
                   Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->

--- a/src/client/elements/inputs.ml
+++ b/src/client/elements/inputs.ml
@@ -135,7 +135,7 @@ module Text = struct
     Lwt.async (fun () ->
         Lwt_js_events.keydowns t.root
           (fun ev _ ->
-             if Js.Optdef.to_option ev##.key = Some (js "Enter")
+             if ev##.keyCode = 13
              then cb (Js.to_string t.root##.value) else Lwt.return_unit))
 
   let on_focus t cb =
@@ -205,7 +205,7 @@ module Textarea = struct
     Lwt.async (fun () ->
         Lwt_js_events.keydowns t.root
           (fun ev _ ->
-             if Js.Optdef.to_option ev##.key = Some (js "Enter")
+             if ev##.keyCode = 13
              then cb (Js.to_string t.root##.value) else Lwt.return_unit))
 
   let on_focus t cb =


### PR DESCRIPTION
This is shorter, more robust, and it should work better on phones as well as in Selenium.