### PR TITLE
One-to-one correspondence of endpoints and controllers

### DIFF
--- a/src/client/components/contextLinks.ml
+++ b/src/client/components/contextLinks.ml
@@ -16,9 +16,8 @@ let book_page_to_any = function
 let get_neighbours any = function
   | PageRouter.InSearch query ->
     (* TODO: Unify with [Explorer.search]. *)
-    let threshold = 0.4 in
     let filter = Result.get_ok (Any.Filter.from_string query) in
-    let%lwt (total, previous, index, next) = Any.search_context ~threshold filter any in
+    let%lwt (total, previous, index, next) = Any.search_context filter any in
     Lwt.return List.{total; previous; index; next; element = any}
   | PageRouter.InSet (set, index) ->
     let%lwt set = Set.get set in

--- a/src/client/model/any/any.ml
+++ b/src/client/model/any/any.ml
@@ -1,14 +1,10 @@
+open Nes
 open Dancelor_common
+
 include AnyLifted
 
-let search ?slice ?threshold filter =
-  Madge_cohttp_lwt_client.call ApiRouter.(route @@ Any Search) slice threshold filter
+let search = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Any Search)
+let search' = Lwt.map snd % search Model.Slice.everything
+let count = Lwt.map fst % search Model.Slice.nothing
 
-let search' ?slice ?threshold filter =
-  Lwt.map snd @@ search ?slice ?threshold filter
-
-let count ?threshold filter =
-  Lwt.map fst @@ search ?threshold filter
-
-let search_context ?threshold filter element =
-  Madge_cohttp_lwt_client.call ApiRouter.(route @@ Any SearchContext) threshold filter element
+let search_context = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Any SearchContext)

--- a/src/client/model/book/book.ml
+++ b/src/client/model/book/book.ml
@@ -1,15 +1,12 @@
+open Nes
 open Dancelor_common
+
 include BookLifted
 
 let create = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Book Create)
 let update = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Book Update)
 let save ?slug = match slug with None -> create | Some slug -> update slug
 
-let search ?slice ?threshold filter =
-  Madge_cohttp_lwt_client.call ApiRouter.(route @@ Book Search) slice threshold filter
-
-let search' ?slice ?threshold filter =
-  Lwt.map snd @@ search ?slice ?threshold filter
-
-let count ?threshold filter =
-  Lwt.map fst @@ search ?threshold filter
+let search = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Book Search)
+let search' = Lwt.map snd % search Model.Slice.everything
+let count = Lwt.map fst % search Model.Slice.nothing

--- a/src/client/model/dance/dance.ml
+++ b/src/client/model/dance/dance.ml
@@ -1,15 +1,12 @@
+open Nes
 open Dancelor_common
+
 include DanceLifted
 
 let create = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Dance Create)
 let update = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Dance Update)
 let save ?slug = match slug with None -> create | Some slug -> update slug
 
-let search ?slice ?threshold filter =
-  Madge_cohttp_lwt_client.call ApiRouter.(route @@ Dance Search) slice threshold filter
-
-let search' ?slice ?threshold filter =
-  Lwt.map snd @@ search ?slice ?threshold filter
-
-let count ?threshold filter =
-  Lwt.map fst @@ search ?threshold filter
+let search = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Dance Search)
+let search' = Lwt.map snd % search Model.Slice.everything
+let count = Lwt.map fst % search Model.Slice.nothing

--- a/src/client/model/person/person.ml
+++ b/src/client/model/person/person.ml
@@ -1,15 +1,12 @@
+open Nes
 open Dancelor_common
+
 include PersonLifted
 
 let create = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Person Create)
 let update = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Person Update)
 let save ?slug = match slug with None -> create | Some slug -> update slug
 
-let search ?slice ?threshold filter =
-  Madge_cohttp_lwt_client.call ApiRouter.(route @@ Person Search) slice threshold filter
-
-let search' ?slice ?threshold filter =
-  Lwt.map snd @@ search ?slice ?threshold filter
-
-let count ?threshold filter =
-  Lwt.map fst @@ search ?threshold filter
+let search = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Person Search)
+let search' = Lwt.map snd % search Model.Slice.everything
+let count = Lwt.map fst % search Model.Slice.nothing

--- a/src/client/model/set/set.ml
+++ b/src/client/model/set/set.ml
@@ -1,4 +1,6 @@
+open Nes
 open Dancelor_common
+
 include SetLifted
 
 let create = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Set Create)
@@ -7,11 +9,6 @@ let save ?slug = match slug with None -> create | Some slug -> update slug
 
 let delete s = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Set Delete) (Database.Entry.slug s)
 
-let search ?slice ?threshold filter =
-  Madge_cohttp_lwt_client.call ApiRouter.(route @@ Set Search) slice threshold filter
-
-let search' ?slice ?threshold filter =
-  Lwt.map snd @@ search ?slice ?threshold filter
-
-let count ?threshold filter =
-  Lwt.map fst @@ search ?threshold filter
+let search = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Set Search)
+let search' = Lwt.map snd % search Model.Slice.everything
+let count = Lwt.map fst % search Model.Slice.nothing

--- a/src/client/model/tune/tune.ml
+++ b/src/client/model/tune/tune.ml
@@ -1,15 +1,12 @@
+open Nes
 open Dancelor_common
+
 include TuneLifted
 
 let create = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Tune Create)
 let update = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Tune Update)
 let save ?slug = match slug with None -> create | Some slug -> update slug
 
-let search ?slice ?threshold filter =
-  Madge_cohttp_lwt_client.call ApiRouter.(route @@ Tune Search) slice threshold filter
-
-let search' ?slice ?threshold filter =
-  Lwt.map snd @@ search ?slice ?threshold filter
-
-let count ?threshold filter =
-  Lwt.map fst @@ search ?threshold filter
+let search = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Tune Search)
+let search' = Lwt.map snd % search Model.Slice.everything
+let count = Lwt.map fst % search Model.Slice.nothing

--- a/src/client/model/version/version.ml
+++ b/src/client/model/version/version.ml
@@ -1,16 +1,12 @@
 open Nes
 open Dancelor_common
+
 include VersionLifted
 
 let create = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Version Create)
 let update = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Version Update)
 let save ?slug = match slug with None -> create | Some slug -> update slug
 
-let search ?slice ?threshold filter =
-  Madge_cohttp_lwt_client.call ApiRouter.(route @@ Version Search) slice threshold filter
-
-let search' ?slice ?threshold filter =
-  Lwt.map snd @@ search ?slice ?threshold filter
-
-let count ?threshold filter =
-  Lwt.map fst @@ search ?threshold filter
+let search = Madge_cohttp_lwt_client.call ApiRouter.(route @@ Version Search)
+let search' = Lwt.map snd % search Model.Slice.everything
+let count = Lwt.map fst % search Model.Slice.nothing

--- a/src/client/views/book/bookDownloadDialog.ml
+++ b/src/client/views/book/bookDownloadDialog.ml
@@ -8,7 +8,7 @@ open Dancelor_client_components
    factorisation here. *)
 type t = {
   choice_rows: Html_types.tr elt list;
-  parameters_signal: BookParameters.t option React.signal;
+  parameters_signal: BookParameters.t React.signal;
 }
 
 let lift_set_parameters every_set =
@@ -41,12 +41,12 @@ let create () =
         tr [td [label [txt "Mode:"]]; td [Choices.render booklet_choices]]
       ]
     );
-    parameters_signal =
+    parameters_signal = S.map (Option.value ~default: BookParameters.none) @@
       S.merge
         (Option.concat BookParameters.compose)
         None
         [
-          S.map (Option.map lift_set_parameters) set_dialog.parameters_signal;
+          S.map (Option.some % lift_set_parameters) set_dialog.parameters_signal;
           Choices.signal booklet_choices;
         ]
   }

--- a/src/client/views/book/bookEditor.ml
+++ b/src/client/views/book/bookEditor.ml
@@ -115,9 +115,8 @@ module Editor = struct
       Selector.make
         ~arity: Selector.many
         ~search: (fun slice input ->
-            let threshold = 0.4 in
             let%rlwt filter = Lwt.return (Model.Set.Filter.from_string input) in
-            Lwt.map Result.ok @@ Model.Set.search ~threshold ~slice filter
+            Lwt.map Result.ok @@ Model.Set.search slice filter
           )
         ~serialise: Database.Entry.slug
         ~unserialise: Model.Set.get

--- a/src/client/views/dance/danceEditor.ml
+++ b/src/client/views/dance/danceEditor.ml
@@ -98,9 +98,8 @@ module Editor = struct
       Selector.make
         ~arity: Selector.many
         ~search: (fun slice input ->
-            let threshold = 0.4 in
             let%rlwt filter = Lwt.return (Model.Person.Filter.from_string input) in
-            Lwt.map Result.ok @@ Model.Person.search ~threshold ~slice filter
+            Lwt.map Result.ok @@ Model.Person.search slice filter
           )
         ~serialise: Database.Entry.slug
         ~unserialise: Model.Person.get

--- a/src/client/views/explorer.ml
+++ b/src/client/views/explorer.ml
@@ -15,10 +15,9 @@ let update_uri input =
     (Js.string "")
     (Js.some (Js.string uri))
 
-let search ?slice input =
-  let threshold = 0.4 in
+let search slice input =
   let%rlwt filter = Lwt.return (Any.Filter.from_string input) in
