### PR TITLE
Cleaner GC dependencies management

### DIFF
--- a/src/client/main.ml
+++ b/src/client/main.ml
@@ -113,12 +113,6 @@ let dispatch url =
   | DanceAdd -> DanceEditor.create ()
   | Dance {slug; context} -> DanceViewer.create slug ?context
 
-(** Used by {!on_load} to avoid garbage-collection of the iterators that store
-    the state in the local storage. This is inspired by {!S.keep}, except
-    {!S.keep} does not seem to work in our context and introduces a memory
-    leak. *)
-let gc_roots = ref []
-
 let set_title title =
   Dom_html.document##.title := Js.string @@ match title with
     | "" -> "Dancelor"
@@ -127,7 +121,7 @@ let set_title title =
 let on_load _ev =
   let page = dispatch @@ Uri.of_string (Js.to_string Dom_html.window##.location##.href) in
   let iter_title = React.S.map set_title (Page.get_title page) in
-  gc_roots := iter_title :: !gc_roots;
+  Depart.keep_forever iter_title;
   Dom.appendChild Dom_html.document##.body (To_dom.of_header header);
   let content = To_dom.of_div (Page.get_content page) in
   content##.classList##add (Js.string "content");

--- a/src/nes/nes.ml
+++ b/src/nes/nes.ml
@@ -19,6 +19,7 @@ module Result = NesResult
 module Cache = NesCache
 module Date = NesDate
 module Datetime = NesDatetime
+module Depart = NesDepart
 module PartialDate = NesPartialDate
 module Filesystem = NesFilesystem
 module Json = NesJson

--- a/src/nes/nesDepart.ml
+++ b/src/nes/nesDepart.ml
@@ -1,0 +1,18 @@
+let next_key = ref 0
+let gc_roots = ref []
+
+let keep value =
+  let key = !next_key in
+  incr next_key;
+  gc_roots := (key, Obj.magic value) :: !gc_roots;
+  key
+
+let free key =
+  gc_roots := List.remove_assq key !gc_roots
+
+let depends ~on value =
+  let key = keep value in
+  Gc.finalise_last (fun () -> free key) on
+
+let keep_forever value =
+  ignore (keep value)

--- a/src/nes/nesDepart.mli
+++ b/src/nes/nesDepart.mli
@@ -1,0 +1,11 @@
+(** {1 Depart — Artificial dependencies} *)
+
+val depends : on:'a -> 'b -> unit
+(** [depends ~on value] declares an artificial GC dependency from [value] on
+    [on]. [value] will not be garbage collected until [on] is. [value] may of
+    course outlive [on] if other other objects depend on it, artificially or
+    not. *)
+
+val keep_forever : 'a -> unit
+(** [keep_forever value] declares an artificial GC dependency from [value] on
+    the global root set. [value] will never be garbage collected. *)


### PR DESCRIPTION
Replace the previous hack of `gc_roots` by a clean module that does that and
documents what it does.