### PR TITLE
Use `ppx_variants_conv` and `ppx_fields_conv`

### DIFF
--- a/.nix/package.nix
+++ b/.nix/package.nix
@@ -32,6 +32,9 @@
         ppx_deriving_qcheck
         qcheck
         qcheck-alcotest
+
+        # used for vendored `ppx_variants_conv`
+        variantslib
       ];
     };
   };

--- a/.nix/package.nix
+++ b/.nix/package.nix
@@ -22,6 +22,7 @@
         ppx_deriving_yojson
         ppx_import
         ppx_inline_test
+        ppx_fields_conv
         ppx_monad
         slug
         yaml

--- a/src/client/views/book/bookDownloadDialog.ml
+++ b/src/client/views/book/bookDownloadDialog.ml
@@ -61,7 +61,7 @@ let open_ slug dialog =
         ~a:[
           a_class ["button"];
           a_target "_blank";
-          R.a_href (S.map ApiRouter.(path % bookPdf slug) dialog.parameters_signal);
+          R.a_href (S.map (fun params -> ApiRouter.path_bookPdf ?params slug) dialog.parameters_signal);
           a_onclick (fun _ -> return (); true);
         ] [txt "Download"];
     ];

--- a/src/client/views/dune
+++ b/src/client/views/dune
@@ -16,4 +16,10 @@
   dancelor.common
   dancelor.client.components)
  (preprocess
-  (pps lwt_ppx js_of_ocaml-ppx ppx_monad ppx_monad_olwt ppx_monad_rlwt)))
+  (pps
+   lwt_ppx
+   js_of_ocaml-ppx
+   ppx_monad
+   ppx_monad_olwt
+   ppx_monad_rlwt
+   ppx_variants_conv)))

--- a/src/client/views/searchComplexFiltersDialog.ml
+++ b/src/client/views/searchComplexFiltersDialog.ml
@@ -12,14 +12,7 @@ type restricted_predicate =
   | Set     of     Set.Filter.predicate list list
   | Tune    of    Tune.Filter.predicate list list
   | Version of Version.Filter.predicate list list
-
-(* FIXME: PPX *)
-let person rpc = Person rpc
-let dance rpc = Dance rpc
-let book rpc = Book rpc
-let set rpc = Set rpc
-let tune rpc = Tune rpc
-let version rpc = Version rpc
+[@@deriving variants]
 
 (** Restricted formulas supported by the complex filter dialog. This is a bunch
     of raw strings and zero or one {!restricted_predicate}. *)

--- a/src/client/views/set/setDownloadDialog.ml
+++ b/src/client/views/set/setDownloadDialog.ml
@@ -40,7 +40,7 @@ let open_ slug dialog =
         ~a:[
           a_class ["button"];
           a_target "_blank";
-          R.a_href (S.map ApiRouter.(path % setPdf slug) dialog.parameters_signal);
+          R.a_href (S.map ApiRouter.(fun params -> path_setPdf ?params slug) dialog.parameters_signal);
           a_onclick (fun _ -> return (); true);
         ] [txt "Download"];
     ];

--- a/src/client/views/set/setEditorInterface.ml
+++ b/src/client/views/set/setEditorInterface.ml
@@ -127,7 +127,7 @@ let make_version_subwindow t index version =
   Dom.appendChild buttons delli;
   Dom.appendChild toolbar buttons;
   Dom.appendChild subwin toolbar;
-  let source = Lwt.return ApiRouter.(path (versionSvg version.SetEditor.slug None)) in
+  let source = Lwt.return (ApiRouter.path_versionSvg version.SetEditor.slug) in
   let img = Image.create ~source t.page in
   Dom.appendChild subwin (Image.root img);
   subwin

--- a/src/client/views/set/setViewer.ml
+++ b/src/client/views/set/setViewer.ml
@@ -82,7 +82,7 @@ let create ?context slug page =
 
                      object_ ~a:[
                        a_mime_type "image/svg+xml";
-                       a_data ApiRouter.(path (versionSvg slug None));
+                       a_data ApiRouter.(path_versionSvg slug);
                      ] [];
                    ]
                )

--- a/src/client/views/version/versionDownloadDialog.ml
+++ b/src/client/views/version/versionDownloadDialog.ml
@@ -59,7 +59,7 @@ let open_ slug dialog =
         ~a:[
           a_class ["button"];
           a_target "_blank";
-          R.a_href (S.map ApiRouter.(path % versionPdf slug) dialog.parameters_signal);
+          R.a_href (S.map ApiRouter.(fun params -> path_versionPdf ?params slug) dialog.parameters_signal);
           a_onclick (fun _ -> return (); true);
         ] [txt "Download"];
     ];

--- a/src/client/views/version/versionViewer.ml
+++ b/src/client/views/version/versionViewer.ml
@@ -28,7 +28,7 @@ let create ?context slug page =
     let%lwt version = version_lwt in
     Version.search' Formula.(and_l [
         Version.Filter.tuneIs' tune;
-        not_ (Version.Filter.is' version);
+        not (Version.Filter.is' version);
       ])
   in
 

--- a/src/client/views/version/versionViewer.ml
+++ b/src/client/views/version/versionViewer.ml
@@ -84,7 +84,7 @@ let create ?context slug page =
           a
             ~a:[
               a_class ["button"];
-              a_href ApiRouter.(path @@ versionLy slug);
+              a_href ApiRouter.(path_versionLy slug);
             ]
             [
               i ~a:[a_class ["material-symbols-outlined"]] [txt "article"];
@@ -118,14 +118,14 @@ let create ?context slug page =
         div ~a:[a_class ["image-container"]] [
           object_ ~a:[
             a_mime_type "image/svg+xml";
-            a_data ApiRouter.(path (versionSvg slug None))
+            a_data ApiRouter.(path_versionSvg slug)
           ] [];
         ]
       ];
 
       div ~a:[a_class ["audio-container"]] [
         audio ~a:[a_controls ()]
-          ~src:ApiRouter.(path (versionOgg slug))
+          ~src:ApiRouter.(path_versionOgg slug)
           []
       ];
 

--- a/src/common/apiRouter.ml
+++ b/src/common/apiRouter.ml
@@ -8,23 +8,7 @@ type endpoint =
   | Set     of     SetEndpoints.t
   | Version of VersionEndpoints.t
   | Victor of victor_level
-
-let mkBook e = Book e
-let mkSet e = Set e
-let mkVersion e = Version e
-
-let unBook = function Book e -> Some e | _ -> None
-let unSet = function Set e -> Some e | _ -> None
-let unVersion = function Version e -> Some e | _ -> None
-
-(** Constructors that can be used as functions. FIXME: This is a job for a PPX
-    and there is probably one that exists for that. *)
-let bookPdf slug params = Book (Pdf (slug, params))
-let setPdf slug params = Set (Pdf (slug, params))
-let versionLy slug = Version (Ly slug)
-let versionSvg slug params = Version (Svg (slug, params))
-let versionOgg slug = Version (Ogg slug)
-let versionPdf slug params = Version (Pdf (slug, params))
+[@@deriving variants]
 
 (** {2 Routes} *)
 
