### PR TITLE
Move builder's `make` to core - trim person's name

### DIFF
--- a/src/common/modelBuilder/builder/book.ml
+++ b/src/common/modelBuilder/builder/book.ml
@@ -80,19 +80,6 @@ module Build (Getters : Getters.S) = struct
 
   let lilypond_contents_cache_key' = lilypond_contents_cache_key % Entry.value
 
-  let page_to_page_core = function
-    | (Version (version, params): page) -> Core.Book.Page.Version (Entry.slug version, params)
-    | (Set (set, params): page) -> Core.Book.Page.Set (Entry.slug set, params)
-    | (InlineSet (set, params): page) -> Core.Book.Page.InlineSet (set, params)
-
-  let make ~title ?subtitle ?short_title ?authors ?date ?contents ?source ?remark ?scddb_id () =
-    let title = String.remove_duplicates ~char: ' ' title in
-    let subtitle = Option.map (String.remove_duplicates ~char: ' ') subtitle in
-    let short_title = Option.map (String.remove_duplicates ~char: ' ') short_title in
-    let authors = Option.map (List.map Entry.slug) authors in
-    let contents = Option.map (List.map page_to_page_core) contents in
-    make ~title ?subtitle ?short_title ?authors ?date ?contents ?source ?remark ?scddb_id ()
-
   module Warnings = struct
     (* The following functions all have the name of a warning of
        {!Dancelor_common.Model.Core.Book.warning}. They all are in charge of

--- a/src/common/modelBuilder/builder/dance.ml
+++ b/src/common/modelBuilder/builder/dance.ml
@@ -5,12 +5,6 @@ module Build (Getters : Getters.S) = struct
 
   let get = Getters.get_dance
 
-  let make ~name ~kind ?devisers ?two_chords ?scddb_id ?disambiguation ?date () =
-    let name = String.remove_duplicates ~char: ' ' name in
-    let disambiguation = Option.map (String.remove_duplicates ~char: ' ') disambiguation in
-    let devisers = Option.map (List.map Entry.slug) devisers in
-    make ~name ~kind ?devisers ~two_chords ~scddb_id ?disambiguation ~date ()
-
   let devisers = Lwt_list.map_p Getters.get_person % devisers
   let devisers' = devisers % Entry.value
 

--- a/src/common/modelBuilder/builder/set.ml
+++ b/src/common/modelBuilder/builder/set.ml
@@ -5,13 +5,6 @@ module Build (Getters : Getters.S) = struct
 
   let get = Getters.get_set
 
-  let make ~name ?conceptors ~kind ?contents ~order ?dances () =
-    let name = String.remove_duplicates ~char: ' ' name in
-    let conceptors = Option.map (List.map Entry.slug) conceptors in
-    let contents = Option.map (List.map (fun (version, parameters) -> (Entry.slug version, parameters))) contents in
-    let dances = Option.map (List.map Entry.slug) dances in
-    make ~name ?conceptors ~kind ?contents ~order ?dances ()
-
   let conceptors = Lwt_list.map_p Getters.get_person % conceptors
   let conceptors' = conceptors % Entry.value
 

--- a/src/common/modelBuilder/builder/tune.ml
+++ b/src/common/modelBuilder/builder/tune.ml
@@ -5,13 +5,6 @@ module Build (Getters : Getters.S) = struct
 
   let get = Getters.get_tune
 
-  let make ~name ?alternative_names ~kind ?composers ?dances ?remark ?scddb_id ?date () =
-    let name = String.remove_duplicates ~char: ' ' name in
-    let alternative_names = Option.map (List.map (String.remove_duplicates ~char: ' ')) alternative_names in
-    let composers = Option.map (List.map Entry.slug) composers in
-    let dances = Option.map (List.map Entry.slug) dances in
-    make ~name ?alternative_names ~kind ?composers ?dances ?remark ~scddb_id ~date ()
-
   let composers = Lwt_list.map_p Getters.get_person % composers
   let composers' = composers % Entry.value
 

--- a/src/common/modelBuilder/builder/user.ml
+++ b/src/common/modelBuilder/builder/user.ml
@@ -3,9 +3,6 @@ open Nes
 module Build (Getters : Getters.S) = struct
   include Core.User
 
-  let make ~display_name ~person ?password ?password_reset_token ?remember_me_tokens () =
-    make ~display_name ~person: (Entry.slug person) ?password ?password_reset_token ?remember_me_tokens ()
-
   let update ?display_name ?person ?password ?password_reset_token ?remember_me_tokens user =
     update
       ?display_name

--- a/src/common/modelBuilder/builder/version.ml
+++ b/src/common/modelBuilder/builder/version.ml
@@ -5,14 +5,6 @@ module Build (Getters : Getters.S) = struct
 
   let get = Getters.get_version
 
-  let make ~tune ~bars ~key ~structure ?sources ?arrangers ?remark ?disambiguation ~content () =
-    let structure = String.remove_duplicates ~char: ' ' structure in
-    let disambiguation = Option.map (String.remove_duplicates ~char: ' ') disambiguation in
-    let tune = Entry.slug tune in
-    let sources = Option.map (List.map Entry.slug) sources in
-    let arrangers = Option.map (List.map Entry.slug) arrangers in
-    make ~tune ~bars ~key ~structure ?sources ?arrangers ?remark ?disambiguation ~content ()
-
   let tune = Getters.get_tune % tune
   let tune' = tune % Entry.value
 

--- a/src/common/modelBuilder/core/dance.ml
+++ b/src/common/modelBuilder/core/dance.ml
@@ -13,6 +13,12 @@ type t = {
 }
 [@@deriving eq, make, show {with_path = false}, yojson, fields]
 
+let make ~name ~kind ?devisers ?two_chords ?scddb_id ?disambiguation ?date () =
+  let name = String.remove_duplicates ~char: ' ' name in
+  let disambiguation = Option.map (String.remove_duplicates ~char: ' ') disambiguation in
+  let devisers = Option.map (List.map Entry.slug) devisers in
+  make ~name ~kind ?devisers ~two_chords ~scddb_id ?disambiguation ~date ()
+
 let name' = name % Entry.value
 let kind' = kind % Entry.value
 let two_chords' = two_chords % Entry.value

--- a/src/common/modelBuilder/core/person.ml
+++ b/src/common/modelBuilder/core/person.ml
@@ -8,7 +8,9 @@ type t = {
 }
 [@@deriving eq, yojson, make, show {with_path = false}, fields]
 
-let make ~name ?scddb_id () = make ~name ~scddb_id ()
+let make ~name ?scddb_id () =
+  let name = String.remove_duplicates ~char: ' ' name in
+  make ~name ~scddb_id ()
 
 let name' = name % Entry.value
 let scddb_id' = scddb_id % Entry.value

--- a/src/common/modelBuilder/core/set.ml
+++ b/src/common/modelBuilder/core/set.ml
@@ -14,6 +14,13 @@ type t = {
 }
 [@@deriving eq, yojson, make, show {with_path = false}, fields]
 
+let make ~name ?conceptors ~kind ?contents ~order ?dances () =
+  let name = String.remove_duplicates ~char: ' ' name in
+  let conceptors = Option.map (List.map Entry.slug) conceptors in
+  let contents = Option.map (List.map (fun (version, parameters) -> (Entry.slug version, parameters))) contents in
+  let dances = Option.map (List.map Entry.slug) dances in
+  make ~name ?conceptors ~kind ?contents ~order ?dances ()
+
 let name' = name % Entry.value
 let kind' = kind % Entry.value
 let order' = order % Entry.value

--- a/src/common/modelBuilder/core/source.ml
+++ b/src/common/modelBuilder/core/source.ml
@@ -9,17 +9,9 @@ type t = {
 }
 [@@deriving eq, yojson, make, show {with_path = false}, fields]
 
-let make
-    ~name
-    ?scddb_id
-    ?description
-    ()
-  =
-  make
-    ~name
-    ~scddb_id
-    ~description
-    ()
+let make ~name ?scddb_id ?description () =
+  let name = String.remove_duplicates ~char: ' ' name in
+  make ~name ~scddb_id ~description ()
 
 let name' = name % Entry.value
 let scddb_id' = scddb_id % Entry.value

--- a/src/common/modelBuilder/core/tune.ml
+++ b/src/common/modelBuilder/core/tune.ml
@@ -14,6 +14,13 @@ type t = {
 }
 [@@deriving eq, yojson, make, show {with_path = false}, fields]
 
+let make ~name ?alternative_names ~kind ?composers ?dances ?remark ?scddb_id ?date () =
+  let name = String.remove_duplicates ~char: ' ' name in
+  let alternative_names = Option.map (List.map (String.remove_duplicates ~char: ' ')) alternative_names in
+  let composers = Option.map (List.map Entry.slug) composers in
+  let dances = Option.map (List.map Entry.slug) dances in
+  make ~name ?alternative_names ~kind ?composers ?dances ?remark ~scddb_id ~date ()
+
 let name' = name % Entry.value
 let alternative_names' = alternative_names % Entry.value
 let kind' = kind % Entry.value

--- a/src/common/modelBuilder/core/user.ml
+++ b/src/common/modelBuilder/core/user.ml
@@ -14,6 +14,10 @@ type t = {
 let make ~display_name ~person ?password ?password_reset_token ?remember_me_tokens () =
   make ~display_name ~person ~password ~password_reset_token ?remember_me_tokens ()
 
+let make ~display_name ~person ?password ?password_reset_token ?remember_me_tokens () =
+  let display_name = String.remove_duplicates ~char: ' ' display_name in
+  make ~display_name ~person: (Entry.slug person) ?password ?password_reset_token ?remember_me_tokens ()
+
 let update ?display_name ?person ?password ?password_reset_token ?remember_me_tokens user =
   let%lwt person = Option.value person ~default: lwt user.person in
   lwt {

--- a/src/common/modelBuilder/core/version.ml
+++ b/src/common/modelBuilder/core/version.ml
@@ -15,6 +15,14 @@ type t = {
 }
 [@@deriving eq, yojson, make, show {with_path = false}, fields]
 
+let make ~tune ~bars ~key ~structure ?sources ?arrangers ?remark ?disambiguation ~content () =
+  let structure = String.remove_duplicates ~char: ' ' structure in
+  let disambiguation = Option.map (String.remove_duplicates ~char: ' ') disambiguation in
+  let tune = Entry.slug tune in
+  let sources = Option.map (List.map Entry.slug) sources in
+  let arrangers = Option.map (List.map Entry.slug) arrangers in
+  make ~tune ~bars ~key ~structure ?sources ?arrangers ?remark ?disambiguation ~content ()
+
 let tune' = tune % Entry.value
 let bars' = bars % Entry.value
 let key' = key % Entry.value

--- a/src/nes/nesString.ml
+++ b/src/nes/nesString.ml
@@ -383,6 +383,9 @@ let remove_duplicates ?(char_equal = Char.equal) ?(char = ' ') input =
   done;
   trim ~char_equal ~chars: [char] (Buffer.contents output)
 
+let%test _ = remove_duplicates "  bonjour   toi     comment ça   va ?  " = "bonjour toi comment ça va ?"
+let%test _ = remove_duplicates "bonjour toi comment ça va ?" = "bonjour toi comment ça va ?"
+
 (** Richer version of [concat] that can also handle differently the last
     separator. For instance, [concat ~last:" & " ", " \["a"; "b"; "c"\] = "a, b
     & c"]. *)


### PR DESCRIPTION
Since the introduction of `Entry`, that `make` functions do not need to
be lifted anymore!

Closes #469