### PR TITLE
Improve `AnySignature` and documentation in general

### DIFF
--- a/dancelor.opam
+++ b/dancelor.opam
@@ -29,6 +29,7 @@ depends: [
   "ppx_deriving"
   "ppx_deriving_yojson"
   "ppx_inline_test" {build | with-test}
+  "ppx_import"
   "ppx_monad" {build & >= "0.2.0"}
   "slug"
   "yaml"

--- a/dune-project
+++ b/dune-project
@@ -35,6 +35,7 @@
    ppx_deriving
    ppx_deriving_yojson
   (ppx_inline_test     (or :build :with-test))
+   ppx_import
   (ppx_monad           (and :build (>= 0.2.0)))
    slug
    yaml

--- a/src/client/components/choices.mli
+++ b/src/client/components/choices.mli
@@ -30,7 +30,7 @@ val choice' :
   ?value: 'value ->
   Html_types.label_content_fun elt list ->
   'value option choice
-(** Variant of {!choice} that holds the option of a value. Useful when the
+(** Variant of {!val-choice} that holds the option of a value. Useful when the
     default choice is to do nothing. *)
 
 (** {2 Choices element} *)

--- a/src/client/model/dancelor_client_model.ml
+++ b/src/client/model/dancelor_client_model.ml
@@ -20,7 +20,7 @@ module BookParameters                     = BookParameters
 
 module Any               : Common.ANY     = Any
 
-(** {2 Modules taken as-is from {!Dancelor_common}} *)
+(** {2 Modules taken as-is from [Dancelor_common]} *)
 
 open Common
 

--- a/src/common/model/any/anySignature.mli
+++ b/src/common/model/any/anySignature.mli
@@ -26,6 +26,8 @@ module Filter : sig
   type predicate = [%import: AnyCore.Filter.predicate]
   type t = [%import: AnyCore.Filter.t]
 
+  val type_ : Type.t -> t
+
   val accepts : t -> AnyCore.t -> float Lwt.t
 
   val from_string : string -> (t, string list) result

--- a/src/common/model/any/anySignature.mli
+++ b/src/common/model/any/anySignature.mli
@@ -139,10 +139,10 @@ val search' :
   ?threshold:float ->
   Filter.t ->
   t Score.t list Lwt.t
-(** Like {!search} but returns only the list. *)
+(** Like {!val-search} but returns only the list. *)
 
 val count :
   ?threshold:float ->
   Filter.t ->
   int Lwt.t
-(** Like {!search} but returns only the number of items. *)
+(** Like {!val-search} but returns only the number of items. *)

--- a/src/common/model/any/anySignature.mli
+++ b/src/common/model/any/anySignature.mli
@@ -15,7 +15,7 @@ val name : t -> string Lwt.t
 (** Finds a name to give to the element, no matter what it is. *)
 
 module Type : sig
-  type t = AnyCore.Type.t
+  type t = [%import: AnyCore.Type.t]
 
   val to_string : t -> string
 end

--- a/src/common/model/any/anySignature.mli
+++ b/src/common/model/any/anySignature.mli
@@ -23,7 +23,8 @@ end
 val type_of : t -> Type.t
 
 module Filter : sig
-  type t = AnyCore.Filter.t
+  type predicate = [%import: AnyCore.Filter.predicate]
+  type t = [%import: AnyCore.Filter.t]
 
   val accepts : t -> AnyCore.t -> float Lwt.t
 

--- a/src/common/model/any/anySignature.mli
+++ b/src/common/model/any/anySignature.mli
@@ -1,41 +1,128 @@
+(** {1 Any} *)
+
 open Nes
 
-type t = AnyCore.t
+type t = [%import: AnyCore.t]
+(** Type of an “any” element, that is simply a sum type of all the other
+    models. *)
+
+(** {3 Constructors} *)
 
 val person : PersonCore.t -> t
+(** Function equivalent of the [Person] constructor. *)
+
 val dance : DanceCore.t -> t
+(** Function equivalent of the [Dance] constructor. *)
+
 val book : BookCore.t -> t
+(** Function equivalent of the [Book] constructor. *)
+
 val set : SetCore.t -> t
+(** Function equivalent of the [Set] constructor. *)
+
 val tune : TuneCore.t -> t
+(** Function equivalent of the [Tune] constructor. *)
+
 val version : VersionCore.t -> t
+(** Function equivalent of the [Version] constructor. *)
+
+(** {3 Destructors} *)
 
 val equal : t -> t -> bool
+(** Equality between two {!t}. *)
 
 val name : t -> string Lwt.t
 (** Finds a name to give to the element, no matter what it is. *)
 
+(** {2 Type} *)
+
 module Type : sig
   type t = [%import: AnyCore.Type.t]
+  (** Type to represent the type of an “any”. There is basically one type per
+      model, eg. [Version] or [Dance]. Must not be mistaken for a kind, which,
+      in Dancelor parlance, is eg. [Reel] or [8 x 32 Strathspey]. *)
 
   val all : t list
+  (** All the existing types, as a list. There is no guarantee on the order in
+      which those elements appear. *)
+
   val to_string : t -> string
+  (** Convert a type to a string, eg [to_string Person = "Person"]. *)
+
+  exception NotAType of string
+  (** See {!of_string}. *)
+
+  val of_string : string -> t
+  (** Convert a string to a type, eg. [of_string "person" = Person]. If the
+      string is not a valid representation of a type, raises {!NotAType}. *)
+
+  val of_string_opt : string -> t option
+  (** Option equivalent of {!of_string}. *)
 end
 
 val type_of : t -> Type.t
+(** Get the type of an “any” element. *)
+
+(** {2 Filters} *)
 
 module Filter : sig
   type predicate = [%import: AnyCore.Filter.predicate]
-  type t = [%import: AnyCore.Filter.t]
+  (** Type of predicates on “any” elements. *)
 
-  val type_ : Type.t -> t
+  type t = [%import: AnyCore.Filter.t]
+  (** Type of a filter on “any” element, that is a formula over
+      {!predicate}s. *)
 
   val accepts : t -> AnyCore.t -> float Lwt.t
+  (** Whether the given filter accepts the given element. *)
+
+  (** {3 Constructors} *)
+
+  val type_ : Type.t -> t
+  (** A filter that asserts that the element has the given type. *)
+
+  val asPerson : PersonSignature.Filter.t -> t
+  (** Lift a filter on persons to make a filter on “any”. This filter asserts
+      that the “any” element is a person that matches the given filter. *)
+
+  val asDance : DanceSignature.Filter.t -> t
+  (** Lift a filter on dances to make a filter on “any”. This filter asserts
+      that the “any” element is a dance that matches the given filter. *)
+
+  val asBook : BookSignature.Filter.t -> t
+  (** Lift a filter on books to make a filter on “any”. This filter asserts that
+      the “any” element is a book that matches the given filter. *)
+
+  val asSet : SetSignature.Filter.t -> t
+  (** Lift a filter on sets to make a filter on “any”. This filter asserts that
+      the “any” element is a set that matches the given filter. *)
+
+  val asTune : TuneSignature.Filter.t -> t
+  (** Lift a filter on tunes to make a filter on “any”. This filter asserts that
+      the “any” element is a tune that matches the given filter. *)
+
+  val asVersion : VersionSignature.Filter.t -> t
+  (** Lift a filter on versions to make a filter on “any”. This filter asserts
+      that the “any” element is a version that matches the given filter. *)
+
+  (** {3 Destructors} *)
 
   val from_string : string -> (t, string list) result
+  (** Parse a text formula into a filter on “any” elements. *)
+
   val from_string_exn : string -> t
+  (** Exceptional equivalent of {!from_string}. *)
+
+  (** {3 Others} *)
 
   val possible_types : t -> Type.t list
+  (** Returns the list of types that a formula can match. It is guaranteed that
+      elements whose types are not in the list will be rejected by the filter.
+      It is not guaranteed that for each type in the list there will be an
+      element of this type accepted by the filter. *)
 end
+
+(** {2 Search} *)
 
 val search :
   ?pagination:Pagination.t ->

--- a/src/common/model/any/anySignature.mli
+++ b/src/common/model/any/anySignature.mli
@@ -17,6 +17,7 @@ val name : t -> string Lwt.t
 module Type : sig
   type t = [%import: AnyCore.Type.t]
 
+  val all : t list
   val to_string : t -> string
 end
 
@@ -32,6 +33,8 @@ module Filter : sig
 
   val from_string : string -> (t, string list) result
   val from_string_exn : string -> t
+
+  val possible_types : t -> Type.t list
 end
 
 val search :

--- a/src/common/model/dune
+++ b/src/common/model/dune
@@ -6,8 +6,8 @@
  (libraries str lwt dancelor.nes dancelor.madge.common dancelor.madge.router
    menhirLib yojson ppx_deriving_yojson.runtime)
  (preprocess
-  (pps lwt_ppx ppx_inline_test ppx_deriving_yojson ppx_deriving.std ppx_monad
-    ppx_monad_olwt ppx_monad_rlwt))
+  (staged_pps lwt_ppx ppx_inline_test ppx_deriving_yojson ppx_deriving.std
+    ppx_monad ppx_monad_olwt ppx_monad_rlwt ppx_import))
  (modules_without_implementation personSignature danceSignature bookSignature
    anySignature setSignature tuneSignature versionSignature)
  (inline_tests))

