### PR TITLE
Editors show toast on successful creation

### DIFF
--- a/src/client/components/button.ml
+++ b/src/client/components/button.ml
@@ -173,28 +173,52 @@ let clear ~onclick () =
     )
     ()
 
-let cancel ~onclick () =
+let cancel ?onclick ?more_a () =
   make
     ~label: "Cancel"
     ~label_processing: "Cancelling..."
     ~icon: "x-lg"
     ~classes: ["btn-secondary"]
-    ~onclick
+    ?onclick
+    ?more_a
     ()
 
-let cancel' ~return () =
-  cancel ~onclick: (fun () -> return None; lwt_unit) ()
+let cancel' ~return ?more_a () =
+  cancel
+    ~onclick: (fun () -> return None; lwt_unit)
+    ?more_a
+    ()
 
-let ok ~onclick () =
+let close ?onclick ?more_a () =
+  make
+    ~label: "Close"
+    ~label_processing: "Closing..."
+    ~icon: "x-lg"
+    ~classes: ["btn-secondary"]
+    ?onclick
+    ?more_a
+    ()
+
+let close' ~return ?more_a () =
+  close
+    ~onclick: (fun () -> return None; lwt_unit)
+    ?more_a
+    ()
+
+let ok ?onclick ?more_a () =
   make
     ~label: "OK"
     ~label_processing: "Closing..."
     ~classes: ["btn-primary"]
-    ~onclick
+    ?onclick
+    ?more_a
     ()
 
-let ok' ~return () =
-  ok ~onclick: (fun () -> return (Some ()); lwt_unit) ()
+let ok' ~return ?more_a () =
+  ok
+    ~onclick: (fun () -> return (Some ()); lwt_unit)
+    ?more_a
+    ()
 
 let download ~href () =
   make_a

--- a/src/client/components/button.mli
+++ b/src/client/components/button.mli
@@ -53,25 +53,43 @@ val clear :
 (** A button specialised in clearing a form. *)
 
 val cancel :