-  Lwt.map Result.ok @@ Any.search ~threshold ?slice filter
+  Lwt.map Result.ok @@ Any.search slice filter
 
 (** Generic row showing an emoji on the left and a message on the right. *)
 let emoji_row emoji message =
@@ -37,7 +36,7 @@ let create ?query () =
   in
   let search_bar =
     SearchBar.make
-      ~search: (fun slice input -> search ~slice input)
+      ~search
       ~slice: (Pagination.slice pagination)
       ~on_number_of_entries: (set_number_of_entries % Option.some)
       ?initial_input: query

--- a/src/client/views/set/setDownloadDialog.ml
+++ b/src/client/views/set/setDownloadDialog.ml
@@ -8,7 +8,7 @@ open Dancelor_client_components
    factorisation here. *)
 type t = {
   choice_rows: Html_types.tr elt list;
-  parameters_signal: SetParameters.t option React.signal;
+  parameters_signal: SetParameters.t React.signal;
 }
 
 let lift_version_parameters every_version =
@@ -18,12 +18,12 @@ let create () =
   let version_dialog = VersionDownloadDialog.create () in
   {
     choice_rows = version_dialog.choice_rows;
-    parameters_signal =
+    parameters_signal = S.map (Option.value ~default: SetParameters.none) @@
       S.merge
         (Option.concat SetParameters.compose)
         None
         [
-          S.map (Option.map lift_version_parameters) version_dialog.parameters_signal;
+          S.map (Option.some % lift_version_parameters) version_dialog.parameters_signal;
           (* feels a bit silly at this point but will make more sense once we have set-specific options *)
         ];
   }

--- a/src/client/views/set/setEditor.ml
+++ b/src/client/views/set/setEditor.ml
@@ -92,9 +92,8 @@ module Editor = struct
       Selector.make
         ~arity: Selector.many
         ~search: (fun slice input ->
-            let threshold = 0.4 in
             let%rlwt filter = Lwt.return (Model.Person.Filter.from_string input) in
-            Lwt.map Result.ok @@ Model.Person.search ~threshold ~slice filter
+            Lwt.map Result.ok @@ Model.Person.search slice filter
           )
         ~serialise: Database.Entry.slug
         ~unserialise: Model.Person.get
@@ -104,9 +103,8 @@ module Editor = struct
       Selector.make
         ~arity: Selector.many
         ~search: (fun slice input ->
-            let threshold = 0.4 in
             let%rlwt filter = Lwt.return (Model.Version.Filter.from_string input) in
-            Lwt.map Result.ok @@ Model.Version.search ~threshold ~slice filter
+            Lwt.map Result.ok @@ Model.Version.search slice filter
           )
         ~serialise: Database.Entry.slug
         ~unserialise: Model.Version.get

--- a/src/client/views/set/setEditor.ml
+++ b/src/client/views/set/setEditor.ml
@@ -183,7 +183,7 @@ let create ?on_save ?text () =
                             object_
                               ~a: [
                                 a_mime_type "image/svg+xml";
-                                a_data (ApiRouter.(href @@ Version Svg) None (Database.Entry.slug version));
+                                a_data (ApiRouter.(href @@ Version Svg) Model.VersionParameters.none (Database.Entry.slug version));
                               ]
                               [];
                           ]

--- a/src/client/views/set/setViewer.ml
+++ b/src/client/views/set/setViewer.ml
@@ -89,7 +89,7 @@ let create ?context slug =
                            object_
                              ~a: [
                                a_mime_type "image/svg+xml";
-                               a_data (ApiRouter.(href @@ Version Svg) None slug);
+                               a_data (ApiRouter.(href @@ Version Svg) Model.VersionParameters.none slug);
                              ]
                              [];
                          ]

--- a/src/client/views/tune/tuneEditor.ml
+++ b/src/client/views/tune/tuneEditor.ml
@@ -97,9 +97,8 @@ module Editor = struct
       Selector.make
         ~arity: Selector.many
         ~search: (fun slice input ->
-            let threshold = 0.4 in
             let%rlwt filter = Lwt.return (Model.Person.Filter.from_string input) in
-            Lwt.map Result.ok @@ Model.Person.search ~threshold ~slice filter
+            Lwt.map Result.ok @@ Model.Person.search slice filter
           )
         ~serialise: Database.Entry.slug
         ~unserialise: Model.Person.get
@@ -116,9 +115,8 @@ module Editor = struct
       Selector.make
         ~arity: Selector.many
         ~search: (fun slice input ->
-            let threshold = 0.4 in
             let%rlwt filter = Lwt.return (Model.Dance.Filter.from_string input) in
-            Lwt.map Result.ok @@ Model.Dance.search ~threshold ~slice filter
+            Lwt.map Result.ok @@ Model.Dance.search slice filter
           )
         ~serialise: Database.Entry.slug
         ~unserialise: Model.Dance.get

--- a/src/client/views/version/versionDownloadDialog.ml
+++ b/src/client/views/version/versionDownloadDialog.ml
@@ -6,7 +6,7 @@ open Dancelor_client_components
 
 type t = {
   choice_rows: Html_types.tr elt list;
-  parameters_signal: VersionParameters.t option React.signal;
+  parameters_signal: VersionParameters.t React.signal;
 }
 
 let create () =
@@ -38,6 +38,7 @@ let create () =
 
   (* A signal containing the composition of all the parameters. *)
   let parameters_signal =
+    S.map (Option.value ~default: VersionParameters.none) @@
     S.merge
       (Option.concat VersionParameters.compose)
       None

--- a/src/client/views/version/versionEditor.ml
+++ b/src/client/views/version/versionEditor.ml
@@ -92,9 +92,8 @@ module Editor = struct
       Selector.make
         ~arity: Selector.one
         ~search: (fun slice input ->
-            let threshold = 0.4 in
             let%rlwt filter = Lwt.return (Model.Tune.Filter.from_string input) in
-            Lwt.map Result.ok @@ Model.Tune.search ~threshold ~slice filter
+            Lwt.map Result.ok @@ Model.Tune.search slice filter
           )
         ~has_interacted
         ~serialise: Database.Entry.slug
@@ -114,9 +113,8 @@ module Editor = struct
       Selector.make
         ~arity: Selector.many
         ~search: (fun slice input ->
-            let threshold = 0.4 in
             let%rlwt filter = Lwt.return (Model.Person.Filter.from_string input) in
-            Lwt.map Result.ok @@ Model.Person.search ~threshold ~slice filter
+            Lwt.map Result.ok @@ Model.Person.search slice filter
           )
         ~serialise: Database.Entry.slug
         ~unserialise: Model.Person.get

--- a/src/client/views/version/versionViewer.ml
+++ b/src/client/views/version/versionViewer.ml
@@ -112,7 +112,7 @@ let create ?context slug =
               object_
                 ~a: [
                   a_mime_type "image/svg+xml";
-                  a_data (ApiRouter.(href @@ Version Svg) None slug)
+                  a_data (ApiRouter.(href @@ Version Svg) Model.VersionParameters.none slug)
                 ]
                 [];
             ]
@@ -122,7 +122,7 @@ let create ?context slug =
         [
           audio
             ~a: [a_controls ()]
-            ~src: (ApiRouter.(href @@ Version Ogg) slug)
+            ~src: (ApiRouter.(href @@ Version Ogg) Model.VersionParameters.none slug)
             []
         ];
       Utils.quick_explorer_links

--- a/src/common/model/any/anyEndpoints.ml
+++ b/src/common/model/any/anyEndpoints.ml
@@ -2,13 +2,13 @@ open Nes
 open Madge
 
 type (_, _, _) t =