@@ -36,9 +20,9 @@ let routes : endpoint route list =
     direct `GET "/victor2" @@ Victor Two ;
     direct `GET "/victor3" @@ Victor Three ;
     direct `GET "/victor4" @@ Victor Four ]
-  @ wrap_routes ~prefix:"/book"    ~wrap:mkBook    ~unwrap:unBook       BookEndpoints.routes
-  @ wrap_routes ~prefix:"/set"     ~wrap:mkSet     ~unwrap:unSet         SetEndpoints.routes
-  @ wrap_routes ~prefix:"/version" ~wrap:mkVersion ~unwrap:unVersion VersionEndpoints.routes
+  @ wrap_routes ~prefix:"/book"    ~wrap:book    ~unwrap:unBook       BookEndpoints.routes
+  @ wrap_routes ~prefix:"/set"     ~wrap:set     ~unwrap:unSet         SetEndpoints.routes
+  @ wrap_routes ~prefix:"/version" ~wrap:version ~unwrap:unVersion VersionEndpoints.routes
 
 let path ?(api_prefix=true) endpoint =
   let request = Madge_router.resource_to_request endpoint routes in
@@ -46,6 +30,13 @@ let path ?(api_prefix=true) endpoint =
   let path = Uri.(to_string @@ make ~path:request.path ~query:(MQ.to_strings request.query) ()) in
   (* FIXME: a bit stupid to convert it to string, we should just carry [Uri.t] around! *)
   if api_prefix then "/" ^ Constant.api_prefix ^ path else path
+
+let path_versionLy slug = path @@ version @@ VersionEndpoints.ly slug
+let path_versionSvg ?params slug = path @@ version @@ VersionEndpoints.svg slug params
+let path_versionOgg slug = path @@ version @@ VersionEndpoints.ogg slug
+let path_versionPdf ?params slug = path @@ version @@ VersionEndpoints.pdf slug params
+let path_setPdf ?params slug = path @@ set @@ SetEndpoints.pdf slug params
+let path_bookPdf ?params slug = path @@ book @@ BookEndpoints.pdf slug params
 
 let endpoint method_ path query =
   Madge_router.request_to_resource { method_; path; query } routes

--- a/src/common/dancelor_common_pageRouter.ml
+++ b/src/common/dancelor_common_pageRouter.ml
@@ -9,11 +9,7 @@ type context =
   | InSearch of string
   | InSet of SetCore.t Slug.t * int
   | InBook of BookCore.t Slug.t * int
-[@@deriving yojson]
-
-let inSearch query = InSearch query
-let inSet slug index = InSet (slug, index)
-let inBook slug index = InBook (slug, index)
+[@@deriving yojson, variants]
 
 let inSet' = inSet % Slug.unsafe_of_string
 let inBook' = inBook % Slug.unsafe_of_string
@@ -33,22 +29,19 @@ type page =
   | Tune of {slug: TuneCore.t Slug.t; context: context option}
   | VersionAdd
   | Version of {slug : VersionCore.t Slug.t; context: context option}
+[@@deriving variants]
 
 (* FIXME: It would be so much nicer if [Search] could carry an actual
    [AnyCore.Filter.predicate Formula.t]. That however requires moving a lot of
    code from [*Lifter] to [*Core] for all models (basically everything but the
    [accepts] function, I would say), so, for now, we keep it as a string. *)
 
-let book ?context slug = Book {slug; context}
-let bookEdit slug = BookEdit slug
-let person ?context slug = Person {slug; context}
-let dance ?context slug = Dance {slug; context}
-let explore q = Explore q
-let set ?context slug = Set {slug; context}
-let tune ?context slug = Tune {slug; context}
-let version ?context slug = Version {slug; context}
-
-let unBookEdit = function BookEdit slug -> Some slug | _ -> None
+let book ?context slug = book ~context ~slug
+let person ?context slug = person ~context ~slug
+let dance ?context slug = dance ~context ~slug
+let set ?context slug = set ~context ~slug
+let tune ?context slug = tune ~context ~slug
+let version ?context slug = version ~context ~slug
 
 open Madge_router
 module MQ = Madge_query

--- a/src/common/dune
+++ b/src/common/dune
@@ -18,6 +18,7 @@
    ppx_deriving_yojson
    ppx_deriving.std
    ppx_inline_test
+   ppx_variants_conv
    ppx_monad
    ppx_monad_olwt
    ppx_monad_rlwt))
@@ -29,4 +30,4 @@
  (public_name dancelor.common.page-router)
  (libraries dancelor.nes dancelor.common.model)
  (preprocess
-  (pps ppx_deriving_yojson)))
+  (pps ppx_deriving_yojson ppx_variants_conv)))

--- a/src/common/model/any/anyCore.ml
+++ b/src/common/model/any/anyCore.ml
@@ -9,15 +9,7 @@ type t =
   | Set     of     SetCore.t
   | Tune    of    TuneCore.t
   | Version of VersionCore.t
-[@@deriving show {with_path = false}, yojson]
-
-(* FIXME: PPX *)
-let person p = Person p
-let dance d = Dance d
-let book b = Book b
-let set s = Set s
-let tune t = Tune t
-let version v = Version v
+[@@deriving show {with_path = false}, yojson, variants]
 
 module Type = struct
   let _key = "type"
@@ -63,26 +55,7 @@ module Filter = struct
     | Set     of     SetCore.Filter.t
     | Tune    of    TuneCore.Filter.t
     | Version of VersionCore.Filter.t
-  [@@deriving eq, show {with_path = false}, yojson]
-
-  (* FIXME: PPX *)
-  let raw string = Raw string
-  let type_ type_ = Type type_
-  let person  filter = Person  filter
-  let dance   filter = Dance   filter
-  let book    filter = Book    filter
-  let set     filter = Set     filter
-  let tune    filter = Tune    filter
-  let version filter = Version filter
-
-  let unRaw = function Raw s -> Some s | _ -> None
-  let unType = function Type t -> Some t | _ -> None
-  let unPerson = function Person pf -> Some pf | _ -> None
-  let unDance = function Dance df -> Some df | _ -> None
-  let unBook = function Book bf -> Some bf | _ -> None
-  let unSet = function Set sf -> Some sf | _ -> None
-  let unTune = function Tune tf -> Some tf | _ -> None
-  let unVersion = function Version vf -> Some vf | _ -> None
+  [@@deriving eq, show {with_path = false}, yojson, variants]
 
   type t = predicate Formula.t
   [@@deriving eq, show {with_path = false}, yojson]

--- a/src/common/model/any/anyLifter.ml
+++ b/src/common/model/any/anyLifter.ml
@@ -205,7 +205,7 @@ module Lift
         | True -> (t, True)
         | Not f ->
           (* REVIEW: Not 100% of this [Type.Set.comp t] argument. *)
-          map_pair (Type.Set.diff t) not_ @@ refine_types_and_cleanup (Type.Set.comp t) f
+          map_pair (Type.Set.diff t) not @@ refine_types_and_cleanup (Type.Set.comp t) f
         | And (f1, f2) ->
           (* Refine [t] on [f1], the refine it again while cleaning up [f2],
              then come back and clean up [f1]. *)

--- a/src/common/model/book/bookCore.ml
+++ b/src/common/model/book/bookCore.ml
@@ -25,7 +25,7 @@ type t =
     scddb_id    : int option [@default None] [@key "scddb-id"] ;
     modified_at : Datetime.t [@key "modified-at"] ;
     created_at  : Datetime.t [@key "created-at"] }
-[@@deriving make, show {with_path = false}, yojson]
+[@@deriving make, show {with_path = false}, yojson, fields]
 
 let make
     ~slug ?status ~title ?subtitle ?short_title ?date ?(contents=[]) ?source ?remark
@@ -36,20 +36,6 @@ let make
     ~slug ?status ~title ?subtitle ?short_title ~date ~contents ?source ?remark
     ~scddb_id ~modified_at ~created_at
     ()
-
-(* FIXME: PPX *)
-let slug book = book.slug
-let status book = book.status
-let title book = book.title
-let subtitle book = book.subtitle
-let short_title book = book.short_title
-let date book = book.date
-let contents book = book.contents
-let source book = book.source
-let remark book = book.remark
-let scddb_id book = book.scddb_id
-let modified_at book = book.modified_at
-let created_at book = book.created_at
 
 let contains_set set1 book =
   List.exists

--- a/src/common/model/book/bookCore.ml
+++ b/src/common/model/book/bookCore.ml
@@ -96,29 +96,7 @@ module Filter = struct
     | ExistsSet of SetCore.Filter.t
     | ExistsInlineSet of SetCore.Filter.t
     | ExistsVersionDeep of VersionCore.Filter.t
-  [@@deriving eq, show {with_path = false}, yojson]
-
-  (* FIXME: PPX *)
-  let is book = Is book
-  let title string = Title string
-  let titleMatches string = TitleMatches string
-  let subtitle string = Subtitle string
-  let subtitleMatches string = SubtitleMatches string
-  let isSource = IsSource
-  let existsVersion vfilter = ExistsVersion vfilter
-  let existsSet sfilter = ExistsSet sfilter
-  let existsInlineSet sfilter = ExistsInlineSet sfilter
-  let existsVersionDeep vfilter = ExistsVersionDeep vfilter
-
-  let unIs = function Is s -> Some s | _ -> None
-  let unTitle = function Title t -> Some t | _ -> None
-  let unTitleMatches = function TitleMatches t -> Some t | _ -> None
-  let unSubtitle = function Subtitle s -> Some s | _ -> None
-  let unSubtitleMatches = function SubtitleMatches s -> Some s | _ -> None
-  let unExistsVersion = function ExistsVersion vf -> Some vf | _ -> None
-  let unExistsSet = function ExistsSet sf -> Some sf | _ -> None
-  let unExistsInlineSet = function ExistsInlineSet sf -> Some sf | _ -> None
-  let unExistsVersionDeep = function ExistsVersionDeep vf -> Some vf | _ -> None
+  [@@deriving eq, show {with_path = false}, yojson, variants]
 
   type t = predicate Formula.t
   [@@deriving eq, show {with_path = false}, yojson]

--- a/src/common/model/book/bookEndpoints.ml
+++ b/src/common/model/book/bookEndpoints.ml
@@ -29,6 +29,7 @@ module MQ = Madge_query
 
 type t =
   | Pdf of BookCore.t Slug.t * BookParameters.t option
+[@@deriving variants]
 
 let routes : t route list =
   [

--- a/src/common/model/dance/danceCore.ml
+++ b/src/common/model/dance/danceCore.ml
@@ -14,20 +14,7 @@ type t =
     date : PartialDate.t option [@default None] ; (** When the dance was devised. *)
     modified_at : Datetime.t [@key "modified-at"] ;
     created_at  : Datetime.t [@key "created-at"] }
-[@@deriving make, show {with_path = false}, yojson]
-
-(* FIXME: PPX *)
-let slug dance = dance.slug
-let status dance = dance.status
-let name dance = dance.name
-let kind dance = dance.kind
-let devisers dance = dance.devisers
-let two_chords dance = dance.two_chords
-let scddb_id dance = dance.scddb_id
-let disambiguation dance = dance.disambiguation
-let date dance = dance.date
-let modified_at dance = dance.modified_at
-let created_at dance = dance.created_at
+[@@deriving make, show {with_path = false}, yojson, fields]
 
 module Filter = struct
   let _key = "dance-filter"

--- a/src/common/model/dance/danceCore.ml
+++ b/src/common/model/dance/danceCore.ml
@@ -42,20 +42,7 @@ module Filter = struct
     | NameMatches of string
     | Kind of Kind.Dance.Filter.t
     | ExistsDeviser of PersonCore.Filter.t (** deviser is defined and passes the filter *)
-  [@@deriving eq, show {with_path = false}, yojson]
-
-  (* FIXME: PPX *)
-  let is dance = Is dance
-  let name name = Name name
-  let nameMatches name = NameMatches name
-  let kind kfilter = Kind kfilter
-  let existsDeviser pfilter = ExistsDeviser pfilter
-
-  let unIs = function Is s -> Some s | _ -> None
-  let unName = function Name n -> Some n | _ -> None
-  let unNameMatches = function NameMatches n -> Some n | _ -> None
-  let unKind = function Kind kf -> Some kf | _ -> None
-  let unExistsDeviser = function ExistsDeviser pf -> Some pf | _ -> None
+  [@@deriving eq, show {with_path = false}, yojson, variants]
 
   type t = predicate Formula.t
   [@@deriving eq, show {with_path = false}, yojson]

--- a/src/common/model/dune
+++ b/src/common/model/dune
@@ -21,6 +21,7 @@
    ppx_monad
    ppx_monad_olwt
    ppx_monad_rlwt
+   ppx_fields_conv
    ppx_variants_conv
    ppx_import))
  (modules_without_implementation

--- a/src/common/model/dune
+++ b/src/common/model/dune
@@ -21,6 +21,7 @@
    ppx_monad
    ppx_monad_olwt
    ppx_monad_rlwt
+   ppx_variants_conv
    ppx_import))
  (modules_without_implementation
   personSignature

--- a/src/common/model/formula.ml
+++ b/src/common/model/formula.ml
@@ -7,7 +7,7 @@ type 'p t =
   | And of 'p t * 'p t
   | Or  of 'p t * 'p t
   | Pred of 'p
-[@@deriving yojson]
+[@@deriving yojson, variants]
 
 (** Comparison of ands and ors is problematic, so we normalise them always in
     the same way before comparing. *)
@@ -49,18 +49,10 @@ let pp pp_pred fmt formula =
   in
   ppf (match formula with Pred _ -> false | _ -> true) fmt "%a" (pp `Root) formula
 
