### PR TITLE
Environment for `ppx_variants_conv`

### DIFF
--- a/dancelor.opam
+++ b/dancelor.opam
@@ -34,6 +34,7 @@ depends: [
   "ppx_monad" {build & >= "0.2.0"}
   "qcheck"
   "qcheck-alcotest" {with-test}
+  "variantslib"
   "slug"
   "yaml"
   "yojson" {>= "1.6.0"}

--- a/dune-project
+++ b/dune-project
@@ -40,6 +40,7 @@
   (ppx_monad           (and :build (>= 0.2.0)))
    qcheck
   (qcheck-alcotest      :with-test)
+   variantslib
    slug
    yaml
   (yojson              (>= 1.6.0))))


### PR DESCRIPTION
Fix error introduced in https://github.com/paris-branch/dancelor/pull/331 and that slipped away because of the temporarily broken OPAM CI.