-  | Search : ((Slice.t option -> float option -> AnyCore.Filter.t -> 'w), 'w, (int * AnyCore.t list)) t
-  | SearchContext : ((float option -> AnyCore.Filter.t -> AnyCore.t -> 'w), 'w, (int * AnyCore.t option * int * AnyCore.t option)) t
+  | Search : ((Slice.t -> AnyCore.Filter.t -> 'w), 'w, (int * AnyCore.t list)) t
+  | SearchContext : ((AnyCore.Filter.t -> AnyCore.t -> 'w), 'w, (int * AnyCore.t option * int * AnyCore.t option)) t
 
 (* FIXME: make a simple PPX for the following *)
 type wrapped = W : ('a, 'r Lwt.t, 'r) t -> wrapped
 let all = [W Search; W SearchContext]
 
 let route : type a w r. (a, w, r) t -> (a, w, r) route = function
-  | Search -> literal "search" @@ query_opt "slice" (module Slice) @@ query_opt "threshold" (module JFloat) @@ query "filter" (module AnyCore.Filter) @@ return (module JPair(JInt)(JList(AnyCore)))
-  | SearchContext -> literal "search-context" @@ query_opt "threshold" (module JFloat) @@ query "filter" (module AnyCore.Filter) @@ query "element" (module AnyCore) @@ return (module JQuad(JInt)(JOption(AnyCore))(JInt)(JOption(AnyCore)))
+  | Search -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module AnyCore.Filter) @@ return (module JPair(JInt)(JList(AnyCore)))
+  | SearchContext -> literal "search-context" @@ query "filter" (module AnyCore.Filter) @@ query "element" (module AnyCore) @@ return (module JQuad(JInt)(JOption(AnyCore))(JInt)(JOption(AnyCore)))

--- a/src/common/model/any/anySignature.mli
+++ b/src/common/model/any/anySignature.mli
@@ -152,35 +152,20 @@ end
 
 (** {2 Search} *)
 
-val search :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  (int * t list) Lwt.t
-(** [search ?slice ?threshold filter] returns the list of all the objects
-    that match [filter] with a score higher than [threshold] (if any). The first
-    element of the pair is the number of objects. The second element of the pair
-    is a slice of the list, taken as per the [slice] (if any). *)
+val search : Slice.t -> Filter.t -> (int * t list) Lwt.t
+(** Returns the list of all the objects that match the filter with a score
+    higher than the hardcoded threshold. The first element of the pair is the
+    number of objects. The second element of the pair is a slice of the list,
+    taken as per the slice. *)
 
-val search' :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  t list Lwt.t
-(** Like {!val-search} but returns only the list. *)
+val search' : Filter.t -> t list Lwt.t
+(** Like {!val-search} but returns only the list of all values. *)
 
-val search_context :
-  ?threshold: float ->
-  Filter.t ->
-  t ->
-  (int * t option * int * t option) Lwt.t
-(** [search_context ?threshold filter elt] is equivalent to running [search
-    ?threshold filter], looking for [elt] in the resulting list and returning
-    the total number of elements, the element before [elt], the index of [elt],
-    and the element after [elt], but it does this much more efficiently. *)
-
-val count :
-  ?threshold: float ->
-  Filter.t ->
-  int Lwt.t
+val count : Filter.t -> int Lwt.t
 (** Like {!val-search} but returns only the number of items. *)
+
+val search_context : Filter.t -> t -> (int * t option * int * t option) Lwt.t
+(** [search_context filter elt] is equivalent to running [search filter],
+    looking for [elt] in the resulting list and returning the total number of
+    elements, the element before [elt], the index of [elt], and the element
+    after [elt], but it does this much more efficiently. *)

--- a/src/common/model/book/bookEndpoints.ml
+++ b/src/common/model/book/bookEndpoints.ml
@@ -4,7 +4,7 @@ open Dancelor_common_database
 
 type (_, _, _) t =
   | Get : ((BookCore.t Slug.t -> 'w), 'w, BookCore.t Entry.t) t
-  | Search : ((Slice.t option -> float option -> BookCore.Filter.t -> 'w), 'w, (int * BookCore.t Entry.t list)) t
+  | Search : ((Slice.t -> BookCore.Filter.t -> 'w), 'w, (int * BookCore.t Entry.t list)) t
   | Create : ((BookCore.t -> 'w), 'w, BookCore.t Entry.t) t
   | Update : ((BookCore.t Slug.t -> BookCore.t -> 'w), 'w, BookCore.t Entry.t) t
   | Pdf : ((BookParameters.t option -> BookCore.t Slug.t -> 'w), 'w, Void.t) t
@@ -16,6 +16,6 @@ let all = [W Get; W Search; W Create; W Update; W Pdf]
 let route : type a w r. (a, w, r) t -> (a, w, r) route = function
   | Get -> literal "get" @@ variable (module SSlug(BookCore)) @@ return (module Entry.J(BookCore))
   | Pdf -> literal "pdf" @@ query_opt "parameters" (module BookParameters) @@ variable (module SSlug(BookCore)) @@ return (module JVoid)
-  | Search -> literal "search" @@ query_opt "slice" (module Slice) @@ query_opt "threshold" (module JFloat) @@ query "filter" (module BookCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(BookCore))))
+  | Search -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module BookCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(BookCore))))
   | Create -> literal "create" @@ query "book" (module BookCore) @@ return (module Entry.J(BookCore))
   | Update -> literal "update" @@ variable (module SSlug(BookCore)) @@ query "book" (module BookCore) @@ return (module Entry.J(BookCore))

--- a/src/common/model/book/bookEndpoints.ml
+++ b/src/common/model/book/bookEndpoints.ml
@@ -7,7 +7,7 @@ type (_, _, _) t =
   | Search : ((Slice.t -> BookCore.Filter.t -> 'w), 'w, (int * BookCore.t Entry.t list)) t
   | Create : ((BookCore.t -> 'w), 'w, BookCore.t Entry.t) t
   | Update : ((BookCore.t Slug.t -> BookCore.t -> 'w), 'w, BookCore.t Entry.t) t
-  | Pdf : ((BookParameters.t option -> BookCore.t Slug.t -> 'w), 'w, Void.t) t
+  | Pdf : ((BookParameters.t -> BookCore.t Slug.t -> 'w), 'w, Void.t) t
 
 (* FIXME: make a simple PPX for the following *)
 type wrapped = W : ('a, 'r Lwt.t, 'r) t -> wrapped
@@ -15,7 +15,7 @@ let all = [W Get; W Search; W Create; W Update; W Pdf]
 
 let route : type a w r. (a, w, r) t -> (a, w, r) route = function
   | Get -> literal "get" @@ variable (module SSlug(BookCore)) @@ return (module Entry.J(BookCore))
-  | Pdf -> literal "pdf" @@ query_opt "parameters" (module BookParameters) @@ variable (module SSlug(BookCore)) @@ return (module JVoid)
+  | Pdf -> literal "pdf" @@ query "parameters" (module BookParameters) @@ variable (module SSlug(BookCore)) @@ return (module JVoid)
   | Search -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module BookCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(BookCore))))
   | Create -> literal "create" @@ query "book" (module BookCore) @@ return (module Entry.J(BookCore))
   | Update -> literal "update" @@ variable (module SSlug(BookCore)) @@ query "book" (module BookCore) @@ return (module Entry.J(BookCore))

--- a/src/common/model/book/bookSignature.mli
+++ b/src/common/model/book/bookSignature.mli
@@ -137,27 +137,16 @@ val update : t Slug.t -> t -> t Entry.t Lwt.t
 val save : ?slug: t Slug.t -> t -> t Entry.t Lwt.t
 (** Either {!create} or {!update}. *)
 
-val search :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  (int * t Entry.t list) Lwt.t
-(** [search ?slice ?threshold filter] returns the list of all the books
-    that match [filter] with a score higher than [threshold] (if any). The first
-    element of the pair is the number of books. The second element of the pair
-    is a slice of the list, taken as per the [slice] (if any). *)
+val search : Slice.t -> Filter.t -> (int * t Entry.t list) Lwt.t
+(** Returns the list of all the books that match the filter with a score higher
+    than the hardcoded threshold. The first element of the pair is the number of
+    books. The second element of the pair is a slice of the list, taken as per
+    the slice. *)
 
-val search' :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  t Entry.t list Lwt.t
-(** Like {!search} but returns only the list. *)
+val search' : Filter.t -> t Entry.t list Lwt.t
+(** Like {!search} but returns only the list of all values. *)
 
-val count :
-  ?threshold: float ->
-  Filter.t ->
-  int Lwt.t
+val count : Filter.t -> int Lwt.t
 (** Like {!search} but returns only the number of items. *)
 
 val page_core_to_page : BookCore.PageCore.t -> page Lwt.t

--- a/src/common/model/dance/danceEndpoints.ml
+++ b/src/common/model/dance/danceEndpoints.ml
@@ -7,7 +7,7 @@ type (_, _, _) t =
   | Search : ((Slice.t -> DanceCore.Filter.t -> 'w), 'w, (int * DanceCore.t Entry.t list)) t
   | Create : ((DanceCore.t -> 'w), 'w, DanceCore.t Entry.t) t
   | Update : ((DanceCore.t Slug.t -> DanceCore.t -> 'w), 'w, DanceCore.t Entry.t) t
-  | Pdf : ((SetParameters.t option -> DanceCore.t Slug.t -> 'w), 'w, Void.t) t
+  | Pdf : ((SetParameters.t -> DanceCore.t Slug.t -> 'w), 'w, Void.t) t
 
 (* FIXME: make a simple PPX for the following *)
 type wrapped = W : ('a, 'r Lwt.t, 'r) t -> wrapped
@@ -15,7 +15,7 @@ let all = [W Get; W Search; W Create; W Update; W Pdf]
 
 let route : type a w r. (a, w, r) t -> (a, w, r) route = function
   | Get -> literal "get" @@ variable (module SSlug(DanceCore)) @@ return (module Entry.J(DanceCore))
-  | Pdf -> literal "pdf" @@ query_opt "parameters" (module SetParameters) @@ variable (module SSlug(DanceCore)) @@ return (module JVoid)
+  | Pdf -> literal "pdf" @@ query "parameters" (module SetParameters) @@ variable (module SSlug(DanceCore)) @@ return (module JVoid)
   | Search -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module DanceCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(DanceCore))))
   | Create -> literal "create" @@ query "dance" (module DanceCore) @@ return (module Entry.J(DanceCore))
   | Update -> literal "update" @@ variable (module SSlug(DanceCore)) @@ query "dance" (module DanceCore) @@ return (module Entry.J(DanceCore))

--- a/src/common/model/dance/danceEndpoints.ml
+++ b/src/common/model/dance/danceEndpoints.ml
@@ -4,7 +4,7 @@ open Dancelor_common_database
 
 type (_, _, _) t =
   | Get : ((DanceCore.t Slug.t -> 'w), 'w, DanceCore.t Entry.t) t
-  | Search : ((Slice.t option -> float option -> DanceCore.Filter.t -> 'w), 'w, (int * DanceCore.t Entry.t list)) t
+  | Search : ((Slice.t -> DanceCore.Filter.t -> 'w), 'w, (int * DanceCore.t Entry.t list)) t
   | Create : ((DanceCore.t -> 'w), 'w, DanceCore.t Entry.t) t
   | Update : ((DanceCore.t Slug.t -> DanceCore.t -> 'w), 'w, DanceCore.t Entry.t) t
   | Pdf : ((SetParameters.t option -> DanceCore.t Slug.t -> 'w), 'w, Void.t) t
@@ -16,6 +16,6 @@ let all = [W Get; W Search; W Create; W Update; W Pdf]
 let route : type a w r. (a, w, r) t -> (a, w, r) route = function
   | Get -> literal "get" @@ variable (module SSlug(DanceCore)) @@ return (module Entry.J(DanceCore))
   | Pdf -> literal "pdf" @@ query_opt "parameters" (module SetParameters) @@ variable (module SSlug(DanceCore)) @@ return (module JVoid)
-  | Search -> literal "search" @@ query_opt "slice" (module Slice) @@ query_opt "threshold" (module JFloat) @@ query "filter" (module DanceCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(DanceCore))))
+  | Search -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module DanceCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(DanceCore))))
   | Create -> literal "create" @@ query "dance" (module DanceCore) @@ return (module Entry.J(DanceCore))
   | Update -> literal "update" @@ variable (module SSlug(DanceCore)) @@ query "dance" (module DanceCore) @@ return (module Entry.J(DanceCore))

--- a/src/common/model/dance/danceSignature.mli
+++ b/src/common/model/dance/danceSignature.mli
@@ -67,25 +67,14 @@ val update : t Slug.t -> t -> t Entry.t Lwt.t
 val save : ?slug: t Slug.t -> t -> t Entry.t Lwt.t
 (** Either {!create} or {!update}. *)
 
-val search :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  (int * t Entry.t list) Lwt.t
-(** [search ?slice ?threshold filter] returns the list of all the dances
-    that match [filter] with a score higher than [threshold] (if any). The first
-    element of the pair is the number of dances. The second element of the pair
-    is a slice of the list, taken as per the [slice] (if any). *)
+val search : Slice.t -> Filter.t -> (int * t Entry.t list) Lwt.t
+(** Returns the list of all the dances that match the filter with a score higher
+    than the hardcoded threshold. The first element of the pair is the number of
+    dances. The second element of the pair is a slice of the list, taken as per
+    the slice. *)
 
-val search' :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  t Entry.t list Lwt.t
-(** Like {!search} but returns only the list. *)
+val search' : Filter.t -> t Entry.t list Lwt.t
+(** Like {!search} but returns only the list of all values. *)
 
-val count :
-  ?threshold: float ->
-  Filter.t ->
-  int Lwt.t
+val count : Filter.t -> int Lwt.t
 (** Like {!search} but returns only the number of items. *)

--- a/src/common/model/dancelor_common_model.ml
+++ b/src/common/model/dancelor_common_model.ml
@@ -54,6 +54,7 @@ module Slice = Slice
 module Transposition = Transposition
 module IssueReport = IssueReport
 module Kind = Kind
+module Search = Search
 
 module PersonCore = PersonCore
 module type PERSON = module type of PersonSignature

--- a/src/common/model/person/personEndpoints.ml
+++ b/src/common/model/person/personEndpoints.ml
@@ -4,7 +4,7 @@ open Dancelor_common_database
 
 type (_, _, _) t =
   | Get : ((PersonCore.t Slug.t -> 'w), 'w, PersonCore.t Entry.t) t
-  | Search : ((Slice.t option -> float option -> PersonCore.Filter.t -> 'w), 'w, (int * PersonCore.t Entry.t list)) t
+  | Search : ((Slice.t -> PersonCore.Filter.t -> 'w), 'w, (int * PersonCore.t Entry.t list)) t
   | Create : ((PersonCore.t -> 'w), 'w, PersonCore.t Entry.t) t
   | Update : ((PersonCore.t Slug.t -> PersonCore.t -> 'w), 'w, PersonCore.t Entry.t) t
 
@@ -13,6 +13,6 @@ let all = [W Get; W Search; W Create; W Update]
 
 let route : type a w r. (a, w, r) t -> (a, w, r) route = function
   | Get -> literal "get" @@ variable (module SSlug(PersonCore)) @@ return (module Entry.J(PersonCore))
-  | Search -> literal "search" @@ query_opt "slice" (module Slice) @@ query_opt "threshold" (module JFloat) @@ query "filter" (module PersonCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(PersonCore))))
+  | Search -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module PersonCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(PersonCore))))
   | Create -> literal "create" @@ query "person" (module PersonCore) @@ return (module Entry.J(PersonCore))
   | Update -> literal "update" @@ variable (module SSlug(PersonCore)) @@ query "person" (module PersonCore) @@ return (module Entry.J(PersonCore))

--- a/src/common/model/person/personSignature.mli
+++ b/src/common/model/person/personSignature.mli
@@ -57,25 +57,14 @@ val update : t Slug.t -> t -> t Entry.t Lwt.t
 val save : ?slug: t Slug.t -> t -> t Entry.t Lwt.t
 (** Either {!create} or {!update}. *)
 
-val search :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  (int * t Entry.t list) Lwt.t
-(** [search ?slice ?threshold filter] returns the list of all the persons
-    that match [filter] with a score higher than [threshold] (if any). The first
-    element of the pair is the number of persons. The second element of the pair
-    is a slice of the list, taken as per the [slice] (if any). *)
+val search : Slice.t -> Filter.t -> (int * t Entry.t list) Lwt.t
+(** Returns the list of all the persons that match the filter with a score
+    higher than the hardcoded threshold. The first element of the pair is the
+    number of persons. The second element of the pair is a slice of the list,
+    taken as per the slice. *)
 
-val search' :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  t Entry.t list Lwt.t
-(** Like {!search} but returns only the list. *)
+val search' : Filter.t -> t Entry.t list Lwt.t
+(** Like {!search} but returns only the list of all values. *)
 
-val count :
-  ?threshold: float ->
-  Filter.t ->
-  int Lwt.t
+val count : Filter.t -> int Lwt.t
 (** Like {!search} but returns only the number of items. *)

--- a/src/common/model/search.ml
+++ b/src/common/model/search.ml
@@ -31,5 +31,5 @@ let search
   Lwt.return
     (
       List.length results,
-      Option.fold ~none: Fun.id ~some: (Dancelor_common.Model.Slice.list ~strict: false) slice results
+      Option.fold ~none: Fun.id ~some: (Slice.list ~strict: false) slice results
     )

--- a/src/common/model/search.mli
+++ b/src/common/model/search.mli
@@ -17,10 +17,10 @@ module type S = sig
   type value
   type filter
 
-  val search : ?slice: Slice.t -> ?threshold: float -> filter -> (int * value list) Lwt.t
+  val search : Slice.t -> filter -> (int * value list) Lwt.t
 
-  val search' : ?slice: Slice.t -> ?threshold: float -> filter -> value list Lwt.t
-  val count : ?threshold: float -> filter -> int Lwt.t
+  val search' : filter -> value list Lwt.t
+  val count : filter -> int Lwt.t
 
   val tiebreakers : (value -> value -> int Lwt.t) list
 end

--- a/src/common/model/search.mli
+++ b/src/common/model/search.mli
@@ -1,9 +1,28 @@
-val search :
-  cache: (float * 'filter, 'value list Lwt.t) NesCache.t ->
-  values_getter: (unit -> 'value list Lwt.t) ->
-  scoring_function: ('filter -> 'value -> float Lwt.t) ->
-  tiebreakers: ('value -> 'value -> int Lwt.t) list ->
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  'filter ->
-  (int * 'value list) Lwt.t
+open Nes
+
+module type Searchable = sig
+  type value
+  type filter
+
+  val cache : (float * filter, value list Lwt.t) Cache.t
+
+  val get_all : unit -> value list Lwt.t
+
+  val filter_accepts : filter -> value -> float Lwt.t
+
+  val tiebreakers : (value -> value -> int Lwt.t) list
+end
+
+module type S = sig
+  type value
+  type filter
+
+  val search : ?slice: Slice.t -> ?threshold: float -> filter -> (int * value list) Lwt.t
+
+  val search' : ?slice: Slice.t -> ?threshold: float -> filter -> value list Lwt.t
+  val count : ?threshold: float -> filter -> int Lwt.t
+
+  val tiebreakers : (value -> value -> int Lwt.t) list
+end
+
+module Make : functor (M : Searchable) -> S with type value = M.value and type filter = M.filter

--- a/src/common/model/search.mli
+++ b/src/common/model/search.mli
@@ -1,5 +1,3 @@
-open Dancelor_common_model
-
 val search :
   cache: (float * 'filter, 'value list Lwt.t) NesCache.t ->
   values_getter: (unit -> 'value list Lwt.t) ->

--- a/src/common/model/set/setEndpoints.ml
+++ b/src/common/model/set/setEndpoints.ml
@@ -8,7 +8,7 @@ type (_, _, _) t =
   | Create : ((SetCore.t -> 'w), 'w, SetCore.t Entry.t) t
   | Update : ((SetCore.t Slug.t -> SetCore.t -> 'w), 'w, SetCore.t Entry.t) t
   | Delete : ((SetCore.t Slug.t -> 'w), 'w, unit) t
-  | Pdf : ((SetParameters.t option -> SetCore.t Slug.t -> 'w), 'w, Void.t) t
+  | Pdf : ((SetParameters.t -> SetCore.t Slug.t -> 'w), 'w, Void.t) t
 
 (* FIXME: make a simple PPX for the following *)
 type wrapped = W : ('a, 'r Lwt.t, 'r) t -> wrapped
@@ -20,4 +20,4 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route = function
   | Create -> literal "create" @@ query "set" (module SetCore) @@ return (module Entry.J(SetCore))
   | Update -> literal "update" @@ variable (module SSlug(SetCore)) @@ query "set" (module SetCore) @@ return (module Entry.J(SetCore))
   | Delete -> literal "delete" @@ variable (module SSlug(SetCore)) @@ return (module JUnit)
-  | Pdf -> literal "pdf" @@ query_opt "parameters" (module SetParameters) @@ variable (module SSlug(SetCore)) @@ return (module JVoid)
+  | Pdf -> literal "pdf" @@ query "parameters" (module SetParameters) @@ variable (module SSlug(SetCore)) @@ return (module JVoid)

--- a/src/common/model/set/setEndpoints.ml
+++ b/src/common/model/set/setEndpoints.ml
@@ -4,7 +4,7 @@ open Dancelor_common_database
 
 type (_, _, _) t =
   | Get : ((SetCore.t Slug.t -> 'w), 'w, SetCore.t Entry.t) t
-  | Search : ((Slice.t option -> float option -> SetCore.Filter.t -> 'w), 'w, (int * SetCore.t Entry.t list)) t
+  | Search : ((Slice.t -> SetCore.Filter.t -> 'w), 'w, (int * SetCore.t Entry.t list)) t
   | Create : ((SetCore.t -> 'w), 'w, SetCore.t Entry.t) t
   | Update : ((SetCore.t Slug.t -> SetCore.t -> 'w), 'w, SetCore.t Entry.t) t
   | Delete : ((SetCore.t Slug.t -> 'w), 'w, unit) t
@@ -16,7 +16,7 @@ let all = [W Get; W Search; W Create; W Update; W Delete; W Pdf]
 
 let route : type a w r. (a, w, r) t -> (a, w, r) route = function
   | Get -> literal "get" @@ variable (module SSlug(SetCore)) @@ return (module Entry.J(SetCore))
-  | Search -> literal "search" @@ query_opt "slice" (module Slice) @@ query_opt "threshold" (module JFloat) @@ query "filter" (module SetCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(SetCore))))
+  | Search -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module SetCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(SetCore))))
   | Create -> literal "create" @@ query "set" (module SetCore) @@ return (module Entry.J(SetCore))
   | Update -> literal "update" @@ variable (module SSlug(SetCore)) @@ query "set" (module SetCore) @@ return (module Entry.J(SetCore))
   | Delete -> literal "delete" @@ variable (module SSlug(SetCore)) @@ return (module JUnit)

--- a/src/common/model/set/setSignature.mli
+++ b/src/common/model/set/setSignature.mli
@@ -97,25 +97,14 @@ val save : ?slug: t Slug.t -> t -> t Entry.t Lwt.t
 
 val delete : t Entry.t -> unit Lwt.t
 
-val search :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  (int * t Entry.t list) Lwt.t
-(** [search ?slice ?threshold filter] returns the list of all the sets
-    that match [filter] with a score higher than [threshold] (if any). The first
-    element of the pair is the number of sets. The second element of the pair
-    is a slice of the list, taken as per the [slice] (if any). *)
+val search : Slice.t -> Filter.t -> (int * t Entry.t list) Lwt.t
+(** Returns the list of all the sets that match the filter with a score higher
+    than the hardcoded threshold. The first element of the pair is the number of
+    sets. The second element of the pair is a slice of the list, taken as per
+    the slice. *)
 
-val search' :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  t Entry.t list Lwt.t
-(** Like {!search} but returns only the list. *)
+val search' : Filter.t -> t Entry.t list Lwt.t
+(** Like {!search} but returns only the list of all values. *)
 
-val count :
-  ?threshold: float ->
-  Filter.t ->
-  int Lwt.t
+val count : Filter.t -> int Lwt.t
 (** Like {!search} but returns only the number of items. *)

--- a/src/common/model/slice.ml
+++ b/src/common/model/slice.ml
@@ -28,6 +28,9 @@ let make
     invalid_arg "Slice.make";
   {start; end_incl}
 
+let nothing = make ~end_excl: 0 ()
+let everything = make ~end_incl: max_int ()
+
 let list ?(strict = true) s xs =
   let rec list i = function
     | [] when strict && s.end_incl <> i - 1 -> invalid_arg "Slice.list"

--- a/src/common/model/slice.mli
+++ b/src/common/model/slice.mli
@@ -17,6 +17,12 @@ val make :
     than the start, or if more than one of [end_incl], [end_excl] and
     [length] are specified. *)
 
+val nothing : t
+(** The slice that contains nothing. *)
+
+val everything : t
+(** The slice that contains everything. *)
+
 val start : t -> int
 val length : t -> int
 val end_incl : t -> int

--- a/src/common/model/tune/tuneEndpoints.ml
+++ b/src/common/model/tune/tuneEndpoints.ml
@@ -4,7 +4,7 @@ open Dancelor_common_database
 
 type (_, _, _) t =
   | Get : ((TuneCore.t Slug.t -> 'w), 'w, TuneCore.t Entry.t) t
-  | Search : ((Slice.t option -> float option -> TuneCore.Filter.t -> 'w), 'w, (int * TuneCore.t Entry.t list)) t
+  | Search : ((Slice.t -> TuneCore.Filter.t -> 'w), 'w, (int * TuneCore.t Entry.t list)) t
   | Create : ((TuneCore.t -> 'w), 'w, TuneCore.t Entry.t) t
   | Update : ((TuneCore.t Slug.t -> TuneCore.t -> 'w), 'w, TuneCore.t Entry.t) t
 
@@ -13,6 +13,6 @@ let all = [W Get; W Search; W Create; W Update]
 
 let route : type a w r. (a, w, r) t -> (a, w, r) route = function
   | Get -> literal "get" @@ variable (module SSlug(TuneCore)) @@ return (module Entry.J(TuneCore))
-  | Search -> literal "search" @@ query_opt "slice" (module Slice) @@ query_opt "threshold" (module JFloat) @@ query "filter" (module TuneCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(TuneCore))))
+  | Search -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module TuneCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(TuneCore))))
   | Create -> literal "create" @@ query "tune" (module TuneCore) @@ return (module Entry.J(TuneCore))
   | Update -> literal "update" @@ variable (module SSlug(TuneCore)) @@ query "tune" (module TuneCore) @@ return (module Entry.J(TuneCore))

--- a/src/common/model/tune/tuneSignature.mli
+++ b/src/common/model/tune/tuneSignature.mli
@@ -87,25 +87,14 @@ val update : t Slug.t -> t -> t Entry.t Lwt.t
 val save : ?slug: t Slug.t -> t -> t Entry.t Lwt.t
 (** Either {!create} or {!update}. *)
 
-val search :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  (int * t Entry.t list) Lwt.t
-(** [search ?slice ?threshold filter] returns the list of all the tunes
-    that match [filter] with a score higher than [threshold] (if any). The first
-    element of the pair is the number of tunes. The second element of the pair
-    is a slice of the list, taken as per the [slice] (if any). *)
+val search : Slice.t -> Filter.t -> (int * t Entry.t list) Lwt.t
+(** Returns the list of all the tunes that match the filter with a score higher
+    than the hardcoded threshold. The first element of the pair is the number of
+    tunes. The second element of the pair is a slice of the list, taken as per
+    the slice. *)
 
-val search' :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  t Entry.t list Lwt.t
-(** Like {!search} but returns only the list. *)
+val search' : Filter.t -> t Entry.t list Lwt.t
+(** Like {!search} but returns only the list of all values. *)
 
-val count :
-  ?threshold: float ->
-  Filter.t ->
-  int Lwt.t
+val count : Filter.t -> int Lwt.t
 (** Like {!search} but returns only the number of items. *)

--- a/src/common/model/version/versionEndpoints.ml
+++ b/src/common/model/version/versionEndpoints.ml
@@ -4,7 +4,7 @@ open Dancelor_common_database
 
 type (_, _, _) t =
   | Get : ((VersionCore.t Slug.t -> 'w), 'w, VersionCore.t Entry.t) t
-  | Search : ((Slice.t option -> float option -> VersionCore.Filter.t -> 'w), 'w, (int * VersionCore.t Entry.t list)) t
+  | Search : ((Slice.t -> VersionCore.Filter.t -> 'w), 'w, (int * VersionCore.t Entry.t list)) t
   | Create : ((VersionCore.t -> 'w), 'w, VersionCore.t Entry.t) t
   | Update : ((VersionCore.t Slug.t -> VersionCore.t -> 'w), 'w, VersionCore.t Entry.t) t
   | Ly : ((VersionCore.t Slug.t -> 'w), 'w, Void.t) t
@@ -18,7 +18,7 @@ let all = [W Get; W Search; W Create; W Update; W Ly; W Svg; W Ogg; W Pdf]
 
 let route : type a w r. (a, w, r) t -> (a, w, r) route = function
   | Get -> literal "get" @@ variable (module SSlug(VersionCore)) @@ return (module Entry.J(VersionCore))
-  | Search -> literal "search" @@ query_opt "slice" (module Slice) @@ query_opt "threshold" (module JFloat) @@ query "filter" (module VersionCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(VersionCore))))
+  | Search -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module VersionCore.Filter) @@ return (module JPair(JInt)(JList(Entry.J(VersionCore))))
   | Create -> literal "create" @@ query "version" (module VersionCore) @@ return (module Entry.J(VersionCore))
   | Update -> literal "update" @@ variable (module SSlug(VersionCore)) @@ query "version" (module VersionCore) @@ return (module Entry.J(VersionCore))
   | Ly -> literal "ly" @@ variable (module SSlug(VersionCore)) @@ return (module JVoid)

--- a/src/common/model/version/versionEndpoints.ml
+++ b/src/common/model/version/versionEndpoints.ml
@@ -8,9 +8,9 @@ type (_, _, _) t =
   | Create : ((VersionCore.t -> 'w), 'w, VersionCore.t Entry.t) t
   | Update : ((VersionCore.t Slug.t -> VersionCore.t -> 'w), 'w, VersionCore.t Entry.t) t
   | Ly : ((VersionCore.t Slug.t -> 'w), 'w, Void.t) t
-  | Svg : ((VersionParameters.t option -> VersionCore.t Slug.t -> 'w), 'w, Void.t) t
-  | Ogg : ((VersionCore.t Slug.t -> 'w), 'w, Void.t) t
-  | Pdf : ((VersionParameters.t option -> VersionCore.t Slug.t -> 'w), 'w, Void.t) t
+  | Svg : ((VersionParameters.t -> VersionCore.t Slug.t -> 'w), 'w, Void.t) t
+  | Ogg : ((VersionParameters.t -> VersionCore.t Slug.t -> 'w), 'w, Void.t) t
+  | Pdf : ((VersionParameters.t -> VersionCore.t Slug.t -> 'w), 'w, Void.t) t
 
 (* FIXME: make a simple PPX for the following *)
 type wrapped = W : ('a, 'r Lwt.t, 'r) t -> wrapped
@@ -22,6 +22,6 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route = function
   | Create -> literal "create" @@ query "version" (module VersionCore) @@ return (module Entry.J(VersionCore))
   | Update -> literal "update" @@ variable (module SSlug(VersionCore)) @@ query "version" (module VersionCore) @@ return (module Entry.J(VersionCore))
   | Ly -> literal "ly" @@ variable (module SSlug(VersionCore)) @@ return (module JVoid)
-  | Svg -> literal "svg" @@ query_opt "parameters" (module VersionParameters) @@ variable (module SSlug(VersionCore)) @@ return (module JVoid)
-  | Ogg -> literal "ogg" @@ variable (module SSlug(VersionCore)) @@ return (module JVoid)
-  | Pdf -> literal "pdf" @@ query_opt "parameters" (module VersionParameters) @@ variable (module SSlug(VersionCore)) @@ return (module JVoid)
+  | Svg -> literal "svg" @@ query "parameters" (module VersionParameters) @@ variable (module SSlug(VersionCore)) @@ return (module JVoid)
+  | Ogg -> literal "ogg" @@ query "parameters" (module VersionParameters) @@ variable (module SSlug(VersionCore)) @@ return (module JVoid)
+  | Pdf -> literal "pdf" @@ query "parameters" (module VersionParameters) @@ variable (module SSlug(VersionCore)) @@ return (module JVoid)

--- a/src/common/model/version/versionSignature.mli
+++ b/src/common/model/version/versionSignature.mli
@@ -78,25 +78,14 @@ val update : t Slug.t -> t -> t Entry.t Lwt.t
 val save : ?slug: t Slug.t -> t -> t Entry.t Lwt.t
 (** Either {!create} or {!update}. *)
 
-val search :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  (int * t Entry.t list) Lwt.t
-(** [search ?slice ?threshold filter] returns the list of all the versions
-    that match [filter] with a score higher than [threshold] (if any). The first
-    element of the pair is the number of versions. The second element of the pair
-    is a slice of the list, taken as per the [slice] (if any). *)
+val search : Slice.t -> Filter.t -> (int * t Entry.t list) Lwt.t
+(** Returns the list of all the versions that match the filter with a score
+    higher than the hardcoded threshold. The first element of the pair is the
+    number of versions. The second element of the pair is a slice of the list,
+    taken as per the slice. *)
 
-val search' :
-  ?slice: Slice.t ->
-  ?threshold: float ->
-  Filter.t ->
-  t Entry.t list Lwt.t
-(** Like {!search} but returns only the list. *)
+val search' : Filter.t -> t Entry.t list Lwt.t
+(** Like {!search} but returns only the list of all values. *)
 
-val count :
-  ?threshold: float ->
-  Filter.t ->
-  int Lwt.t
+val count : Filter.t -> int Lwt.t
 (** Like {!search} but returns only the number of items. *)

--- a/src/server/controller/any.ml
+++ b/src/server/controller/any.ml
@@ -2,5 +2,5 @@ open Nes
 module Model = Dancelor_server_model
 
 let dispatch : type a r. (a, r Lwt.t, r) Dancelor_common_model.AnyEndpoints.t -> a = function
-  | Search -> (fun slice threshold filter -> Model.Any.search ?slice ?threshold filter)
-  | SearchContext -> (fun threshold filter element -> Model.Any.search_context ?threshold filter element)
+  | Search -> Model.Any.search
+  | SearchContext -> Model.Any.search_context

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -290,7 +290,7 @@ end
 
 let dispatch : type a r. (a, r Lwt.t, r) Dancelor_common_model.BookEndpoints.t -> a = function
   | Get -> Model.Book.get
-  | Search -> (fun slice threshold filter -> Model.Book.search ?slice ?threshold filter)
+  | Search -> Model.Book.search
   | Create -> Model.Book.create
   | Update -> Model.Book.update
   | Pdf -> (fun parameters book -> Pdf.get book parameters)

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -47,7 +47,7 @@ module Ly = struct
   let cache : ([`Ly] * Model.Book.t Database.Entry.t * Model.BookParameters.t * string, string Lwt.t) StorageCache.t =
     StorageCache.create ()
 
-  let render ?(parameters = Model.BookParameters.none) book =
+  let render parameters book =
     let%lwt body = Model.Book.lilypond_contents_cache_key book in
     StorageCache.use ~cache ~key: (`Ly, book, parameters, body) @@ fun _hash ->
     let (res, prom) =
@@ -255,16 +255,16 @@ let populate_cache ~cache ~ext ~pp_ext =
     files
 
 module Pdf = struct
-  let cache : ([`Pdf] * Model.Book.t Database.Entry.t * Model.BookParameters.t option * string, string Lwt.t) StorageCache.t =
+  let cache : ([`Pdf] * Model.Book.t Database.Entry.t * Model.BookParameters.t * string, string Lwt.t) StorageCache.t =
     StorageCache.create ()
 
   let populate_cache () =
     populate_cache ~cache ~ext: ".pdf" ~pp_ext: "pdf"
 
-  let render ?parameters book =
+  let render parameters book =
     let%lwt body = Model.Book.lilypond_contents_cache_key book in
     StorageCache.use ~cache ~key: (`Pdf, book, parameters, body) @@ fun hash ->
-    let%lwt lilypond = Ly.render ?parameters book in
+    let%lwt lilypond = Ly.render parameters book in
     let path = Filename.concat !Dancelor_server_config.cache "book" in
     let (fname_ly, fname_pdf) =
       let fname = StorageCache.hash_to_string hash in
@@ -282,9 +282,9 @@ module Pdf = struct
     let path_pdf = Filename.concat path fname_pdf in
     Lwt.return path_pdf
 
-  let get book parameters =
+  let get parameters book =
     let%lwt book = Model.Book.get book in
-    let%lwt path_pdf = render ?parameters book in
+    let%lwt path_pdf = render parameters book in
     Madge_cohttp_lwt_server.shortcut @@ Cohttp_lwt_unix.Server.respond_file ~fname: path_pdf ()
 end
 
@@ -293,4 +293,4 @@ let dispatch : type a r. (a, r Lwt.t, r) Dancelor_common_model.BookEndpoints.t -
   | Search -> Model.Book.search
   | Create -> Model.Book.create
   | Update -> Model.Book.update
-  | Pdf -> (fun parameters book -> Pdf.get book parameters)
+  | Pdf -> Pdf.get

--- a/src/server/controller/dance.ml
+++ b/src/server/controller/dance.ml
@@ -40,7 +40,7 @@ end
 
 let dispatch : type a r. (a, r Lwt.t, r) Dancelor_common_model.DanceEndpoints.t -> a = function
   | Get -> Model.Dance.get
-  | Search -> (fun slice threshold filter -> Model.Dance.search ?slice ?threshold filter)
+  | Search -> Model.Dance.search
   | Create -> Model.Dance.create
   | Update -> Model.Dance.update
   | Pdf -> (fun parameters dance -> Pdf.get dance parameters)

--- a/src/server/controller/person.ml
+++ b/src/server/controller/person.ml
@@ -3,6 +3,6 @@ module Model = Dancelor_server_model
 
 let dispatch : type a r. (a, r Lwt.t, r) Dancelor_common_model.PersonEndpoints.t -> a = function
   | Get -> Model.Person.get
-  | Search -> (fun slice threshold filter -> Model.Person.search ?slice ?threshold filter)
+  | Search -> Model.Person.search
   | Create -> Model.Person.create
   | Update -> Model.Person.update

--- a/src/server/controller/set.ml
+++ b/src/server/controller/set.ml
@@ -3,26 +3,21 @@ module Model = Dancelor_server_model
 module Database = Dancelor_server_database
 
 module Pdf = struct
-  let render ?parameters set =
+  let render parameters set =
     let book =
       Database.Entry.make_dummy @@
-      Model.Book.make
-        ~title: ""
-        ~contents: [InlineSet (Database.Entry.value set, Option.value ~default: Model.SetParameters.none parameters)]
-        ()
+      Model.Book.make ~title: "" ~contents: [InlineSet (Database.Entry.value set, parameters)] ()
     in
     let parameters =
       (* FIXME: the fact that we need to transfer this is just wrong. see
          https://github.com/paris-branch/dancelor/issues/250 *)
-      Model.BookParameters.make
-        ?paper_size: (Option.bind parameters Model.SetParameters.paper_size)
-        ()
+      Model.BookParameters.make ?paper_size: (Model.SetParameters.paper_size parameters) ()
     in
-    Book.Pdf.render book ~parameters
+    Book.Pdf.render parameters book
 
-  let get set parameters =
+  let get parameters set =
     let%lwt set = Model.Set.get set in
-    let%lwt path_pdf = render set ?parameters in
+    let%lwt path_pdf = render parameters set in
     Madge_cohttp_lwt_server.shortcut @@ Cohttp_lwt_unix.Server.respond_file ~fname: path_pdf ()
 end
 
@@ -32,4 +27,4 @@ let dispatch : type a r. (a, r Lwt.t, r) Dancelor_common_model.SetEndpoints.t ->
   | Search -> Model.Set.search
   | Create -> Model.Set.create
   | Update -> Model.Set.update
-  | Pdf -> (fun parameters set -> Pdf.get set parameters)
+  | Pdf -> Pdf.get

--- a/src/server/controller/set.ml
+++ b/src/server/controller/set.ml
@@ -29,7 +29,7 @@ end
 let dispatch : type a r. (a, r Lwt.t, r) Dancelor_common_model.SetEndpoints.t -> a = function
   | Get -> Model.Set.get
   | Delete -> (fun slug -> Lwt.bind (Model.Set.get slug) Model.Set.delete)
-  | Search -> (fun slice threshold filter -> Model.Set.search ?slice ?threshold filter)
+  | Search -> Model.Set.search
   | Create -> Model.Set.create
   | Update -> Model.Set.update
   | Pdf -> (fun parameters set -> Pdf.get set parameters)

--- a/src/server/controller/tune.ml
+++ b/src/server/controller/tune.ml
@@ -3,6 +3,6 @@ module Model = Dancelor_server_model
 
 let dispatch : type a r. (a, r Lwt.t, r) Dancelor_common_model.TuneEndpoints.t -> a = function
   | Get -> Model.Tune.get
-  | Search -> (fun slice threshold filter -> Model.Tune.search ?slice ?threshold filter)
+  | Search -> Model.Tune.search
   | Create -> Model.Tune.create
   | Update -> Model.Tune.update

--- a/src/server/controller/version.ml
+++ b/src/server/controller/version.ml
@@ -226,7 +226,7 @@ end
 
 let dispatch : type a r. (a, r Lwt.t, r) Dancelor_common_model.VersionEndpoints.t -> a = function
   | Get -> Model.Version.get
-  | Search -> (fun slice threshold filter -> Model.Version.search ?slice ?threshold filter)
+  | Search -> Model.Version.search
   | Create -> Model.Version.create
   | Update -> Model.Version.update
   | Ly -> get_ly

--- a/src/server/model/any/any.ml
+++ b/src/server/model/any/any.ml
@@ -33,8 +33,8 @@ include Common.Model.Search.Make(struct
     ]
   end)
 
-let search_context ?threshold filter element =
-  let%lwt results = search' ?threshold filter in
+let search_context filter element =
+  let%lwt results = search' filter in
   let List.{total; previous; index; next; _} = Option.get @@ List.find_context (equal element) results in
   (* TODO: Return the context directly. *)
   Lwt.return (total, previous, index, next)

--- a/src/server/model/any/any.ml
+++ b/src/server/model/any/any.ml
@@ -24,7 +24,7 @@ let tiebreaker =
   | a1, a2 -> Lwt.return (Type.compare (type_of a1) (type_of a2))
 
 let search =
-  Search.search
+  Common.Model.Search.search
     ~cache: (Cache.create ~lifetime: 600 ())
     ~values_getter: get_all
     ~scoring_function: Filter.accepts

--- a/src/server/model/any/any.ml
+++ b/src/server/model/any/any.ml
@@ -4,37 +4,34 @@ module Database = Dancelor_server_database
 
 include AnyLifted
 
-let get_all () =
-  let%lwt persons = Database.Person.get_all () >|=| List.map (fun c -> Person c) in
-  let%lwt dances = Database.Dance.get_all () >|=| List.map (fun d -> Dance d) in
-  let%lwt books = Database.Book.get_all () >|=| List.map (fun b -> Book b) in
-  let%lwt sets = Database.Set.get_all () >|=| List.map (fun s -> Set s) in
-  let%lwt tunes = Database.Tune.get_all () >|=| List.map (fun t -> Tune t) in
-  let%lwt versions = Database.Version.get_all () >|=| List.map (fun v -> Version v) in
-  (Lwt.return (persons @ dances @ books @ sets @ tunes @ versions))
+include Common.Model.Search.Make(struct
+    type value = t
+    type filter = Filter.t
 
-let tiebreaker =
-  curry @@ function
-  | Person p1, Person p2 -> Lwt_list.compare_multiple Person.tiebreakers p1 p2
-  | Dance d1, Dance d2 -> Lwt_list.compare_multiple Dance.tiebreakers d1 d2
-  | Book b1, Book b2 -> Lwt_list.compare_multiple Book.tiebreakers b1 b2
-  | Set s1, Set s2 -> Lwt_list.compare_multiple Set.tiebreakers s1 s2
-  | Tune t1, Tune t2 -> Lwt_list.compare_multiple Tune.tiebreakers t1 t2
-  | Version v1, Version v2 -> Lwt_list.compare_multiple Version.tiebreakers v1 v2
-  | a1, a2 -> Lwt.return (Type.compare (type_of a1) (type_of a2))
+    let cache = Cache.create ~lifetime: 600 ()
 
-let search =
-  Common.Model.Search.search
-    ~cache: (Cache.create ~lifetime: 600 ())
-    ~values_getter: get_all
-    ~scoring_function: Filter.accepts
-    ~tiebreakers: [tiebreaker]
+    let get_all () =
+      let%lwt persons = Database.Person.get_all () >|=| List.map (fun c -> Person c) in
+      let%lwt dances = Database.Dance.get_all () >|=| List.map (fun d -> Dance d) in
+      let%lwt books = Database.Book.get_all () >|=| List.map (fun b -> Book b) in
+      let%lwt sets = Database.Set.get_all () >|=| List.map (fun s -> Set s) in
+      let%lwt tunes = Database.Tune.get_all () >|=| List.map (fun t -> Tune t) in
+      let%lwt versions = Database.Version.get_all () >|=| List.map (fun v -> Version v) in
+      (Lwt.return (persons @ dances @ books @ sets @ tunes @ versions))
 
-let search' ?slice ?threshold filter =
-  Lwt.map snd @@ search ?slice ?threshold filter
+    let filter_accepts = Filter.accepts
 
-let count ?threshold filter =
-  Lwt.map fst @@ search ?threshold filter
+    let tiebreakers = [
+      curry @@ function
+      | Person p1, Person p2 -> Lwt_list.compare_multiple Person.tiebreakers p1 p2
+      | Dance d1, Dance d2 -> Lwt_list.compare_multiple Dance.tiebreakers d1 d2
+      | Book b1, Book b2 -> Lwt_list.compare_multiple Book.tiebreakers b1 b2
+      | Set s1, Set s2 -> Lwt_list.compare_multiple Set.tiebreakers s1 s2
+      | Tune t1, Tune t2 -> Lwt_list.compare_multiple Tune.tiebreakers t1 t2
+      | Version v1, Version v2 -> Lwt_list.compare_multiple Version.tiebreakers v1 v2
+      | a1, a2 -> Lwt.return (Type.compare (type_of a1) (type_of a2))
+    ]
+  end)
 
 let search_context ?threshold filter element =
   let%lwt results = search' ?threshold filter in

--- a/src/server/model/book/book.ml
+++ b/src/server/model/book/book.ml
@@ -18,7 +18,7 @@ let tiebreakers =
   ]
 
 let search =
-  Search.search
+  Common.Model.Search.search
     ~cache: (Cache.create ~lifetime: 600 ())
     ~values_getter: Database.Book.get_all
     ~scoring_function: Filter.accepts

--- a/src/server/model/dance/dance.ml
+++ b/src/server/model/dance/dance.ml
@@ -8,20 +8,16 @@ let create = Database.Dance.create
 let update = Database.Dance.update
 let save = Database.Dance.save
 
-let tiebreakers =
-  Lwt_list.[
-    increasing (Lwt.return % name) String.Sensible.compare
-  ]
+include Common.Model.Search.Make(struct
+    type value = t Database.Entry.t
+    type filter = Filter.t
 
-let search =
-  Common.Model.Search.search
-    ~cache: (Cache.create ~lifetime: 600 ())
-    ~values_getter: Database.Dance.get_all
-    ~scoring_function: Filter.accepts
-    ~tiebreakers
+    let cache = Cache.create ~lifetime: 600 ()
+    let get_all = Database.Dance.get_all
+    let filter_accepts = Filter.accepts
 
-let search' ?slice ?threshold filter =
-  Lwt.map snd @@ search ?slice ?threshold filter
-
-let count ?threshold filter =
-  Lwt.map fst @@ search ?threshold filter
+    let tiebreakers =
+      Lwt_list.[
+        increasing (Lwt.return % name) String.Sensible.compare
+      ]
+  end)

--- a/src/server/model/dance/dance.ml
+++ b/src/server/model/dance/dance.ml
@@ -14,7 +14,7 @@ let tiebreakers =
   ]
 
 let search =
-  Search.search
+  Common.Model.Search.search
     ~cache: (Cache.create ~lifetime: 600 ())
     ~values_getter: Database.Dance.get_all
     ~scoring_function: Filter.accepts

--- a/src/server/model/person/person.ml
+++ b/src/server/model/person/person.ml
@@ -14,7 +14,7 @@ let tiebreakers =
   ]
 
 let search =
-  Search.search
+  Common.Model.Search.search
     ~cache: (Cache.create ~lifetime: 600 ())
     ~values_getter: Database.Person.get_all
     ~scoring_function: Filter.accepts

--- a/src/server/model/person/person.ml
+++ b/src/server/model/person/person.ml
@@ -8,20 +8,16 @@ let create = Database.Person.create
 let update = Database.Person.update
 let save = Database.Person.save
 
-let tiebreakers =
-  Lwt_list.[
-    increasing (Lwt.return % name) String.Sensible.compare
-  ]
+include Common.Model.Search.Make(struct
+    type value = t Database.Entry.t
+    type filter = Filter.t
 
-let search =
-  Common.Model.Search.search
-    ~cache: (Cache.create ~lifetime: 600 ())
-    ~values_getter: Database.Person.get_all
-    ~scoring_function: Filter.accepts
-    ~tiebreakers
+    let cache = Cache.create ~lifetime: 600 ()
+    let get_all = Database.Person.get_all
+    let filter_accepts = Filter.accepts
 
-let search' ?slice ?threshold filter =
-  Lwt.map snd @@ search ?slice ?threshold filter
-
-let count ?threshold filter =
-  Lwt.map fst @@ search ?threshold filter
+    let tiebreakers =
+      Lwt_list.[
+        increasing (Lwt.return % name) String.Sensible.compare
+      ]
+  end)

--- a/src/server/model/set/set.ml
+++ b/src/server/model/set/set.ml
@@ -17,7 +17,7 @@ let tiebreakers =
   ]
 
 let search =
-  Search.search
+  Common.Model.Search.search
     ~cache: (Cache.create ~lifetime: 600 ())
     ~values_getter: Database.Set.get_all
     ~scoring_function: Filter.accepts

--- a/src/server/model/set/set.ml
+++ b/src/server/model/set/set.ml
@@ -10,21 +10,17 @@ let save = Database.Set.save
 
 let delete = Database.(Set.delete % Entry.slug)
 
-let tiebreakers =
-  Lwt_list.[
-    increasing (Lwt.return % name) String.Sensible.compare;
-    increasing (Lwt.return % name) String.compare_lengths;
-  ]
+include Common.Model.Search.Make(struct
+    type value = t Database.Entry.t
+    type filter = Filter.t
 
-let search =
-  Common.Model.Search.search
-    ~cache: (Cache.create ~lifetime: 600 ())
-    ~values_getter: Database.Set.get_all
-    ~scoring_function: Filter.accepts
-    ~tiebreakers
+    let cache = Cache.create ~lifetime: 600 ()
+    let get_all = Database.Set.get_all
+    let filter_accepts = Filter.accepts
 
-let search' ?slice ?threshold filter =
-  Lwt.map snd @@ search ?slice ?threshold filter
-
-let count ?threshold filter =
-  Lwt.map fst @@ search ?threshold filter
+    let tiebreakers =
+      Lwt_list.[
+        increasing (Lwt.return % name) String.Sensible.compare;
+        increasing (Lwt.return % name) String.compare_lengths;
+      ]
+  end)

--- a/src/server/model/tune/tune.ml
+++ b/src/server/model/tune/tune.ml
@@ -15,7 +15,7 @@ let tiebreakers =
   ]
 
 let search =
-  Search.search
+  Common.Model.Search.search
     ~cache: (Cache.create ~lifetime: 600 ())
     ~values_getter: Database.Tune.get_all
     ~scoring_function: Filter.accepts

--- a/src/server/model/tune/tune.ml
+++ b/src/server/model/tune/tune.ml
@@ -8,21 +8,17 @@ let create = Database.Tune.create
 let update = Database.Tune.update
 let save = Database.Tune.save
 
-let tiebreakers =
-  Lwt_list.[
-    increasing (Lwt.return % name) String.Sensible.compare;
-    increasing (Lwt.return % name) String.compare_lengths;
-  ]
+include Common.Model.Search.Make(struct
+    type value = t Database.Entry.t
+    type filter = Filter.t
 
-let search =
-  Common.Model.Search.search
-    ~cache: (Cache.create ~lifetime: 600 ())
-    ~values_getter: Database.Tune.get_all
-    ~scoring_function: Filter.accepts
-    ~tiebreakers
+    let cache = Cache.create ~lifetime: 600 ()
+    let get_all = Database.Tune.get_all
+    let filter_accepts = Filter.accepts
 
-let search' ?slice ?threshold filter =
-  Lwt.map snd @@ search ?slice ?threshold filter
-
-let count ?threshold filter =
-  Lwt.map fst @@ search ?threshold filter
+    let tiebreakers =
+      Lwt_list.[
+        increasing (Lwt.return % name) String.Sensible.compare;
+        increasing (Lwt.return % name) String.compare_lengths;
+      ]
+  end)

--- a/src/server/model/version/version.ml
+++ b/src/server/model/version/version.ml
@@ -35,20 +35,16 @@ let score_list_vs_list words needles =
       |> List.fold_left max 0.
     end
 
-let tiebreakers =
-  Lwt_list.[
-    increasing (Lwt.map Tune.name % tune) String.Sensible.compare
-  ]
+include Common.Model.Search.Make(struct
+    type value = t Database.Entry.t
+    type filter = Filter.t
 
-let search =
-  Common.Model.Search.search
-    ~cache: (Cache.create ~lifetime: 600 ())
-    ~values_getter: Database.Version.get_all
-    ~scoring_function: Filter.accepts
-    ~tiebreakers
+    let cache = Cache.create ~lifetime: 600 ()
+    let get_all = Database.Version.get_all
+    let filter_accepts = Filter.accepts
 
-let search' ?slice ?threshold filter =
-  Lwt.map snd @@ search ?slice ?threshold filter
-
-let count ?threshold filter =
-  Lwt.map fst @@ search ?threshold filter
+    let tiebreakers =
+      Lwt_list.[
+        increasing (Lwt.map Tune.name % tune) String.Sensible.compare
+      ]
+  end)

--- a/src/server/model/version/version.ml
+++ b/src/server/model/version/version.ml
@@ -41,7 +41,7 @@ let tiebreakers =
   ]
 
 let search =
-  Search.search
+  Common.Model.Search.search
     ~cache: (Cache.create ~lifetime: 600 ())
     ~values_getter: Database.Version.get_all
     ~scoring_function: Filter.accepts

--- a/src/server/routine.ml
+++ b/src/server/routine.ml
@@ -1,18 +1,23 @@
+module Config = Dancelor_server_config
+module Database = Dancelor_server_database
+module Model = Dancelor_server_model
+module Controller = Dancelor_server_controller
+
 module Log = (val Dancelor_server_logs.create "routine": Logs.LOG)
 
 let preload_versions ?max_concurrency () =
-  let%lwt all = Dancelor_server_database.Version.get_all () in
+  let%lwt all = Database.Version.get_all () in
   let all = Lwt_stream.of_list all in
   let%lwt t =
     NesLwt_unix.with_difftimeofday @@ fun () ->
     Lwt_stream.iter_n
       ?max_concurrency
       (fun version ->
-         let%lwt tune = Dancelor_server_model.Version.tune version in
-         let name = Dancelor_server_model.Tune.name tune in
+         let%lwt tune = Model.Version.tune version in
+         let name = Model.Tune.name tune in
          Log.debug (fun m -> m "Prerendering %s" name);
-         let%lwt _ = Dancelor_server_controller.Version.Svg.render version in
-         let%lwt _ = Dancelor_server_controller.Version.Ogg.render version in
+         let%lwt _ = Controller.Version.Svg.render Model.VersionParameters.none version in
+         let%lwt _ = Controller.Version.Ogg.render Model.VersionParameters.none version in
          Lwt.return ()
       )
       all
@@ -21,5 +26,5 @@ let preload_versions ?max_concurrency () =
   Lwt.return_unit
 
 let initialise () =
-  let max_concurrency = if !Dancelor_server_config.heavy_routines then 8 else 1 in
+  let max_concurrency = if !Config.heavy_routines then 8 else 1 in
   Lwt.async (fun () -> preload_versions ~max_concurrency ())


### PR DESCRIPTION
This PR finalises cleaning up the endpoints and controllers to make it such that
there is a one-to-one correspondence between endpoints and controllers. This
makes the code cleaner, and I used the opportunity to clean up the handling of
searches and parameters.