-  onclick: (unit -> unit Lwt.t) ->
+  ?onclick: (unit -> unit Lwt.t) ->
+  ?more_a: [< Html_types.button_attrib >`Button_Type `Class `OnClick] attrib list ->
   unit ->
   [> Html_types.button] elt
 (** A button specialised in cancelling something. *)
 
 val cancel' :
   return: ('any option -> unit) ->
+  ?more_a: [< Html_types.button_attrib >`Button_Type `Class `OnClick] attrib list ->
   unit ->
   [> Html_types.button] elt
 (** Variant of {!cancel'} passing [None] to a [return] function. *)
 
+val close :
+  ?onclick: (unit -> unit Lwt.t) ->
+  ?more_a: [< Html_types.button_attrib >`Button_Type `Class `OnClick] attrib list ->
+  unit ->
+  [> Html_types.button] elt
+(** A button specialised in closing something. *)
+
+val close' :
+  return: ('any option -> unit) ->
+  ?more_a: [< Html_types.button_attrib >`Button_Type `Class `OnClick] attrib list ->
+  unit ->
+  [> Html_types.button] elt
+(** Variant of {!close'} passing [None] to a [return] function. *)
+
 val ok :
-  onclick: (unit -> unit Lwt.t) ->
+  ?onclick: (unit -> unit Lwt.t) ->
+  ?more_a: [< Html_types.button_attrib >`Button_Type `Class `OnClick] attrib list ->
   unit ->
   [> Html_types.button] elt
 (** A button specialised in closing an information dialog. *)
 
 val ok' :
   return: (unit option -> unit) ->
+  ?more_a: [< Html_types.button_attrib >`Button_Type `Class `OnClick] attrib list ->
   unit ->
   [> Html_types.button] elt
 (** Variant of {!ok'} passing [Some ()] to a [return] function. *)

--- a/src/client/components/input.ml
+++ b/src/client/components/input.ml
@@ -69,6 +69,7 @@ module Text = struct
           ~a: [
             a_rows 15;
             a_placeholder placeholder;
+            (* R.a_value state.raw_signal; FIXME: not possible in textarea but necessary for cleanup *)
             R.a_class (case_errored ~no: ["form-control"; "is-valid"] ~yes: (const ["form-control"; "is-invalid"]) state);
             a_oninput (fun event ->
               (

--- a/src/client/components/toast.ml
+++ b/src/client/components/toast.ml
@@ -21,7 +21,7 @@ let level_to_class = function
   | Normal -> ([], [])
   | Warning -> (["bg-warning"; "text-dark"], ["bg-warning-subtle"])
 
-let open_ ?(level = Normal) ~title content =
+let open_ ?(level = Normal) ~title ?(buttons = []) content =
   let start = Unix.time () in
   let (class_header, class_body) = level_to_class level in
   let toast =
@@ -36,7 +36,13 @@ let open_ ?(level = Normal) ~title content =
               small [R.txt (Time.ago_s start)];
               button ~a: [a_button_type `Button; a_class ["btn-close"]; a_user_data "bs-dismiss" "toast"; a_aria "label" ["Close"]] [];
             ];
-          div ~a: [a_class (["toast-body"] @ class_body)] content;
+          div ~a: [a_class (["toast-body"] @ class_body)] (
+            content @ [
+              div ~a: [a_class ["mt-2"; "pt-2"; "border-top"; "text-end"]] (
+                (Button.close ~more_a: [a_user_data "bs-dismiss" "toast"] ()) :: buttons
+              )
+            ]
+          );
         ]
   in
   Lwt.async (fun () ->

--- a/src/client/views/bookEditor.ml
+++ b/src/client/views/bookEditor.ml
@@ -1,7 +1,6 @@
 open Nes
 open Common
 
-open Js_of_ocaml
 open Components
 open Html
 open Utils
@@ -179,7 +178,19 @@ let create ?on_save ?text ?edit () =
           Option.iter @@ fun book ->
           Editor.clear editor;
           match on_save with
-          | None -> Dom_html.window##.location##.href := Js.string (Endpoints.Page.href_book (Entry.slug book))
+          | None ->
+            Components.Toast.open_
+              ~title: "Book created"
+              [txt "The book ";
+              Formatters.Book.title_and_subtitle' book;
+              txt " has been created successfully."]
+              ~buttons: [
+                Components.Button.make_a
+                  ~label: "Go to book"
+                  ~classes: ["btn-primary"]
+                  ~href: (S.const @@ Endpoints.Page.href_book @@ Entry.slug book)
+                  ();
+              ]
           | Some on_save -> on_save book
         )
         ();

--- a/src/client/views/danceEditor.ml
+++ b/src/client/views/danceEditor.ml
@@ -1,7 +1,6 @@
 open Nes
 open Common
 
-open Js_of_ocaml
 open Components
 open Html
 open Utils
@@ -204,7 +203,19 @@ let create ?on_save ?text () =
           Option.iter @@ fun dance ->
           Editor.clear editor;
           match on_save with
-          | None -> Dom_html.window##.location##.href := Js.string (Endpoints.Page.href_dance (Entry.slug dance))
+          | None ->
+            Components.Toast.open_
+              ~title: "Dance created"
+              [txt "The dance ";
+              Formatters.Dance.name' ~link: true dance;
+              txt " has been created successfully."]
+              ~buttons: [
+                Components.Button.make_a
+                  ~label: "Go to dance"
+                  ~classes: ["btn-primary"]
+                  ~href: (S.const @@ Endpoints.Page.href_dance @@ Entry.slug dance)
+                  ();
+              ]
           | Some on_save -> on_save dance
         )
         ();

--- a/src/client/views/issueReport.ml
+++ b/src/client/views/issueReport.ml
@@ -103,6 +103,10 @@ let open_dialog page =
     | None ->
       Components.Toast.open_
         ~title: "Issue not reported"
-        [txt "Your issue has not been reported, as you closed the dialog. If this is an error, please contact your system administrator."]
+        [
+          txt
+            "Your issue has not been reported, as you closed the dialog. If this \
+             is an error, please contact your system administrator."
+        ]
   );
   lwt_unit

--- a/src/client/views/personEditor.ml
+++ b/src/client/views/personEditor.ml
@@ -1,7 +1,6 @@
 open Nes
 open Common
 
-open Js_of_ocaml
 open Components
 open Html
 
@@ -100,7 +99,19 @@ let create ?on_save ?text () =
           Option.iter @@ fun person ->
           Editor.clear editor;
           match on_save with
-          | None -> Dom_html.window##.location##.href := Js.string (Endpoints.Page.href_person (Entry.slug person))
+          | None ->
+            Components.Toast.open_
+              ~title: "Person created"
+              [txt "The person ";
+              Formatters.Person.name' ~link: true person;
+              txt " has been created successfully."]
+              ~buttons: [
+                Components.Button.make_a
+                  ~label: "Go to person"
+                  ~classes: ["btn-primary"]
+                  ~href: (S.const @@ Endpoints.Page.href_person @@ Entry.slug person)
+                  ();
+              ]
           | Some on_save -> on_save person
         )
         ();

--- a/src/client/views/setEditor.ml
+++ b/src/client/views/setEditor.ml
@@ -1,7 +1,6 @@
 open Nes
 open Common
 
-open Js_of_ocaml
 open Components
 open Html
 open Utils
@@ -181,7 +180,19 @@ let create ?on_save ?text () =
           Option.iter @@ fun set ->
           Editor.clear editor;
           match on_save with
-          | None -> Dom_html.window##.location##.href := Js.string (Endpoints.Page.href_set (Entry.slug set))
+          | None ->
+            Components.Toast.open_
+              ~title: "Set created"
+              [txt "The set ";
+              Formatters.Set.name' ~link: true set;
+              txt " has been created successfully."]
+              ~buttons: [
+                Components.Button.make_a
+                  ~label: "Go to set"
+                  ~classes: ["btn-primary"]
+                  ~href: (S.const @@ Endpoints.Page.href_set @@ Entry.slug set)
+                  ();
+              ]
           | Some on_save -> on_save set
         )
         ();

--- a/src/client/views/sourceEditor.ml
+++ b/src/client/views/sourceEditor.ml
@@ -1,7 +1,6 @@
 open Nes
 open Common
 
-open Js_of_ocaml
 open Components
 open Html
 
@@ -112,7 +111,19 @@ let create ?on_save ?text () =
           Option.iter @@ fun source ->
           Editor.clear editor;
           match on_save with
-          | None -> Dom_html.window##.location##.href := Js.string (Endpoints.Page.href_source (Entry.slug source))
+          | None ->
+            Components.Toast.open_
+              ~title: "Source created"
+              [txt "The source ";
+              Formatters.Source.name' ~link: true source;
+              txt " has been created successfully."]
+              ~buttons: [
+                Components.Button.make_a
+                  ~label: "Go to source"
+                  ~classes: ["btn-primary"]
+                  ~href: (S.const @@ Endpoints.Page.href_source @@ Entry.slug source)
+                  ();
+              ]
           | Some on_save -> on_save source
         )
         ();

--- a/src/client/views/tuneEditor.ml
+++ b/src/client/views/tuneEditor.ml
@@ -1,7 +1,6 @@
 open Nes
 open Common
 
-open Js_of_ocaml
 open Components
 open Html
 open Utils
@@ -197,7 +196,19 @@ let create ?on_save ?text () =
           Option.iter @@ fun tune ->
           Editor.clear editor;
           match on_save with
-          | None -> Dom_html.window##.location##.href := Js.string (Endpoints.Page.href_tune (Entry.slug tune))
+          | None ->
+            Components.Toast.open_
+              ~title: "Tune created"
+              [txt "The tune ";
+              Formatters.Tune.name' ~link: true tune;
+              txt " has been created successfully."]
+              ~buttons: [
+                Components.Button.make_a
+                  ~label: "Go to tune"
+                  ~classes: ["btn-primary"]
+                  ~href: (S.const @@ Endpoints.Page.href_tune @@ Entry.slug tune)
+                  ();
+              ]
           | Some on_save -> on_save tune
         )
         ();

--- a/src/client/views/versionEditor.ml
+++ b/src/client/views/versionEditor.ml
@@ -1,7 +1,6 @@
 open Nes
 open Common
 
-open Js_of_ocaml
 open Components
 open Html
 open Utils
@@ -252,7 +251,19 @@ let create ?on_save ?text ?tune () =
                       Editor.clear editor;
                       (
                         match on_save with
-                        | None -> Dom_html.window##.location##.href := Js.string (Endpoints.Page.href_version (Entry.slug version))
+                        | None ->
+                          Components.Toast.open_
+                            ~title: "Version created"
+                            [txt "The version ";
+                            Formatters.Version.name' ~link: true version;
+                            txt " has been created successfully."]
+                            ~buttons: [
+                              Components.Button.make_a
+                                ~label: "Go to version"
+                                ~classes: ["btn-primary"]
+                                ~href: (S.const @@ Endpoints.Page.href_version @@ Entry.slug version)
+                                ();
+                            ]
                         | Some on_save -> on_save version
                       );
                       lwt_unit


### PR DESCRIPTION
Fixes a bunch of resets, but not in a good way. I need something blocking that resets and makes sure to trigger the save to local storage, instead of relying on `S.iter`, which might not trigger fast enough.