-let false_ = False
-let true_ = True
-
-(* FIXME: PPX *)
-let not_ f = Not f
-
-let and_ f1 f2 = And(f1, f2)
 let and_l = function
   | [] -> True
   | h::t -> List.fold_left and_ h t
 
-let or_ f1 f2 = Or(f1, f2)
 let or_l = function
   | [] -> False
   | h::t -> List.fold_left or_ h t

--- a/src/common/model/formula.mli
+++ b/src/common/model/formula.mli
@@ -16,7 +16,7 @@ type 'p t =
 
 val false_ : 'p t
 val true_ : 'p t
-val not_ : 'p t -> 'p t
+val not : 'p t -> 'p t
 
 val and_ : 'p t -> 'p t -> 'p t
 (** Conjunction of two formulas. *)

--- a/src/common/model/kind/kindBase.ml
+++ b/src/common/model/kind/kindBase.ml
@@ -71,11 +71,7 @@ type base_kind = t (* needed for the interface of filters *)
 module Filter = struct
   type predicate =
     | Is of t
-  [@@deriving eq, show {with_path = false}, yojson]
-
-  (* FIXME: PPX *)
-  let is kind = Is kind
-  let unIs = function Is k -> Some k
+  [@@deriving eq, show {with_path = false}, yojson, variants]
 
   type t = predicate Formula.t
   [@@deriving eq, show {with_path = false}, yojson]

--- a/src/common/model/kind/kindDance.ml
+++ b/src/common/model/kind/kindDance.ml
@@ -60,15 +60,7 @@ module Filter = struct
     | Is of t
     | Simple
     | Version of KindVersion.Filter.t
-  [@@deriving eq, show {with_path = false}, yojson]
-
-  (* FIXME: PPX *)
-  let is kind = Is kind
-  let version vfilter = Version vfilter
-  let simple = Simple
-
-  let unIs = function Is k -> Some k | _ -> None
-  let unVersion = function Version vf -> Some vf | _ -> None
+  [@@deriving eq, show {with_path = false}, yojson, variants]
 
   let base = version % KindVersion.Filter.base'
   let baseIs = version % KindVersion.Filter.baseIs'

--- a/src/common/model/kind/kindVersion.ml
+++ b/src/common/model/kind/kindVersion.ml
@@ -69,26 +69,7 @@ module Filter = struct
     | BarsLt of int
     | BarsLe of int
     | Base of KindBase.Filter.t
-  [@@deriving eq, show {with_path = false}, yojson]
-
-  (* FIXME: PPX *)
-  let is kind = Is kind
-  let barsEq int = BarsEq int
-  let barsNe int = BarsNe int
-  let barsGt int = BarsGt int
-  let barsGe int = BarsGe int
-  let barsLt int = BarsLt int
-  let barsLe int = BarsLe int
-  let base bfilter = Base bfilter
-
-  let unIs = function Is k -> Some k | _ -> None
-  let unBarsEq = function BarsEq i -> Some i | _ -> None
-  let unBarsNe = function BarsNe i -> Some i | _ -> None
-  let unBarsGt = function BarsGt i -> Some i | _ -> None
-  let unBarsGe = function BarsGe i -> Some i | _ -> None
-  let unBarsLt = function BarsLt i -> Some i | _ -> None
-  let unBarsLe = function BarsLe i -> Some i | _ -> None
-  let unBase = function Base bf -> Some bf | _ -> None
+  [@@deriving eq, show {with_path = false}, yojson, variants]
 
   let baseIs = base % KindBase.Filter.is'
 

