### PR TITLE
Rework the `Choices` component

### DIFF
--- a/src/client/components/choices.ml
+++ b/src/client/components/choices.ml
@@ -10,30 +10,31 @@ let unique =
 
 type 'value choice = {
   id : string;
-  value : 'value option;
+  value : 'value;
   checked : bool;
   contents : Html_types.label_content_fun elt list;
 }
 
-let choice ?(checked=false) ?value contents =
+let choice ?(checked=false) ~value contents =
   { id = unique (); value; checked; contents }
+
+let choice' ?checked ?value contents = choice ?checked ~value contents
 
 type 'value t = {
   box : Html_types.div elt;
-  values : 'value option S.t;
+  values : 'value S.t;
 }
 
 let signal c = c.values
 let render c = c.box
 
-let make choices =
+let make_gen_unsafe ~radios choices =
   let name = unique () in
   let (values, set_values) = S.create [] in
   let update_values () =
     let choice_inputElement choice = Option.get @@ Dom_html.getElementById_coerce choice.id Dom_html.CoerceTo.input in
-    set_values @@ List.filter_map (fun choice -> if Js.to_bool (choice_inputElement choice)##.checked then choice.value else None) choices
+    set_values @@ List.filter_map (fun choice -> if Js.to_bool (choice_inputElement choice)##.checked then Some choice.value else None) choices
   in
-  let values' = Fun.flip S.map values @@ function [] -> None | [x] -> Some x | _ -> failwith "too many values at once" in
   let box =
     div
       ~a:[
@@ -44,7 +45,7 @@ let make choices =
         Fun.flip List.concat_map choices @@ fun choice ->
         [
           input ~a:(List.filter_map Fun.id [
-              Some (a_input_type `Radio);
+              Some (a_input_type (if radios then `Radio else `Checkbox));
               Some (a_name name);
               Some (a_id choice.id);
               (if choice.checked then Some (a_checked ()) else None);
@@ -53,4 +54,12 @@ let make choices =
         ]
       )
   in
-  {box; values=values'}
+  {box; values}
+
+let make_radios choices =
+  let {box; values} = make_gen_unsafe ~radios:true choices in
+  let values = S.map (function [] -> None | [x] -> x | _ -> assert false) values in
+  {box; values}
+
+let make_checkboxes choices =
+  make_gen_unsafe ~radios:false choices

--- a/src/client/components/choices.ml
+++ b/src/client/components/choices.ml
@@ -6,9 +6,27 @@ let unique =
     incr counter;
     "choices-" ^ string_of_int !counter
 
+type 'value choice = {
+  id : string;
+  value : 'value option;
+  checked : bool;
+  contents : Html_types.label_content_fun elt list;
+}
+
+let choice ?(checked=false) ?value contents =
+  { id = unique (); value; checked; contents }
+
+type 'value t = {
+  box : Html_types.div elt;
+  values : 'value option S.t;
+}
+
+let signal c = c.values
+let render c = c.box
+
 let make choices =
   let name = unique () in
-  let (value, set_value) = S.create None in
+  let (values, set_values) = S.create None in
   let box =
     div
       ~a:[
@@ -18,28 +36,23 @@ let make choices =
               let open Js_of_ocaml in
               Js.Opt.iter event##.target @@ fun target ->
               let id = target##.id in
-              let (_, value, _, _) = List.find (fun (id', _, _, _) -> id = Js.string id') choices in
-              set_value value
+              let {value;_} = List.find (fun choice -> id = Js.string choice.id) choices in
+              set_values value
             );
             false
           );
       ]
       (
-        Fun.flip List.concat_map choices @@ fun (id, _value, checked, content) ->
+        Fun.flip List.concat_map choices @@ fun choice ->
         [
           input ~a:(List.filter_map Fun.id [
               Some (a_input_type `Radio);
               Some (a_name name);
-              Some (a_id id);
-              (if checked then Some (a_checked ()) else None);
+              Some (a_id choice.id);
+              (if choice.checked then Some (a_checked ()) else None);
             ]) ();
-          label ~a:[a_label_for id] content;
+          label ~a:[a_label_for choice.id] choice.contents;
         ]
       )
   in
-  (box, value)
-
-let choice ?value ?(checked=false) content =
-  (* FIXME: it would be better as a record, but this would imply managing to
-     type the content part of this. *)
-  (unique (), value, checked, content)
+  {box; values}

--- a/src/client/components/choices.ml
+++ b/src/client/components/choices.ml
@@ -26,6 +26,7 @@ type 'value t = {
 }
 
 let signal c = c.values
+let value c = S.value (signal c)
 let render c = c.box
 
 let make_gen_unsafe ~radios choices =

--- a/src/client/components/choices.mli
+++ b/src/client/components/choices.mli
@@ -53,5 +53,8 @@ val make_checkboxes :
 val signal : 'value t -> 'value S.t
 (** A signal holding the value/s of the “choices” component. *)
 
+val value : 'value t -> 'value
+(** The value/s of the “choices” component at that point. *)
+
 val render : 'value t -> Html_types.div elt
 (** Render the “choices” component as HTML. *)

--- a/src/client/components/choices.mli
+++ b/src/client/components/choices.mli
@@ -19,25 +19,39 @@ type 'value choice
 
 val choice :
   ?checked: bool ->
-  ?value: 'value ->
+  value: 'value ->
   Html_types.label_content_fun elt list ->
   'value choice
-(** Make one choice from the value it must hold (or uses [None]), whether it
-    should be checked at the start (defaults to [false]) and its HTML
-    contents. *)
+(** Make one choice from the value it must hold, whether it should be checked at
+    the start (defaults to [false]) and its HTML contents. *)
+
+val choice' :
+  ?checked: bool ->
+  ?value: 'value ->
+  Html_types.label_content_fun elt list ->
+  'value option choice
+(** Variant of {!choice} that holds the option of a value. Useful when the
+    default choice is to do nothing. *)
 
 (** {2 Choices element} *)
 
 type 'value t
 (** Abstract type for a “choices” component that can take ['value]s. *)
 
-val make :
-  'value choice list ->
-  'value t
-(** Make a “choices” component out of a list of single choices. *)
+val make_radios :
+  'value option choice list ->
+  'value option t
+(** Make a radio-based “choices” component that can hold at most one value at
+    once out of a list of single choices. *)
 
-val signal : 'value t -> 'value option S.t
-(** A signal holding the value of the “choices” component. *)
+val make_checkboxes :
+  'value choice list ->
+  'value list t
+(** Make a checkbox-based “choices” component that can hold zero, one, or
+    several values at once out of a list of single choices. *)
+
+val signal : 'value t -> 'value S.t
+(** A signal holding the value/s of the “choices” component. *)
 
 val render : 'value t -> Html_types.div elt
 (** Render the “choices” component as HTML. *)

--- a/src/client/components/choices.mli
+++ b/src/client/components/choices.mli
@@ -1,0 +1,43 @@
+(** {1 Choices}
+
+    This module helps building a “choices” component, which shows multiple
+    choices horizontally, one of which can be selected. This would show as
+    something like:
+
+        Book Dance Person [Set] Tune Version
+
+    This is similar to a <select> element except that all the choices are
+    visible. Under the hood, it is a bunch of <radio> elements.
+*)
+
+open Dancelor_client_html
+
+(** {2 Single choice} *)
+
+type 'value choice
+(** Abstract type for one choice holding a single ['value]. *)
+
+val choice :
+  ?checked: bool ->
+  ?value: 'value ->
+  Html_types.label_content_fun elt list ->
+  'value choice
+(** Make one choice from the value it must hold (or uses [None]), whether it
+    should be checked at the start (defaults to [false]) and its HTML
+    contents. *)
+
+(** {2 Choices element} *)
+
+type 'value t
+(** Abstract type for a “choices” component that can take ['value]s. *)
+
+val make :
+  'value choice list ->
+  'value t
+(** Make a “choices” component out of a list of single choices. *)
+
+val signal : 'value t -> 'value option S.t
+(** A signal holding the value of the “choices” component. *)
+
+val render : 'value t -> Html_types.div elt
+(** Render the “choices” component as HTML. *)

--- a/src/client/components/modalBox.ml
+++ b/src/client/components/modalBox.ml
@@ -1,11 +1,22 @@
+open Dancelor_client_html
+
 (* REVIEW: Should we use the <dialog> HTML tag? *)
 
-let make content =
-  let open Dancelor_client_html in
+type handlers = {
+  show : unit -> unit;
+  hide : unit -> unit;
+}
 
+let make content =
   (* Reactive signal that holds the information on whether the modal box should
      be visible or not. *)
   let (visible, set_visible) = S.create false in
+
+  let handlers = {
+    show = (fun () -> set_visible true);
+    hide = (fun () -> set_visible false);
+  }
+  in
 
   (* The actual modal box. This looks like:
 
@@ -39,7 +50,7 @@ let make content =
               [
                 txt "⨉"
               ]
-            :: content
+            :: content handlers
           )
       ]
   in
@@ -62,4 +73,4 @@ let make content =
     );
 
   (* We return the box and a function to make it appear. *)
-  (box, (fun () -> set_visible true))
+  (box, handlers)

--- a/src/client/views/book/bookDownloadDialog.ml
+++ b/src/client/views/book/bookDownloadDialog.ml
@@ -51,7 +51,7 @@ let create () =
 (* REVIEW: This is extremely close to `VersionDownloadDialog.render` (apart for
    one line and one type, really); there is room for factorisation here. *)
 let render slug dialog =
-  ModalBox.make @@ _ -> [
+  ModalBox.make @@ fun handlers -> [
     h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
 
     form [
@@ -62,6 +62,7 @@ let render slug dialog =
           a_class ["button"];
           a_target "_blank";
           R.a_href (S.map ApiRouter.(path % bookPdf slug) dialog.parameters_signal);
+          a_onclick (fun _ -> handlers.hide (); true);
         ] [txt "Download"];
     ];
   ]

--- a/src/client/views/book/bookDownloadDialog.ml
+++ b/src/client/views/book/bookDownloadDialog.ml
@@ -51,7 +51,7 @@ let create () =
 (* REVIEW: This is extremely close to `VersionDownloadDialog.render` (apart for
    one line and one type, really); there is room for factorisation here. *)
 let render slug dialog =
-  ModalBox.make [
+  ModalBox.make @@ _ -> [
     h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
 
     form [

--- a/src/client/views/book/bookDownloadDialog.ml
+++ b/src/client/views/book/bookDownloadDialog.ml
@@ -18,7 +18,7 @@ let lift_set_parameters every_set =
 let create () =
   let set_dialog = SetDownloadDialog.create () in
 
-  let (booklet_choices, booklet_choices_signal) =
+  let booklet_choices =
     Choices.(make [
         choice [txt "Normal"] ~checked:true;
 
@@ -37,14 +37,14 @@ let create () =
       (
         set_dialog.choice_rows
         @ [
-          tr [td [label [txt "Mode:"]]; td [booklet_choices]]
+          tr [td [label [txt "Mode:"]]; td [Choices.render booklet_choices]]
         ]
       );
 
     parameters_signal =
       S.merge (Option.concat BookParameters.compose) None [
         S.map (Option.map lift_set_parameters) set_dialog.parameters_signal;
-        booklet_choices_signal;
+        Choices.signal booklet_choices;
       ]
   }
 

--- a/src/client/views/book/bookDownloadDialog.ml
+++ b/src/client/views/book/bookDownloadDialog.ml
@@ -19,10 +19,10 @@ let create () =
   let set_dialog = SetDownloadDialog.create () in
 
   let booklet_choices =
-    Choices.(make [
-        choice [txt "Normal"] ~checked:true;
+    Choices.(make_radios [
+        choice' [txt "Normal"] ~checked:true;
 
-        choice [txt "Booklet"]
+        choice' [txt "Booklet"]
           ~value:(BookParameters.make
                     ~front_page:true
                     ~table_of_contents:End

--- a/src/client/views/book/bookViewer.ml
+++ b/src/client/views/book/bookViewer.ml
@@ -131,7 +131,7 @@ let create ?context slug page =
 
   let open Dancelor_client_html in
 
-  let (download_dialog, show_download_dialog) = BookDownloadDialog.create_and_render slug in
+  let (download_dialog, download_dialog_handlers) = BookDownloadDialog.create_and_render slug in
 
   (
     Dom.appendChild content @@ To_dom.of_div @@ div [
@@ -176,7 +176,7 @@ let create ?context slug page =
         a
           ~a:[
             a_class ["button"];
-            a_onclick (fun _ -> show_download_dialog (); false);
+            a_onclick (fun _ -> download_dialog_handlers.show (); false);
           ]
           [
             i ~a:[a_class ["fas"; "fa-file-pdf"]] [];

--- a/src/client/views/set/setDownloadDialog.ml
+++ b/src/client/views/set/setDownloadDialog.ml
@@ -30,7 +30,7 @@ let create () =
 (* REVIEW: This is extremely close to `VersionDownloadDialog.render` (apart for
    one line and one type, really); there is room for factorisation here. *)
 let render slug dialog =
-  ModalBox.make [
+  ModalBox.make @@ fun _ -> [
     h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
 
     form [

--- a/src/client/views/set/setDownloadDialog.ml
+++ b/src/client/views/set/setDownloadDialog.ml
@@ -30,7 +30,7 @@ let create () =
 (* REVIEW: This is extremely close to `VersionDownloadDialog.render` (apart for
    one line and one type, really); there is room for factorisation here. *)
 let render slug dialog =
-  ModalBox.make @@ fun _ -> [
+  ModalBox.make @@ fun handlers -> [
     h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
 
     form [
@@ -41,6 +41,7 @@ let render slug dialog =
           a_class ["button"];
           a_target "_blank";
           R.a_href (S.map ApiRouter.(path % setPdf slug) dialog.parameters_signal);
+          a_onclick (fun _ -> handlers.hide (); true);
         ] [txt "Download"];
     ];
   ]

--- a/src/client/views/set/setViewer.ml
+++ b/src/client/views/set/setViewer.ml
@@ -24,7 +24,7 @@ let create ?context slug page =
 
   let open Dancelor_client_html in
 
-  let (download_dialog, show_download_dialog) = SetDownloadDialog.create_and_render slug in
+  let (download_dialog, download_dialog_handlers) = SetDownloadDialog.create_and_render slug in
 
   (
     Dom.appendChild content @@ To_dom.of_div @@ div [
@@ -52,7 +52,7 @@ let create ?context slug page =
         a
           ~a:[
             a_class ["button"];
-            a_onclick (fun _ -> show_download_dialog (); false);
+            a_onclick (fun _ -> download_dialog_handlers.show (); false);
           ]
           [
             i ~a:[a_class ["fas"; "fa-file-pdf"]] [];

--- a/src/client/views/version/versionDownloadDialog.ml
+++ b/src/client/views/version/versionDownloadDialog.ml
@@ -49,7 +49,7 @@ let create () =
   }
 
 let render slug dialog =
-  ModalBox.make @@ fun _ -> [
+  ModalBox.make @@ fun handlers -> [
     h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
 
     form [
@@ -60,6 +60,7 @@ let render slug dialog =
           a_class ["button"];
           a_target "_blank";
           R.a_href (S.map ApiRouter.(path % versionPdf slug) dialog.parameters_signal);
+          a_onclick (fun _ -> handlers.hide (); true);
         ] [txt "Download"];
     ];
   ]

--- a/src/client/views/version/versionDownloadDialog.ml
+++ b/src/client/views/version/versionDownloadDialog.ml
@@ -49,7 +49,7 @@ let create () =
   }
 
 let render slug dialog =
-  ModalBox.make [
+  ModalBox.make @@ fun _ -> [
     h2 ~a:[a_class ["title"]] [txt "Download a PDF"];
 
     form [

--- a/src/client/views/version/versionDownloadDialog.ml
+++ b/src/client/views/version/versionDownloadDialog.ml
@@ -11,7 +11,7 @@ type t =
   }
 
 let create () =
-  let (key_choices, key_choices_signal) =
+  let key_choices =
     Choices.(make [
         choice [txt "C"] ~checked:true;
 
@@ -23,7 +23,7 @@ let create () =
       ])
   in
 
-  let (clef_choices, clef_choices_signal) =
+  let clef_choices =
     Choices.(make [
         choice [txt "𝄞"] ~checked:true;
 
@@ -35,15 +35,15 @@ let create () =
   (* A signal containing the composition of all the parameters. *)
   let parameters_signal =
     S.merge (Option.concat VersionParameters.compose) None [
-      key_choices_signal;
-      clef_choices_signal;
+      Choices.signal key_choices;
+      Choices.signal clef_choices;
     ]
   in
 
   {
     choice_rows = [
-      tr [td [label [txt "Key:"]]; td [key_choices]];
-      tr [td [label [txt "Clef:"]]; td [clef_choices]];
+      tr [td [label [txt "Key:"]]; td [Choices.render key_choices]];
+      tr [td [label [txt "Clef:"]]; td [Choices.render clef_choices]];
     ];
     parameters_signal;
   }

--- a/src/client/views/version/versionDownloadDialog.ml
+++ b/src/client/views/version/versionDownloadDialog.ml
@@ -12,22 +12,22 @@ type t =
 
 let create () =
   let key_choices =
-    Choices.(make [
-        choice [txt "C"] ~checked:true;
+    Choices.(make_radios [
+        choice' [txt "C"] ~checked:true;
 
-        choice [txt "B♭"]
+        choice' [txt "B♭"]
           ~value:(VersionParameters.make_instrument (Music.make_pitch B Flat (-1)));
 
-        choice [txt "E♭"]
+        choice' [txt "E♭"]
           ~value:(VersionParameters.make_instrument (Music.make_pitch E Flat 0));
       ])
   in
 
   let clef_choices =
-    Choices.(make [
-        choice [txt "𝄞"] ~checked:true;
+    Choices.(make_radios [
+        choice' [txt "𝄞"] ~checked:true;
 
-        choice [txt "𝄢"]
+        choice' [txt "𝄢"]
           ~value:(VersionParameters.make ~clef:Music.Bass ~transposition:(Relative(Music.pitch_c, Music.make_pitch C Natural (-1))) ());
       ])
   in

--- a/src/client/views/version/versionViewer.ml
+++ b/src/client/views/version/versionViewer.ml
@@ -37,7 +37,7 @@ let create ?context slug page =
 
   let open Dancelor_client_html in
 
-  let (download_dialog, show_download_dialog) = VersionDownloadDialog.create_and_render slug in
+  let (download_dialog, download_dialog_handlers) = VersionDownloadDialog.create_and_render slug in
 
   (
     Dom.appendChild content @@ To_dom.of_div @@ div [
@@ -72,7 +72,7 @@ let create ?context slug page =
           a
             ~a:[
               a_class ["button"];
-              a_onclick (fun _ -> show_download_dialog (); false);
+              a_onclick (fun _ -> download_dialog_handlers.show (); false);
             ]
             [
               i ~a:[a_class ["fas"; "fa-file-pdf"]] [];


### PR DESCRIPTION
This work aims at making this component cleaner and better documented. It also paves the way to adding a variant of the component that supports multiple choices and returns a signal to a list. This component could in turn be used for eg. the search page.