--- a/src/common/model/music.mli
+++ b/src/common/model/music.mli
@@ -33,10 +33,17 @@ type key [@@deriving yojson]
 val make_key : pitch -> mode -> key
 val key_pitch : key -> pitch
 
-val key_to_string : key -> string          (** eg. C  D#m   Eb *)
-val key_to_pretty_string : key -> string   (** eg. C  D♯m   E♭ *)
-val key_to_lilypond_string : key -> string (** eg. c dis:m ees *)
-val key_to_safe_string : key -> string     (** eg. c  dism ees *)
+val key_to_string : key -> string
+(** eg. C  D#m   Eb *)
+
+val key_to_pretty_string : key -> string
+(** eg. C  D♯m   E♭ *)
+
+val key_to_lilypond_string : key -> string
+(** eg. c dis:m ees *)
+
+val key_to_safe_string : key -> string
+(** eg. c  dism ees *)
 
 val key_of_string : string -> key
 val key_of_string_opt : string -> key option

--- a/src/server/model/dancelor_server_model.ml
+++ b/src/server/model/dancelor_server_model.ml
@@ -20,7 +20,7 @@ module BookParameters                     = BookParameters
 
 module Any               : Common.ANY     = Any
 
-(** {2 Modules taken as-is from {!Dancelor_common}} *)
+(** {2 Modules taken as-is from [Dancelor_common]} *)
 
 open Common
 


### PR DESCRIPTION
This PR improves the documentation. It focuses in particular in exposing and documenting everything in `AnySignature` but it also fixes some `odoc` warnings and errors. One important side effect to note is that, in order to export more things in `Any`, we now depend on `ppx_import`.