--- a/src/common/model/person/personCore.ml
+++ b/src/common/model/person/personCore.ml
@@ -9,15 +9,7 @@ type t =
     scddb_id : int option [@default None] [@key "scddb-id"] ;
     modified_at : Datetime.t [@key "modified-at"] ;
     created_at  : Datetime.t [@key "created-at"] }
-[@@deriving yojson, make, show {with_path = false}]
-
-(* FIXME: PPX *)
-let slug person = person.slug
-let status person = person.status
-let name person = person.name
-let scddb_id person = person.scddb_id
-let modified_at person = person.modified_at
-let created_at person = person.created_at
+[@@deriving yojson, make, show {with_path = false}, fields]
 
 module Filter = struct
   let _key = "person-filter"

--- a/src/common/model/person/personCore.ml
+++ b/src/common/model/person/personCore.ml
@@ -30,16 +30,7 @@ module Filter = struct
     | Is of t Slug.t
     | Name of string
     | NameMatches of string
-  [@@deriving eq, show {with_path = false}, yojson]
-
-  (* FIXME: PPX *)
-  let is person = Is person
-  let name name = Name name
-  let nameMatches name = NameMatches name
-
-  let unIs = function Is s -> Some s | _ -> None
-  let unName = function Name n -> Some n | _ -> None
-  let unNameMatches = function NameMatches n -> Some n | _ -> None
+  [@@deriving eq, show {with_path = false}, yojson, variants]
 
   type t = predicate Formula.t
   [@@deriving eq, show {with_path = false}, yojson]

--- a/src/common/model/set/setCore.ml
+++ b/src/common/model/set/setCore.ml
@@ -59,22 +59,7 @@ module Filter = struct
     | ExistsConceptor of PersonCore.Filter.t (** conceptor is defined and passes the filter *)
     | ExistsVersion of VersionCore.Filter.t
     | Kind of Kind.Dance.Filter.t
-  [@@deriving eq, show {with_path = false}, yojson]
-
-  (* FIXME: PPX *)
-  let is set = Is set
-  let name name = Name name
-  let nameMatches name = NameMatches name
-  let existsConceptor pfilter = ExistsConceptor pfilter
-  let existsVersion vfilter = ExistsVersion vfilter
-  let kind kfilter = Kind kfilter
-
-  let unIs = function Is s -> Some s | _ -> None
-  let unName = function Name n -> Some n | _ -> None
-  let unNameMatches = function NameMatches n -> Some n | _ -> None
-  let unExistsConceptor = function ExistsConceptor cf -> Some cf | _ -> None
-  let unExistsVersion = function ExistsVersion vf -> Some vf | _ -> None
-  let unKind = function Kind kf -> Some kf | _ -> None
+  [@@deriving eq, show {with_path = false}, yojson, variants]
 
   type t = predicate Formula.t
   [@@deriving eq, show {with_path = false}, yojson]

--- a/src/common/model/set/setCore.ml
+++ b/src/common/model/set/setCore.ml
@@ -16,23 +16,9 @@ type t =
     remark : string                  [@default ""] ;
     modified_at : Datetime.t      [@key "modified-at"] ;
     created_at  : Datetime.t      [@key "created-at"] }
-[@@deriving make, show {with_path = false}, yojson]
+[@@deriving make, show {with_path = false}, yojson, fields]
 
 (* FIXME: rename [versions_and_parameters] into [contents]. *)
-
-(* FIXME: PPX *)
-let slug set = set.slug
-let status set = set.status
-let name set = set.name
-let conceptors set = set.conceptors
-let kind set = set.kind
-let versions_and_parameters set = set.versions_and_parameters
-let order set = set.order
-let instructions set = set.instructions
-let dances set = set.dances
-let remark set = set.remark
-let modified_at set = set.modified_at
-let created_at set = set.created_at
 
 type warning =
   | Empty

--- a/src/common/model/set/setEndpoints.ml
+++ b/src/common/model/set/setEndpoints.ml
@@ -33,6 +33,7 @@ module MQ = Madge_query
 
 type t =
   | Pdf of SetCore.t Slug.t * SetParameters.t option
+[@@deriving variants]
 
 let routes : t route list =
   [

--- a/src/common/model/tune/tuneCore.ml
+++ b/src/common/model/tune/tuneCore.ml
@@ -15,21 +15,7 @@ type t =
     date : PartialDate.t option [@default None] ; (** When the tune was composed. *)
     modified_at : Datetime.t            [@key "modified-at"] ;
     created_at  : Datetime.t            [@key "created-at"] }
-[@@deriving make, show {with_path = false}, yojson]
-
-(* FIXME: PPX *)
-let slug tune = tune.slug
-let status tune = tune.status
-let name tune = tune.name
-let alternative_names tune = tune.alternative_names
-let kind tune = tune.kind
-let composers tune = tune.composers
-let dances tune = tune.dances
-let remark tune = tune.remark
-let scddb_id tune = tune.scddb_id
-let date tune = tune.date
-let modified_at tune = tune.modified_at
-let created_at tune = tune.created_at
+[@@deriving make, show {with_path = false}, yojson, fields]
 
 let compare = Slug.compare_slugs_or ~fallback:Stdlib.compare slug
 let equal tune1 tune2 = compare tune1 tune2 = 0

--- a/src/common/model/tune/tuneCore.ml
+++ b/src/common/model/tune/tuneCore.ml
@@ -48,22 +48,7 @@ module Filter = struct
     | ExistsComposer of PersonCore.Filter.t (** one of the composers of the list passes the filter *)
     | Kind of Kind.Base.Filter.t
     | ExistsDance of DanceCore.Filter.t
-  [@@deriving eq, show {with_path = false}, yojson]
-
-  (* FIXME: PPX *)
-  let is tune = Is tune
-  let name string = Name string
-  let nameMatches string = NameMatches string
-  let existsComposer pfilter = ExistsComposer pfilter
-  let kind kfilter = Kind kfilter
-  let existsDance dfilter = ExistsDance dfilter
-
-  let unIs = function Is s -> Some s | _ -> None
-  let unName = function Name n -> Some n | _ -> None
-  let unNameMatches = function NameMatches n -> Some n | _ -> None
-  let unExistsComposer = function ExistsComposer pf -> Some pf | _ -> None
-  let unKind = function Kind kf -> Some kf | _ -> None
-  let unExistsDance = function ExistsDance df -> Some df | _ -> None
+  [@@deriving eq, show {with_path = false}, yojson, variants]
 
   type t = predicate Formula.t
   [@@deriving eq, show {with_path = false}, yojson]

--- a/src/common/model/version/versionCore.ml
+++ b/src/common/model/version/versionCore.ml
@@ -44,19 +44,7 @@ module Filter = struct
     | Key of Music.key
     | Kind of Kind.Version.Filter.t
     | Broken
-  [@@deriving eq, show {with_path = false}, yojson]
-
-  (* FIXME: PPX *)
-  let is version = Is version
-  let tune tfilter = Tune tfilter
-  let key key_ = Key key_
-  let kind kfilter = Kind kfilter
-  let broken = Broken
-
-  let unIs = function Is v -> Some v | _ -> None
-  let unTune = function Tune f -> Some f | _ -> None
-  let unKey = function Key k -> Some k | _ -> None
-  let unKind = function Kind f -> Some f | _ -> None
+  [@@deriving eq, show {with_path = false}, yojson, variants]
 
   type t = predicate Formula.t
   [@@deriving eq, show {with_path = false}, yojson]

--- a/src/common/model/version/versionCore.ml
+++ b/src/common/model/version/versionCore.ml
@@ -16,22 +16,7 @@ type t =
     broken : bool                     [@default false] ;
     modified_at : Datetime.t          [@key "modified-at"] ;
     created_at  : Datetime.t          [@key "created-at"] }
-[@@deriving make, show {with_path = false}, yojson]
-
-(* FIXME: PPX *)
-let slug version = version.slug
-let status version = version.status
-let tune version = version.tune
-let bars version = version.bars
-let key version = version.key
-let structure version = version.structure
-let sources version = version.sources
-let arrangers version = version.arrangers
-let remark version = version.remark
-let disambiguation version = version.disambiguation
-let broken version = version.broken
-let modified_at version = version.modified_at
-let created_at  version = version.created_at
+[@@deriving make, show {with_path = false}, yojson, fields]
 
 let equal version1 version2 = Slug.equal' (slug version1) (slug version2)
 

--- a/src/common/model/version/versionEndpoints.ml
+++ b/src/common/model/version/versionEndpoints.ml
@@ -41,6 +41,7 @@ type t =
   | Svg of VersionCore.t Slug.t * VersionParameters.t option
   | Ogg of VersionCore.t Slug.t
   | Pdf of VersionCore.t Slug.t * VersionParameters.t option
+[@@deriving variants]
 
 let routes : t route list =
   [

--- a/src/ppx_blob/README.md
+++ b/src/ppx_blob/README.md
@@ -1,1 +1,2 @@
-ppx_blob fix for `(lang dune 3.0)` vendored from <https://github.com/johnwhitington/ppx_blob/pull/24>.
+Vendored version of `ppx_blob` with a fix for `(lang dune 3.0)` taken from
+<https://github.com/johnwhitington/ppx_blob/pull/24>.

--- a/src/ppx_variants_conv/README.md
+++ b/src/ppx_variants_conv/README.md
@@ -1,0 +1,2 @@
+Vendored modified version of `ppx_variant_conv` to circumvent
+<https://github.com/janestreet/ppx_variants_conv/issues/14>.

--- a/src/ppx_variants_conv/dune
+++ b/src/ppx_variants_conv/dune
@@ -1,0 +1,7 @@
+(library
+ (name ppx_variants_conv)
+ (kind ppx_deriver)
+ (ppx_runtime_libraries variantslib)
+ (libraries base ppxlib)
+ (preprocess
+  (pps ppxlib.metaquot)))

--- a/src/ppx_variants_conv/ppx_variants_conv.ml
+++ b/src/ppx_variants_conv/ppx_variants_conv.ml
@@ -1,0 +1,750 @@
+(* Generated code should depend on the environment in scope as little as possible.
+   E.g. rather than [foo = []] do [match foo with [] ->], to eliminate the use of [=].  It
+   is especially important to not use polymorphic comparisons, since we are moving more
+   and more to code that doesn't have them in scope. *)
+
+open Base
+open Ppxlib
+open Ast_builder.Default
+
+let raise_unsupported loc =
+  Location.raise_errorf
+    ~loc
+    "Unsupported use of variants (you can only use it on variant types)."
+;;
+
+module Create = struct
+  let lambda loc xs body =
+    List.fold_right xs ~init:body ~f:(fun (label, p) e -> pexp_fun ~loc label None p e)
+  ;;
+
+  let lambda_sig loc arg_tys body_ty =
+    List.fold_right arg_tys ~init:body_ty ~f:(fun (label, arg_ty) acc ->
+        ptyp_arrow ~loc label arg_ty acc)
+  ;;
+end
+
+module Variant_constructor = struct
+  type t =
+    { name : string
+    ; loc : Location.t
+    ; kind :
+        [ `Normal of core_type list * core_type option
+        | `Normal_inline_record of label_declaration list * core_type option
+        | `Polymorphic of core_type option
+        ]
+    }
+
+  let args t =
+    match t.kind with
+    | `Normal (pcd_args, _) ->
+      List.mapi pcd_args ~f:(fun i _ -> Nolabel, "v" ^ Int.to_string i)
+    | `Normal_inline_record (fields, _) ->
+      List.mapi fields ~f:(fun i f -> Labelled f.pld_name.txt, "v" ^ Int.to_string i)
+    | `Polymorphic None -> []
+    | `Polymorphic (Some _) -> [ Nolabel, "v0" ]
+  ;;
+
+  let return_ty_opt t =
+    match t.kind with
+    | `Normal (_, return_ty_opt) | `Normal_inline_record (_, return_ty_opt) ->
+      return_ty_opt
+    | `Polymorphic _ -> None
+  ;;
+
+  let return_ty t ~variant_type = Option.value (return_ty_opt t) ~default:variant_type
+
+  (* We could be smarter and avoid treating as GADT constructors that use the GADT syntax
+     but not the expressivity of GADTs. It's not clearly useful though. *)
+  let is_gadt t = Option.is_some (return_ty_opt t)
+
+  let pattern_without_binding { name; loc; kind } =
+    match kind with
+    | `Normal ([], _) -> ppat_construct ~loc (Located.lident ~loc name) None
+    | `Normal (_ :: _, _) | `Normal_inline_record _ ->
+      ppat_construct ~loc (Located.lident ~loc name) (Some (ppat_any ~loc))
+    | `Polymorphic None -> ppat_variant ~loc name None
+    | `Polymorphic (Some _) -> ppat_variant ~loc name (Some (ppat_any ~loc))
+  ;;
+
+  let to_fun_type t ~rhs:body_ty =
+    let arg_types =
+      match t.kind with
+      | `Polymorphic None -> []
+      | `Polymorphic (Some v) -> [ Nolabel, v ]
+      | `Normal (args, _) -> List.map args ~f:(fun typ -> Nolabel, typ)
+      | `Normal_inline_record (fields, _) ->
+        List.map fields ~f:(fun cd -> Labelled cd.pld_name.txt, cd.pld_type)
+    in
+    Create.lambda_sig t.loc arg_types body_ty
+  ;;
+
+  let to_getter_type t ~lhs:input_type =
+    if is_gadt t (* see getter_opt below for why *)
+    then None
+    else (
+      let variant_for_label (ld : label_declaration) =
+        ptyp_variant
+          ~loc:ld.pld_loc
+          [ rtag ~loc:ld.pld_loc ld.pld_name false [ ld.pld_type ] ]
+          Closed
+          None
+      in
+      let loc = t.loc in
+      let result_type =
+        match t.kind with
+        | `Polymorphic None | `Normal ([], _) | `Normal_inline_record ([], _) ->
+          [%type: unit]
+        | `Polymorphic (Some v) -> v
+        | `Normal (tup, _) -> ptyp_tuple ~loc tup
+        | `Normal_inline_record (fields, _) ->
+          ptyp_tuple ~loc (List.map fields ~f:variant_for_label)
+      in
+      Some (ptyp_arrow ~loc Nolabel input_type [%type: [%t result_type] option]))
+  ;;
+
+  let to_getter_case { loc; name; kind } =
+    let pat, idents =
+      match kind with
+      | `Polymorphic None -> ppat_variant ~loc name None, []
+      | `Polymorphic (Some _) ->
+        let ident = "v" in
+        ppat_variant ~loc name (Some (pvar ident ~loc)), [ `Unlabelled ident ]
+      | `Normal ([], _) -> ppat_construct ~loc (Located.lident ~loc name) None, []
+      | `Normal (args, _) ->
+        let idents = List.mapi args ~f:(fun i _ -> "v" ^ Int.to_string i) in
+        let patterns = List.map idents ~f:(pvar ~loc) in
+        ( ppat_construct ~loc (Located.lident ~loc name) (Some (ppat_tuple ~loc patterns))
+        , List.map idents ~f:(fun i -> `Unlabelled i) )
+      | `Normal_inline_record (lds, _) ->
+        let patterns, idents =
+          List.mapi lds ~f:(fun i ld ->
+              let ident = "v" ^ Int.to_string i in
+              let field_pat = Located.map_lident ld.pld_name, pvar ident ~loc in
+              field_pat, `Labelled (ld.pld_name.txt, ident))
+          |> List.unzip
+        in
+        ( ppat_construct
+            ~loc
+            (Located.lident ~loc name)
+            (Some (ppat_record ~loc patterns Closed))
+        , idents )
+    in
+    let ident_expr = function
+      | `Unlabelled ident -> evar ~loc ident
+      | `Labelled (label, ident) -> pexp_variant ~loc label (Some (evar ~loc ident))
+    in
+    let expr =
+      match idents with
+      | [] -> [%expr ()]
+      | idents -> pexp_tuple ~loc (List.map idents ~f:ident_expr)
+    in
+    pat, expr
+  ;;
+end
+
+let variant_name_to_string v =
+  let s = String.lowercase v in
+  if Keyword.is_keyword s then s ^ "_" else s
+;;
+
+module Inspect = struct
+  let row_field loc rf : Variant_constructor.t =
+    match rf.prf_desc with
+    | Rtag ({ txt = name; _ }, true, _) | Rtag ({ txt = name; _ }, _, []) ->
+      { name; loc; kind = `Polymorphic None }
+    | Rtag ({ txt = name; _ }, false, tp :: _) ->
+      { name; loc; kind = `Polymorphic (Some tp) }
+    | Rinherit _ ->
+      Location.raise_errorf
+        ~loc
+        "ppx_variants_conv: polymorphic variant inclusion is not supported"
+  ;;
+
+  let constructor cd : Variant_constructor.t =
+    let kind =
+      match cd.pcd_args with
+      | Pcstr_tuple pcd_args -> `Normal (pcd_args, cd.pcd_res)
+      | Pcstr_record fields -> `Normal_inline_record (fields, cd.pcd_res)
+    in
+    { name = cd.pcd_name.txt; loc = cd.pcd_name.loc; kind }
+  ;;
+
+  let type_decl td =
+    let loc = td.ptype_loc in
+    match td.ptype_kind with
+    | Ptype_variant cds ->
+      let cds = List.map cds ~f:constructor in
+      let names_as_string = Hashtbl.create (module String) in
+      List.iter cds ~f:(fun { name; loc; _ } ->
+          let s = variant_name_to_string name in
+          match Hashtbl.find names_as_string s with
+          | None -> Hashtbl.add_exn names_as_string ~key:s ~data:name
+          | Some name' ->
+            Location.raise_errorf
+              ~loc
+              "ppx_variants_conv: constructors %S and %S both get mapped to value %S"
+              name
+              name'
+              s);
+      cds
+    | Ptype_record _ | Ptype_open -> raise_unsupported loc
+    | Ptype_abstract ->
+      (match td.ptype_manifest with
+       | Some { ptyp_desc = Ptyp_variant (row_fields, Closed, None); _ } ->
+         List.map row_fields ~f:(row_field loc)
+       | Some { ptyp_desc = Ptyp_variant _; ptyp_loc = loc; _ } ->
+         Location.raise_errorf
+           ~loc
+           "ppx_variants_conv: polymorphic variants with a row variable are not supported"
+       | _ -> raise_unsupported loc)
+  ;;
+end
+
+let variants_module = function
+  | "t" -> "Variants"
+  | type_name -> "Variants_of_" ^ type_name
+;;
+
+module Gen_sig = struct
+  let label_arg _loc name ty = Asttypes.Labelled (variant_name_to_string name), ty
+
+  let val_ ~loc name type_ =
+    psig_value ~loc (value_description ~loc ~name:(Located.mk ~loc name) ~type_ ~prim:[])
+  ;;
+
+  let variant_arg f ~variant_type (v : Variant_constructor.t) =
+    let loc = v.loc in
+    let return_ty = Variant_constructor.return_ty v ~variant_type in
+    let variant =
+      [%type: [%t Variant_constructor.to_fun_type v ~rhs:return_ty] Variantslib.Variant.t]
+    in
+    label_arg loc v.Variant_constructor.name (f ~variant)
+  ;;
+
+  let v_fold_fun ~variant_type loc variants =
+    let acc i = ptyp_var ~loc ("acc__" ^ Int.to_string i) in
+    let f i v =
+      variant_arg
+        ~variant_type
+        (fun ~variant -> [%type: [%t acc i] -> [%t variant] -> [%t acc (i + 1)]])
+        v
+    in
+    let types = List.mapi variants ~f in
+    let init_ty = label_arg loc "init" (acc 0) in
+    let t = Create.lambda_sig loc (init_ty :: types) (acc (List.length variants)) in
+    val_ ~loc "fold" t
+  ;;
+
+  let v_iter_fun ~variant_type loc variants =
+    let f = variant_arg ~variant_type (fun ~variant -> [%type: [%t variant] -> unit]) in
+    let types = List.map variants ~f in
+    let t = Create.lambda_sig loc types [%type: unit] in
+    val_ ~loc "iter" t
+  ;;
+
+  let v_map_fun_opt ~variant_type loc variants =
+    let module V = Variant_constructor in
+    if List.exists variants ~f:V.is_gadt
+    then None
+    else (
+      let result_type = [%type: 'result__] in
+      let f v =
+        let variant =
+          let constructor_type = V.to_fun_type v ~rhs:variant_type in
+          Create.lambda_sig
+            loc
+            [ Nolabel, [%type: [%t constructor_type] Variantslib.Variant.t] ]
+            (V.to_fun_type v ~rhs:result_type)
+        in
+        label_arg loc v.V.name variant
+      in
+      let types = List.map variants ~f in
+      let t = Create.lambda_sig loc ((Nolabel, variant_type) :: types) result_type in
+      Some (val_ ~loc "map" t))
+  ;;
+
+  let v_make_matcher_fun_opt ~variant_type loc variants =
+    let module V = Variant_constructor in
+    if List.exists variants ~f:V.is_gadt
+    then None
+    else (
+      let result_type = [%type: 'result__] in
+      let acc i = ptyp_var ~loc ("acc__" ^ Int.to_string i) in
+      let f i v =
+        let variant =
+          [%type:
+            [%t Variant_constructor.to_fun_type v ~rhs:variant_type] Variantslib.Variant.t]
+        in
+        let fun_type =
+          match Variant_constructor.args v with
+          | [] -> [%type: unit -> [%t result_type]]
+          | _ :: _ -> Variant_constructor.to_fun_type v ~rhs:result_type
+        in
+        label_arg
+          loc
+          v.name
+          [%type: [%t variant] -> [%t acc i] -> [%t fun_type] * [%t acc (i + 1)]]
+      in
+      let types = List.mapi variants ~f in
+      let t =
+        Create.lambda_sig
+          loc
+          (types @ [ Nolabel, acc 0 ])
+          [%type:
+            ([%t variant_type] -> [%t result_type]) * [%t acc (List.length variants)]]
+      in
+      Some (val_ ~loc "make_matcher" t))
+  ;;
+
+  let v_descriptions ~variant_type:_ loc _ =
+    val_ ~loc "descriptions" [%type: (string * int) list]
+  ;;
+
+  let v_to_rank_fun ~variant_type loc _ =
+    val_ ~loc "to_rank" [%type: [%t variant_type] -> int]
+  ;;
+
+  let v_to_name_fun ~variant_type loc _ =
+    val_ ~loc "to_name" [%type: [%t variant_type] -> string]
+  ;;
+
+  let variant ~variant_type ~ty_name loc variants =
+    let tester_type = [%type: [%t variant_type] -> bool] in
+    let helpers, variant_defs =
+      List.unzip
+        (List.map variants ~f:(fun v ->
+             let module V = Variant_constructor in
+             let return_ty = V.return_ty v ~variant_type in
+             let constructor_type = V.to_fun_type v ~rhs:return_ty in
+             let getter_type_opt = V.to_getter_type v ~lhs:return_ty in
+             let name = variant_name_to_string v.V.name in
+             ( ( val_ ~loc name constructor_type
+               , val_ ~loc ("is_" ^ name) tester_type
+               , Option.map getter_type_opt ~f:(val_ ~loc (name ^ "_val")) )
+             , val_ ~loc name [%type: [%t constructor_type] Variantslib.Variant.t] )))
+    in
+    let constructors, testers, getters = List.unzip3 helpers in
+    constructors
+    @ testers
+    @ List.filter_opt getters
+    @ [ psig_module
+          ~loc
+          (module_declaration
+             ~loc
+             ~name:(Located.mk ~loc (Some (variants_module ty_name)))
+             ~type_:
+               (pmty_signature
+                  ~loc
+                  (variant_defs
+                   @ List.filter_opt
+                     [ Some (v_fold_fun ~variant_type loc variants)
+                     ; Some (v_iter_fun ~variant_type loc variants)
+                     ; v_map_fun_opt ~variant_type loc variants
+                     ; v_make_matcher_fun_opt ~variant_type loc variants
+                     ; Some (v_to_rank_fun ~variant_type loc variants)
+                     ; Some (v_to_name_fun ~variant_type loc variants)
+                     ; Some (v_descriptions ~variant_type loc variants)
+                     ])))
+      ]
+  ;;
+
+  let variants_of_td td =
+    let ty_name = td.ptype_name.txt in
+    let loc = td.ptype_loc in
+    let variant_type = core_type_of_type_declaration td in
+    variant ~variant_type ~ty_name loc (Inspect.type_decl td)
+  ;;
+
+  let generate ~loc ~path:_ (rec_flag, tds) =
+    (match rec_flag with
+     | Nonrecursive ->
+       Location.raise_errorf
+         ~loc
+         "nonrec is not compatible with the `ppx_variants_conv' preprocessor"
+     | _ -> ());
+    match tds with
+    | [ td ] -> variants_of_td td
+    | _ -> Location.raise_errorf ~loc "ppx_variants_conv: not supported"
+  ;;
+end
+
+module Gen_str = struct
+  (** Replace type variables with locally abstract type, say ['a] with [a], and return the
+      set of locally abstract types created this way. *)
+  let newtypes =
+    let newtype_visitor =
+      object
+        inherit [label list] Ast_traverse.fold_map as super
+
+        method! core_type core_type acc =
+          match core_type.ptyp_desc with
+          | Ptyp_var label ->
+            let loc = core_type.ptyp_loc in
+            let ty = ptyp_constr ~loc { loc; txt = Longident.Lident label } [] in
+            ty, label :: acc
+          | Ptyp_any ->
+            let label = gen_symbol () in
+            let loc = core_type.ptyp_loc in
+            let ty = ptyp_constr ~loc { loc; txt = Longident.Lident label } [] in
+            ty, label :: acc
+          | _ -> super#core_type core_type acc
+      end
+    in
+    fun ty ->
+      let ty, labels = newtype_visitor#core_type ty [] in
+      ty, List.dedup_and_sort ~compare:String.compare labels
+  ;;
+
+  let locally_abstract_match loc cases ~variant_ty =
+    let variant_ty, lbls = newtypes variant_ty in
+    let match_expr = pexp_match ~loc [%expr t] cases in
+    let fun_expr = [%expr fun (t : [%t variant_ty]) -> [%e match_expr]] in
+    List.fold_right lbls ~init:fun_expr ~f:(fun txt acc ->
+        pexp_newtype ~loc { txt; loc } acc)
+  ;;
+
+  let helpers_and_variants loc ~variant_ty variants =
+    let multiple_cases = List.length variants > 1 in
+    let module V = Variant_constructor in
+    let helpers, variants =
+      List.mapi variants ~f:(fun rank v ->
+          let uncapitalized = variant_name_to_string v.V.name in
+          let constructor =
+            let constructed_value =
+              match v.V.kind with
+              | `Normal _ ->
+                let arg =
+                  pexp_tuple_opt ~loc (List.map (V.args v) ~f:(fun (_, v) -> evar ~loc v))
+                in
+                pexp_construct ~loc (Located.lident ~loc v.V.name) arg
+              | `Polymorphic _ ->
+                let arg =
+                  pexp_tuple_opt ~loc (List.map (V.args v) ~f:(fun (_, v) -> evar ~loc v))
+                in
+                pexp_variant ~loc v.V.name arg
+              | `Normal_inline_record (fields, _) ->
+                let arg =
+                  pexp_record
+                    ~loc
+                    (List.map2_exn fields (V.args v) ~f:(fun f (_, name) ->
+                         Located.lident ~loc f.pld_name.txt, evar ~loc name))
+                    None
+                in
+                pexp_construct ~loc (Located.lident ~loc v.V.name) (Some arg)
+            in
+            pstr_value
+              ~loc
+              Nonrecursive
+              [ value_binding
+                  ~loc
+                  ~pat:(pvar ~loc uncapitalized)
+                  ~expr:
+                    (List.fold_right
+                       (V.args v)
+                       ~init:constructed_value
+                       ~f:(fun (label, v) e -> pexp_fun ~loc label None (pvar ~loc v) e))
+              ]
+          in
+          let variant =
+            [%stri
+              let [%p pvar ~loc uncapitalized] =
+                { Variantslib.Variant.name = [%e estring ~loc v.V.name]
+                ; rank = [%e eint ~loc rank]
+                ; constructor = [%e evar ~loc uncapitalized]
+                }
+              ;;]
+          in
+          let match_fun ~name ~true_case ~false_expr =
+            let cases =
+              if multiple_cases
+              then [ true_case; case ~guard:None ~lhs:[%pat? _] ~rhs:false_expr ]
+              else [ true_case ]
+            in
+            let body =
+              if Variant_constructor.is_gadt v
+              then locally_abstract_match loc cases ~variant_ty
+              else pexp_function ~loc cases
+            in
+            [%stri let [%p pvar ~loc name] = [%e body] [@@warning "-4"]]
+          in
+          let tester =
+            let name = "is_" ^ uncapitalized in
+            let true_case =
+              case
+                ~guard:None
+                ~lhs:(Variant_constructor.pattern_without_binding v)
+                ~rhs:[%expr true]
+            in
+            match_fun ~name ~true_case ~false_expr:[%expr false]
+          in
+          let getter_opt =
+            (* We cannot generate a getter for GADTs in the case that we have existentially
+               quantified type vars. Further we can't generate _regular_ getter functions
+               when the GADT is non-regular. For the time being we skip generating getters
+               for GADTs altogether *)
+            if Variant_constructor.is_gadt v
+            then None
+            else (
+              let name = uncapitalized ^ "_val" in
+              let pat, expr = Variant_constructor.to_getter_case v in
+              let true_case =
+                case ~guard:None ~lhs:pat ~rhs:[%expr Stdlib.Option.Some [%e expr]]
+              in
+              Some (match_fun ~name ~true_case ~false_expr:[%expr Stdlib.Option.None]))
+          in
+          (constructor, tester, getter_opt), variant)
+      |> List.unzip
+    in
+    let constructors, testers, getters = List.unzip3 helpers in
+    constructors, testers, List.filter_opt getters, variants
+  ;;
+
+  let label_arg ?label loc name =
+    let l =
+      match label with
+      | None -> name
+      | Some n -> n
+    in
+    Asttypes.Labelled l, pvar ~loc name
+  ;;
+
+  let label_arg_fun loc name = label_arg ~label:name loc (name ^ "_fun__")
+
+  let v_fold_fun loc variants =
+    let module V = Variant_constructor in
+    let variant_fold acc_expr variant =
+      let variant_name = variant_name_to_string variant.V.name in
+      [%expr
+        [%e evar ~loc (variant_name ^ "_fun__")] [%e acc_expr] [%e evar ~loc variant_name]]
+    in
+    let body = List.fold_left variants ~init:[%expr init__] ~f:variant_fold in
+    let patterns =
+      List.map variants ~f:(fun variant ->
+          label_arg_fun loc (variant_name_to_string variant.V.name))
+    in
+    let init = label_arg ~label:"init" loc "init__" in
+    let lambda = Create.lambda loc (init :: patterns) body in
+    [%stri let fold = [%e lambda]]
+  ;;
+
+  let v_descriptions loc variants =
+    let module V = Variant_constructor in
+    let f v =
+      [%expr [%e estring ~loc v.V.name], [%e eint ~loc (List.length (V.args v))]]
+    in
+    let variant_names = List.map ~f variants in
+    [%stri let descriptions = [%e elist ~loc variant_names]]
+  ;;
+
+  let v_map_fun_opt loc variants =
+    let module V = Variant_constructor in
+    (* We are currently not generating getter for GADTs which mean we can't
+       generate [map] *)
+    if List.exists variants ~f:V.is_gadt
+    then None
+    else (
+      let variant_match_case variant =
+        let pattern =
+          match variant.V.kind with
+          | `Polymorphic _ ->
+            let arg =
+              ppat_tuple_opt
+                ~loc
+                (List.map (V.args variant) ~f:(fun (_, v) -> pvar ~loc v))
+            in
+            ppat_variant ~loc variant.V.name arg
+          | `Normal _ ->
+            let arg =
+              ppat_tuple_opt
+                ~loc
+                (List.map (V.args variant) ~f:(fun (_, v) -> pvar ~loc v))
+            in
+            ppat_construct ~loc (Located.lident ~loc variant.V.name) arg
+          | `Normal_inline_record (fields, _) ->
+            let arg =
+              ppat_record
+                ~loc
+                (List.map2_exn fields (V.args variant) ~f:(fun f (_, v) ->
+                     Located.lident ~loc f.pld_name.txt, pvar ~loc v))
+                Closed
+            in
+            ppat_construct ~loc (Located.lident ~loc variant.V.name) (Some arg)
+        in
+        let uncapitalized = variant_name_to_string variant.V.name in
+        let value =
+          List.fold_left
+            (V.args variant)
+            ~init:
+              (eapply
+                 ~loc
+                 (evar ~loc (uncapitalized ^ "_fun__"))
+                 [ evar ~loc uncapitalized ])
+            ~f:(fun acc_expr (label, var) ->
+                pexp_apply ~loc acc_expr [ label, evar ~loc var ])
+        in
+        case ~guard:None ~lhs:pattern ~rhs:value
+      in
+      let body = pexp_match ~loc [%expr t__] (List.map variants ~f:variant_match_case) in
+      let patterns =
+        List.map variants ~f:(fun variant ->
+            label_arg_fun loc (variant_name_to_string variant.V.name))
+      in
+      let lambda = Create.lambda loc ((Nolabel, [%pat? t__]) :: patterns) body in
+      Some [%stri let map = [%e lambda]])
+  ;;
+
+  let v_iter_fun loc variants =
+    let module V = Variant_constructor in
+    let names = List.map variants ~f:(fun v -> variant_name_to_string v.V.name) in
+    let variant_iter variant =
+      let variant_name = variant_name_to_string variant.V.name in
+      [%expr
+        ([%e evar ~loc (variant_name ^ "_fun__")] [%e evar ~loc variant_name] : unit)]
+    in
+    let body = esequence ~loc (List.map variants ~f:variant_iter) in
+    let patterns = List.map names ~f:(label_arg_fun loc) in
+    let lambda = Create.lambda loc patterns body in
+    [%stri let iter = [%e lambda]]
+  ;;
+
+  let v_make_matcher_fun_opt loc variants =
+    let module V = Variant_constructor in
+    (* We are currently not generating getter for GADTs which mean we can't
+       generate [map] and consequently can't generate a matcher either *)
+    if List.exists variants ~f:V.is_gadt
+    then None
+    else (
+      let result =
+        let map =
+          List.fold_left variants ~init:[%expr map] ~f:(fun acc variant ->
+              let variant_name = variant_name_to_string variant.V.name in
+              pexp_apply
+                ~loc
+                acc
+                [ ( Labelled variant_name
+                  , match V.args variant with
+                  | [] -> [%expr fun _ -> [%e evar ~loc (variant_name ^ "_gen__")] ()]
+                  | _ :: _ -> [%expr fun _ -> [%e evar ~loc (variant_name ^ "_gen__")]] )
+                ])
+        in
+        [%expr [%e map], compile_acc__]
+      in
+      let body =
+        List.fold_right variants ~init:result ~f:(fun variant acc ->
+            let variant_name = variant_name_to_string variant.V.name in
+            pexp_let
+              ~loc
+              Nonrecursive
+              [ value_binding
+                  ~loc
+                  ~pat:
+                    (ppat_tuple
+                       ~loc
+                       [ [%pat? [%p pvar ~loc (variant_name ^ "_gen__")]]
+                       ; [%pat? compile_acc__]
+                       ])
+                  ~expr:
+                    [%expr
+                      [%e evar ~loc (variant_name ^ "_fun__")]
+                        [%e evar ~loc variant_name]
+                        compile_acc__]
+              ]
+              acc)
+      in
+      let patterns =
+        List.map variants ~f:(fun v ->
+            label_arg_fun loc (variant_name_to_string v.V.name))
+      in
+      let lambda =
+        Create.lambda loc (patterns @ [ Nolabel, [%pat? compile_acc__] ]) body
+      in
+      Some [%stri let make_matcher = [%e lambda]])
+  ;;
+
+  let case_analysis_ignoring_values variants ~f =
+    let pattern_and_rhs =
+      List.mapi variants ~f:(fun rank v ->
+          Variant_constructor.pattern_without_binding v, f ~rank ~name:v.name)
+    in
+    List.map pattern_and_rhs ~f:(fun (pattern, rhs) -> case ~guard:None ~lhs:pattern ~rhs)
+  ;;
+
+  let v_to_rank loc variants ~variant_ty =
+    let cases =
+      case_analysis_ignoring_values variants ~f:(fun ~rank ~name:_ -> eint ~loc rank)
+    in
+    let body =
+      if List.exists variants ~f:Variant_constructor.is_gadt
+      then locally_abstract_match loc cases ~variant_ty
+      else pexp_function ~loc cases
+    in
+    [%stri let to_rank = [%e body]]
+  ;;
+
+  let v_to_name loc variants ~variant_ty =
+    let cases =
+      case_analysis_ignoring_values variants ~f:(fun ~rank:_ ~name -> estring ~loc name)
+    in
+    let body =
+      if List.exists variants ~f:Variant_constructor.is_gadt
+      then locally_abstract_match loc cases ~variant_ty
+      else pexp_function ~loc cases
+    in
+    [%stri let to_name = [%e body]]
+  ;;
+
+  let variant ~variant_name ~variant_ty loc ty =
+    let constructors, testers, getters, variants =
+      helpers_and_variants loc ~variant_ty ty
+    in
+    constructors
+    @ testers
+    @ getters
+    @ [ pstr_module
+          ~loc
+          (module_binding
+             ~loc
+             ~name:(Located.mk ~loc (Some (variants_module variant_name)))
+             ~expr:
+               (pmod_structure
+                  ~loc
+                  (variants
+                   @ List.filter_opt
+                     [ Some (v_fold_fun loc ty)
+                     ; Some (v_iter_fun loc ty)
+                     ; v_map_fun_opt loc ty
+                     ; v_make_matcher_fun_opt loc ty
+                     ; Some (v_to_rank loc ty ~variant_ty)
+                     ; Some (v_to_name loc ty ~variant_ty)
+                     ; Some (v_descriptions loc ty)
+                     ])))
+      ]
+  ;;
+
+  let variants_of_td td =
+    let variant_name = td.ptype_name.txt in
+    let loc = td.ptype_loc in
+    let variant_ty = core_type_of_type_declaration td in
+    variant ~variant_name ~variant_ty loc (Inspect.type_decl td)
+  ;;
+
+  let generate ~loc ~path:_ (rec_flag, tds) =
+    (match rec_flag with
+     | Nonrecursive ->
+       Location.raise_errorf
+         ~loc
+         "nonrec is not compatible with the `ppx_variants_conv' preprocessor"
+     | _ -> ());
+    match tds with
+    | [ td ] -> variants_of_td td
+    | _ -> Location.raise_errorf ~loc "ppx_variants_conv: not supported"
+  ;;
+end
+
+let variants =
+  Deriving.add
+    "variants"
+    ~str_type_decl:(Deriving.Generator.make_noarg Gen_str.generate)
+    ~sig_type_decl:(Deriving.Generator.make_noarg Gen_sig.generate)
+;;

--- a/src/ppx_variants_conv/ppx_variants_conv.mli
+++ b/src/ppx_variants_conv/ppx_variants_conv.mli
@@ -1,0 +1,3 @@
+open Ppxlib
+
+val variants : Deriving.t


### PR DESCRIPTION
This is a nice first step. We circumvent https://github.com/janestreet/ppx_variants_conv/issues/14 by vendoring `ppx_variants_conv` in ae2da82c60a9f0f59ff6424bb6054ef8dd99dea9 and tinkering with it in 0c8fbea41be4a2e2c751a649a1c0a0860c6a550a.

It would also be nice if `ppx_variants_conv` were able to produce signatures. This is tracked in https://github.com/janestreet/ppx_variants_conv/issues/15.