### PR TITLE
Introduce a common component API and a “list” component

### DIFF
--- a/src/client/client.ml
+++ b/src/client/client.ml
@@ -19,7 +19,7 @@ let dispatch uri =
     | Person -> (fun context id -> PersonViewer.create ?context id)
     | PersonAdd -> PersonEditor.create ()
     | Version -> (fun context id -> VersionViewer.create ?context id)
-    | VersionAdd -> (fun tune -> VersionEditor.create ~tune: (Option.to_list tune) ())
+    | VersionAdd -> (fun tune -> VersionEditor.create ?tune ())
     | Tune -> (fun context id -> TuneViewer.create ?context id)
     | TuneAdd -> TuneEditor.create ()
     | Set -> (fun context id -> SetViewer.create ?context id)

--- a/src/client/components/choices.ml
+++ b/src/client/components/choices.ml
@@ -6,7 +6,8 @@ let unique =
   let counter = ref 0 in
   fun ?name () ->
     incr counter;
-    Option.value name ~default: "anonymous" ^ "-" ^ string_of_int !counter
+    Option.value name ~default: "anonymous" ^
+      ("-" ^ string_of_int !counter)
 
 type 'value choice = {
   id: string;
@@ -19,115 +20,93 @@ let choice ?(checked = false) ~value contents = {id = unique (); value; checked;
 
 let choice' ?checked ?value contents = choice ?checked ~value contents
 
-type 'value t = {
-  box: 'a. ([> Html_types.div] as 'a) elt;
-  values: 'value S.t;
-}
+let prepare_gen_unsafe (type value)(type choice_value)
+  ~(label : string)
+  ~(validate : choice_value list -> (value, string) result)
+  ~(radios_or_checkboxes : [`Radio | `Checkbox])
+  (choices : choice_value choice list)
+  : (value, string) Component.s
+= (module struct
+  let label = label
 
-let signal c = c.values
-let value c = S.value (signal c)
-let render c = c.box
+  type nonrec value = value
+  type raw_value = string
 
-let make_gen_unsafe
-    ?name
-    ~validation
-    ~validate
-    ~post_validate
-    ~radios
-    choices
-  =
-  let html_name = unique ?name: (Option.map Slug.slugify name) () in
-  let gather_values_such_that p = List.filter_map (fun choice -> if p choice then Some choice.value else None) choices in
-  let (values, set_values) = S.create (gather_values_such_that @@ fun choice -> choice.checked) in
-  let values = S.map validate values in
-  let update_values () =
-    let choice_inputElement choice = Option.get @@ Dom_html.getElementById_coerce choice.id Dom_html.CoerceTo.input in
-    set_values @@ gather_values_such_that @@ fun choice -> Js.to_bool (choice_inputElement choice)##.checked
-  in
-  let box =
-    div
-      ~a: [a_class ["mb-2"]]
-      (
-        List.filter_map Fun.id [
-          (Option.map (label ~a: [a_class ["form-label"]] % List.singleton % txt) name);
-          Some
-            (
-              div
-                ~a: [a_onchange (fun _ -> update_values (); true)]
-                (
-                  flip List.concat_map choices @@ fun choice ->
-                  [
-                    input
-                      ~a: (
-                        List.filter_map Fun.id [
-                          Some (a_input_type (if radios then `Radio else `Checkbox));
-                          Some
-                            (
-                              R.a_class
-                                (
-                                  flip S.map values @@ function
-                                    | Ok _ -> ["btn-check"; "form-check-input"; "is-valid"]
-                                    | Error _ -> ["btn-check"; "form-check-input"; "is-invalid"]
-                                )
-                            );
-                          Some (a_name html_name);
-                          Some (a_id choice.id);
-                          (if choice.checked then Some (a_checked ()) else None);
-                        ]
-                      )
-                      ();
-                    label ~a: [a_class ["btn"; "btn-outline-secondary"; "mx-1"]; a_label_for choice.id] choice.contents;
-                  ]
-                )
-            );
-          (
-            match validation with
-            | false -> None
-            | true ->
-              Some
-                (
-                  R.div
-                    ~a: [
-                      R.a_class
-                        (
-                          flip S.map values @@ function
-                            | Ok _ -> ["d-block"; "valid-feedback"]
-                            | Error _ -> ["d-block"; "invalid-feedback"]
-                        )
-                    ]
-                    (
-                      flip S.map values @@ function
-                        | Ok _ -> [txt " "]
-                        | Error msg -> [txt "Error: "; txt msg]
-                    )
-                )
-          );
-        ]
-      )
-  in
-    {box; values = S.map post_validate values}
+  let empty_value = ""
 
-let make_radios_gen ?name ~validate ~post_validate choices =
-  make_gen_unsafe
-    ?name
-    ~radios: true
-    choices
+  type t = {
+    inner_html: 'a. ([> Html_types.div] as 'a) elt;
+    values: choice_value list S.t;
+  }
+
+  let raw_signal _ = S.const "" (* FIXME: handle raw_signal *)
+  let signal c = S.map validate c.values
+  let inner_html c = c.inner_html
+
+  let focus _ = () (* FIXME *)
+  let trigger _ = () (* FIXME *)
+  let clear _ = () (* FIXME *)
+
+  (* Helper returning a list of the values held by choices satisfying a certain
+     predicate, eg. “this choice is checked”. *)
+  let gather_values_such_that p =
+    List.filter_map
+      (fun choice -> if p choice then Some choice.value else None)
+      choices
+
+  let make _initial_value =
+    (* FIXME: process initial value *)
+    let html_name = unique ~name: (Slug.slugify label) () in
+    let (values, set_values) = S.create (gather_values_such_that @@ fun choice -> choice.checked) in
+    let update_values () =
+      let choice_inputElement choice = Option.get @@ Dom_html.getElementById_coerce choice.id Dom_html.CoerceTo.input in
+      set_values @@ gather_values_such_that @@ fun choice -> Js.to_bool (choice_inputElement choice)##.checked
+    in
+    let inner_html =
+      div
+        ~a: [a_onchange (fun _ -> update_values (); true)]
+        (
+          flip List.concat_map choices @@ fun choice ->
+          [
+            input
+              ~a: (
+                List.filter_map Fun.id [
+                  Some (a_input_type radios_or_checkboxes);
+                  Some (a_name html_name);
+                  Some (a_id choice.id);
+                  Some (a_class ["btn-check"]);
+                  (if choice.checked then Some (a_checked ()) else None);
+                ]
+              )
+              ();
+            Html.label
+              ~a: [a_class ["btn"; "btn-outline-secondary"; "mx-1"]; a_label_for choice.id]
+              choice.contents;
+          ]
+        )
+    in
+      {inner_html; values}
+end)
+
+let prepare_checkboxes ~label choices =
+  prepare_gen_unsafe ~label ~radios_or_checkboxes: `Checkbox ~validate: ok choices
+
+let make_checkboxes ~label choices =
+  Component.initialise (prepare_checkboxes ~label choices) "FIXME"
+
+let prepare_radios' ~label ~validate choices =
+  prepare_gen_unsafe
+    ~label
+    ~radios_or_checkboxes: `Radio
     ~validate: (function
       | [] -> validate None
       | [x] -> validate x
-      | _ -> Error "Cannot select multiple options" (* should never happen *)
+      | _ -> assert false (* because of [`Radio], this should never happen *)
     )
-    ~post_validate
-
-let make_radios ?name choices =
-  make_radios_gen ?name ~validation: false ~validate: ok ~post_validate: Result.get_ok choices
-
-let make_radios' = make_radios_gen ~validation: true ~post_validate: Fun.id
-
-let make_checkboxes choices =
-  make_gen_unsafe
-    ~radios: false
     choices
-    ~validation: false
-    ~validate: ok
-    ~post_validate: Result.get_ok
+
+let make_radios' ~label ~validate choices =
+  Component.initialise (prepare_radios' ~validate ~label choices) "FIXME"
+
+let make_radios ~label choices =
+  make_radios' ~label ~validate: ok choices

--- a/src/client/components/choices.ml
+++ b/src/client/components/choices.ml
@@ -75,6 +75,7 @@ let prepare_gen_unsafe (type value)(type choice_value)
                   Some (a_name html_name);
                   Some (a_id choice.id);
                   Some (a_class ["btn-check"]);
+                  (if List.length choices = 1 then Some (a_tabindex (-1)) else None);
                   (if choice.checked then Some (a_checked ()) else None);
                 ]
               )

--- a/src/client/components/choices.mli
+++ b/src/client/components/choices.mli
@@ -35,34 +35,36 @@ val choice' :
 
 (** {2 Choices element} *)
 
-type 'value t
-(** Abstract type for a “choices” component that can take ['value]s. *)
-
 val make_radios :
-  ?name: string ->
+  label: string ->
   'value option choice list ->
-  'value option t
+  ('value option, string) Component.t
 (** Make a radio-based “choices” component that can hold at most one value at
     once out of a list of single choices. *)
 
 val make_radios' :
-  ?name: string ->
-  validate: ('cvalue option -> ('value, string) Result.t) ->
-  'cvalue option choice list ->
-  ('value, string) Result.t t
+  label: string ->
+  validate: ('choice_value option -> ('value, string) Result.t) ->
+  'choice_value option choice list ->
+  ('value, string) Component.t
 (** Variant of {!make_radios} with a validation function. *)
 
 val make_checkboxes :
+  label: string ->
   'value choice list ->
-  'value list t
+  ('value list, string) Component.t
 (** Make a checkbox-based “choices” component that can hold zero, one, or
     several values at once out of a list of single choices. *)
 
-val signal : 'value t -> 'value S.t
-(** A signal holding the value/s of the “choices” component. *)
+(** {2 Internal use} *)
 
-val value : 'value t -> 'value
-(** The value/s of the “choices” component at that point. *)
+val prepare_radios' :
+  label: string ->
+  validate: ('choice_value option -> ('value, string) Result.t) ->
+  'choice_value option choice list ->
+  ('value, string) Component.s
 
-val render : 'value t -> [> Html_types.div] elt
-(** Render the “choices” component as HTML. *)
+val prepare_checkboxes :
+  label: string ->
+  'value choice list ->
+  ('value list, string) Component.s

--- a/src/client/components/component.ml
+++ b/src/client/components/component.ml
@@ -1,0 +1,41 @@
+open Nes
+open Html
+
+module type S = sig
+  type value
+  type raw_value
+  type t
+
+  val label : string
+
+  val make : raw_value -> t
+  val signal : t -> (value, string) result S.t
+  val raw_signal : t -> raw_value S.t
+  val focus : t -> unit
+
+  val trigger : t -> unit
+  (** Trigger the component. For simple components, this is akin to {!focus}.
+      For components with a button triggering an action, though, {!focus} will
+      only focus the button, while {!trigger} will trigger the action. *)
+
+  val clear : t -> unit
+  val inner_html : t -> Html_types.div_content_fun elt
+  val html : t -> [> Html_types.div] elt
+  val empty_value : raw_value
+end
+
+let case_errored ~no ~yes signal =
+  flip S.map signal @@ function
+    | Error msg -> yes msg
+    | _ -> no
+
+let render ?label: label_ ~signal component =
+  div
+    ~a: [a_class ["mb-2"]]
+    [
+      label ~a: [a_class ["form-label"]] (Option.to_list (Option.map txt label_));
+      component;
+      R.div
+        ~a: [R.a_class (case_errored ~no: ["d-block"; "valid-feedback"] ~yes: (const ["d-block"; "invalid-feedback"]) signal)]
+        (case_errored ~no: [txt " "] ~yes: (List.singleton % txt) signal);
+    ]

--- a/src/client/components/component.ml
+++ b/src/client/components/component.ml
@@ -2,40 +2,78 @@ open Nes
 open Html
 
 module type S = sig
-  type value
-  type raw_value
-  type t
-
   val label : string
 
+  type value
+  type raw_value
+  val empty_value : raw_value
+
+  type t
+
   val make : raw_value -> t
+
   val signal : t -> (value, string) result S.t
   val raw_signal : t -> raw_value S.t
   val focus : t -> unit
-
   val trigger : t -> unit
-  (** Trigger the component. For simple components, this is akin to {!focus}.
-      For components with a button triggering an action, though, {!focus} will
-      only focus the button, while {!trigger} will trigger the action. *)
-
   val clear : t -> unit
   val inner_html : t -> Html_types.div_content_fun elt
-  val html : t -> [> Html_types.div] elt
-  val empty_value : raw_value
 end
+
+type ('value, 'raw_value) s = (module S with type value = 'value and type raw_value = 'raw_value)
+
+let prepare (type value)(type raw_value)
+  (module C : S with type value = value and type raw_value = raw_value)
+  : (value, raw_value) s
+=
+  (module C)
+
+type ('value, 'raw_value) t =
+  Component : (module S with type t = 'a and type value = 'value and type raw_value = 'raw_value) * 'a -> ('value, 'raw_value) t
+
+let initialise (type value)(type raw_value)
+    (module C : S with type value = value and type raw_value = raw_value)
+    (initial_value : raw_value)
+    : (value, raw_value) t
+  =
+  Component ((module C), C.make initial_value)
+
+let make (type value)(type raw_value)
+    (module C : S with type value = value and type raw_value = raw_value)
+    (initial_value : raw_value)
+    : (value, raw_value) t
+  =
+  initialise (prepare (module C)) initial_value
+
+let focus : type value raw_value. (value, raw_value) t -> unit = function Component ((module C), c) -> C.focus c
+let trigger : type value raw_value. (value, raw_value) t -> unit = function Component ((module C), c) -> C.trigger c
+let clear : type value raw_value. (value, raw_value) t -> unit = function Component ((module C), c) -> C.clear c
+let signal : type value raw_value. (value, raw_value) t -> (value, string) result S.t = function Component ((module C), c) -> C.signal c
+let raw_signal : type value raw_value. (value, raw_value) t -> raw_value S.t = function Component ((module C), c) -> C.raw_signal c
+let inner_html : type value raw_value. (value, raw_value) t -> Html_types.div_content_fun elt = function Component ((module C), c) -> C.inner_html c
 
 let case_errored ~no ~yes signal =
   flip S.map signal @@ function
     | Error msg -> yes msg
     | _ -> no
 
-let render ?label: label_ ~signal component =
+let html : type value raw_value. (value, raw_value) t -> [> Html_types.div] elt = function
+  | Component ((module C), c) ->
+    div
+      ~a: [a_class ["mb-2"]]
+      [
+        label ~a: [a_class ["form-label"]] [txt C.label];
+        C.inner_html c;
+        R.div
+          ~a: [R.a_class (case_errored ~no: ["d-block"; "valid-feedback"] ~yes: (const ["d-block"; "invalid-feedback"]) (C.signal c))]
+          (case_errored ~no: [txt " "] ~yes: (List.singleton % txt) (C.signal c));
+      ]
+
+let html_fake ~label: label_ content =
   div
     ~a: [a_class ["mb-2"]]
     [
-      label ~a: [a_class ["form-label"]] (Option.to_list (Option.map txt label_));
-      component;
-      R.div
-        ~a: [R.a_class (case_errored ~no: ["d-block"; "valid-feedback"] ~yes: (const ["d-block"; "invalid-feedback"]) signal)]
-        (case_errored ~no: [txt " "] ~yes: (List.singleton % txt) signal);
+      label ~a: [a_class ["form-label"]] [txt label_];
+      content;
+      div ~a: [a_class ["d-block"; "valid-feedback"]] [txt " "];
     ]

--- a/src/client/components/component.mli
+++ b/src/client/components/component.mli
@@ -1,0 +1,75 @@
+(** {1 Component} *)
+
+open Html
+
+(** {2 Regular interface} *)
+
+type ('value, 'raw_value) t
+
+val focus : ('value, 'raw_value) t -> unit
+val trigger : ('value, 'raw_value) t -> unit
+val clear : ('value, 'raw_value) t -> unit
+val signal : ('value, 'raw_value) t -> ('value, string) result S.t
+val raw_signal : ('value, 'raw_value) t -> 'raw_value S.t
+
+val inner_html : ('value, 'raw_value) t -> Html_types.div_content_fun elt
+
+val html : ('value, 'raw_value) t -> [> Html_types.div] elt
+(** Render the component as HTML. This is not provided by the component itself,
+    but is rather a wrapper shared by all components around their
+    {!inner_html}. *)
+
+val html_fake : label: string -> Html_types.div_content_fun elt -> [> Html_types.div] elt
+(** Mimmics a component in terms of spacing above and below and position of the
+    label. *)
+
+(** {2 Module and functor interface}
+
+    This is the interface that composes well. As a creator of components, this
+    is what you want to manipulate. As a consumer of a component, you do not
+    need to go into this. *)
+
+module type S = sig
+  val label : string
+
+  type value
+  type raw_value
+
+  val empty_value : raw_value
+
+  type t
+
+  val make : raw_value -> t
+
+  val signal : t -> (value, string) result S.t
+  val raw_signal : t -> raw_value S.t
+  val focus : t -> unit
+
+  val trigger : t -> unit
+  (** Trigger the component. For simple components, this is akin to {!focus}.
+      For components with a button triggering an action, though, {!focus} will
+      only focus the button, while {!trigger} will trigger the action. *)
+
+  val clear : t -> unit
+  val inner_html : t -> Html_types.div_content_fun elt
+end
+
+type ('value, 'raw_value) s = (module S with type value = 'value and type raw_value = 'raw_value)
+(** The type of an un-initialised component. This is the type that composes well
+    and that one should provide to eg. {!ComponentList}. *)
+
+val prepare : (module S with type value = 'value and type raw_value = 'raw_value) -> ('value, 'raw_value) s
+
+val initialise : ('value, 'raw_value) s -> 'raw_value -> ('value, 'raw_value) t
+(** Initialise a prepared component. *)
+
+val make : (module S with type value = 'value and type raw_value = 'raw_value) -> 'raw_value -> ('value, 'raw_value) t
+(** Combination of {!prepare} and {!initialise}. *)
+
+(** {2 Utilities} *)
+
+val case_errored :
+  no: 'b ->
+  yes: ('e -> 'b) ->
+  ('a, 'e) result S.t ->
+  'b S.t

--- a/src/client/components/componentList.ml
+++ b/src/client/components/componentList.ml
@@ -1,0 +1,138 @@
+open Nes
+open Js_of_ocaml
+open Html
+
+module Make (C : Component.S) : Component.S with
+  type value = C.value list
+  and type raw_value = C.raw_value list
+= struct
+  let label = C.label ^ "s"
+
+  type value = C.value list
+  type raw_value = C.raw_value list
+
+  let empty_value = []
+
+  type t = {
+    components: C.t list S.t;
+    set_components: C.t list -> unit;
+    inner_html: 'a. ([> Html_types.div] as 'a) elt;
+    button_add_object_dom: Dom_html.buttonElement Js.t;
+  }
+
+  let signal l =
+    S.map (Result.map_error ((^) ("At least one " ^ String.lowercase_ascii C.label ^ " has an error: "))) @@
+    S.map (Result.map List.rev) @@
+    S.bind l.components @@
+    List.fold_left
+      (fun values component ->
+        RS.bind values @@ fun values ->
+        RS.bind (C.signal component) @@ fun value ->
+        RS.pure (value :: values)
+      )
+      (S.const (Ok []))
+
+  let raw_signal l =
+    S.map List.rev @@
+    S.bind l.components @@
+    List.fold_left
+      (fun values component ->
+        S.bind values @@ fun values ->
+        S.bind (C.raw_signal component) @@ fun value ->
+        S.const (value :: values)
+      )
+      (S.const [])
+
+  let focus l =
+    match S.value l.components with
+    | first :: _ -> C.focus first
+    | [] -> l.button_add_object_dom##focus
+
+  let trigger = focus
+
+  let clear l = l.set_components []
+
+  let inner_html l = l.inner_html
+  let html l = Component.render ~label ~signal: (signal l) (inner_html l)
+
+  let make initial_values =
+    (* NOTE: We use [fun _ _ -> false] because React needs to be able to compare
+       things and components are very non-comparable. If it causes issues, then
+       we need the module type {!Component} to provide an equality. *)
+    let (components, set_components) = S.create ~eq: (fun _ _ -> false) @@ List.map C.make initial_values in
+    let button_add_object =
+      Button.make
+        ~label: ("Add a " ^ String.lowercase_ascii C.label)
+        ~label_processing: ("Adding a " ^ String.lowercase_ascii C.label)
+        ~icon: "plus-circle"
+        ~classes: ["btn-primary"]
+        ~onclick: (fun () ->
+          let component = C.make C.empty_value in
+          set_components (S.value components @ [component]);
+          C.focus component;
+          lwt_unit
+        )
+        ()
+    in
+    let button_add_object_dom = To_dom.of_button button_add_object in
+    let inner_html =
+      div [
+        R.div
+          ~a: [
+            R.a_class (
+              S.l2
+                (@)
+                (S.map (function [] -> [] | _ -> ["mb-2"]) components)
+                (S.const ["container"; "text-center"])
+            )
+          ]
+          (
+            flip S.map components @@ fun components_ ->
+            flip List.mapi components_ @@ fun n component ->
+            div ~a: [a_class ["row"; "ps-2"; "border-start"]] [
+              div ~a: [a_class ["col"; "p-0"]] [C.inner_html component];
+              div ~a: [a_class ["col-auto"; "p-0"]] [
+                button
+                  ~a: [
+                    a_class (["btn"; "btn-outline-secondary"] @ (if n = List.length components_ - 1 then ["disabled"] else []));
+                    a_onclick (fun _ -> set_components @@ List.swap n (n + 1) @@ S.value components; true);
+                  ]
+                  [i ~a: [a_class ["bi"; "bi-arrow-down"]] []];
+                button
+                  ~a: [
+                    a_class (["btn"; "btn-outline-secondary"] @ (if n = 0 then ["disabled"] else []));
+                    a_onclick (fun _ -> set_components @@ List.swap (n - 1) n @@ S.value components; true);
+                  ]
+                  [i ~a: [a_class ["bi"; "bi-arrow-up"]] []];
+                button
+                  ~a: [
+                    a_onclick (fun _ -> set_components @@ List.remove n @@ S.value components; true);
+                    a_class ["btn"; "btn-warning"];
+                  ]
+                  [i ~a: [a_class ["bi"; "bi-trash"]] []];
+              ];
+            ]
+          );
+        div [
+          Button.clear ~onclick: (fun () -> set_components []) ();
+          txt " ";
+          button_add_object;
+        ];
+      ]
+    in
+      {components; set_components; inner_html; button_add_object_dom}
+end
+
+module MakeNonEmpty (C : Component.S) : Component.S with
+  type value = C.value NonEmptyList.t
+  and type raw_value = C.raw_value list
+= struct
+  include Make(C)
+  type value = C.value NonEmptyList.t
+  let signal =
+    S.map (fun l ->
+      Result.bind l @@ Option.to_result ~none: ("You must add at least one " ^ String.lowercase_ascii C.label ^ ".") % NonEmptyList.of_list
+    ) %
+      signal
+  let html l = Component.render ~label ~signal: (signal l) (inner_html l)
+end

--- a/src/client/components/componentList.ml
+++ b/src/client/components/componentList.ml
@@ -2,8 +2,10 @@ open Nes
 open Js_of_ocaml
 open Html
 
-let prepare (type value)(type raw_value) (component : (value, raw_value) Component.s) =
-((module struct
+let prepare (type value)(type raw_value)
+  (component : (value, raw_value) Component.s)
+  : (value list, raw_value list) Component.s
+= (module struct
   module C = (val component)
 
   let label = C.label ^ "s"
@@ -120,8 +122,7 @@ let prepare (type value)(type raw_value) (component : (value, raw_value) Compone
       ]
     in
       {components; set_components; inner_html; button_add_object_dom}
-end):
-  (value list, raw_value list) Component.s)
+end)
 
 let make (type value)(type raw_value)
     (component : (value, raw_value) Component.s)

--- a/src/client/components/componentList.ml
+++ b/src/client/components/componentList.ml
@@ -68,7 +68,7 @@ let prepare (type value)(type raw_value) (component : (value, raw_value) Compone
         ~onclick: (fun () ->
           let component = C.make C.empty_value in
           set_components (S.value components @ [component]);
-          C.focus component;
+          C.trigger component;
           lwt_unit
         )
         ()

--- a/src/client/components/componentList.mli
+++ b/src/client/components/componentList.mli
@@ -1,0 +1,33 @@
+(** {1 List of components} *)
+
+open Nes
+
+val make :
+  ('value, 'raw_value) Component.s ->
+  'raw_value list ->
+  ('value list, 'raw_value list) Component.t
+(** Make a list component, that is a component that contains 0, 1, or more
+    instances of the same sub-component. It contains as value the list of values
+    of the sub-components. Note that it consume the sub-components as
+    {!Component.s}. *)
+
+val make_non_empty :
+  ('value, 'raw_value) Component.s ->
+  'raw_value list ->
+  ('value NonEmptyList.t, 'raw_value list) Component.t
+(** Variant of {!make} for a list component that has to contain at least one
+    sub-component. The value type is therefore {!NonEmptyList.t}. *)
+
+(** {2 Internal use} *)
+
+val prepare :
+  ('value, 'raw_value) Component.s ->
+  ('value list, 'raw_value list) Component.s
+(** Variant of {!make} that only prepares the component. It must still be
+    {!Component.initialise}d. This is used for composition. *)
+
+val prepare_non_empty :
+  ('value, 'raw_value) Component.s ->
+  ('value NonEmptyList.t, 'raw_value list) Component.s
+(** Variant of {!make_non_empty} that only prepares the component. It must still
+    be {!Component.initialise}d. *)

--- a/src/client/components/input.ml
+++ b/src/client/components/input.ml
@@ -8,103 +8,111 @@ type html =
 
 type type_ = Text | Password | Textarea
 
-type 'a t = {
-  label: string option;
-  raw_signal: string S.t;
-  signal: ('a, string) result S.t;
-  set: string -> unit;
-  html: html;
-}
+module type Constants = sig
+  type value
+  val label : string
+  val placeholder : string
+  val type_ : type_
+  val validator : string -> (value, string) result S.t
+  val oninput : string -> unit
+end
 
-let raw_signal state = state.raw_signal
+module Make (X : Constants) : Component.S with
+  type value = X.value
+  and type raw_value = string
+= struct
+  let label = X.label
 
-let signal state = state.signal
-let value state = S.value @@ signal state
+  type value = X.value
+  type raw_value = string
 
-let focus state =
-  match state.html with
-  | Text {input_dom; _} ->
-    input_dom##focus;
-    let length = String.length (Js.to_string input_dom##.value) in
-    input_dom##.selectionStart := length;
-    input_dom##.selectionEnd := length
-  | Textarea {textarea_dom; _} -> textarea_dom##focus
+  let empty_value = ""
 
-let trigger = focus
+  type t = {
+    raw_signal: string S.t;
+    signal: (value, string) result S.t;
+    set: string -> unit;
+    html: html;
+  }
 
-let clear state = state.set ""
+  let raw_signal i = i.raw_signal
 
-let make'
-    ?label
-    ?(placeholder = "")
-    ?(oninput = ignore)
-    ~type_
-    ~initial_value
-    ~validator
-    ()
-  =
-  let (raw_signal, set_immediately) = S.create initial_value in
-  let set = S.delayed_setter 0.30 set_immediately in
-  let signal = S.bind raw_signal validator in
-  let html : html =
-    match type_ with
-    | Text | Password ->
-      let input =
-        input
-          ()
-          ~a: [
-            a_input_type (match type_ with Text -> `Text | Password -> `Password | _ -> assert false);
-            a_placeholder placeholder;
-            R.a_value raw_signal;
-            R.a_class (Component.case_errored ~no: ["form-control"; "is-valid"] ~yes: (const ["form-control"; "is-invalid"]) signal);
-            a_oninput (fun event ->
-              (
-                Js.Opt.iter event##.target @@ fun elt ->
-                Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
-                let input = Js.to_string input##.value in
-                set input;
-                oninput input
+  let signal i = i.signal
+
+  let focus i =
+    match i.html with
+    | Text {input_dom; _} ->
+      input_dom##focus;
+      let length = String.length (Js.to_string input_dom##.value) in
+      input_dom##.selectionStart := length;
+      input_dom##.selectionEnd := length
+    | Textarea {textarea_dom; _} -> textarea_dom##focus
+
+  let trigger = focus
+
+  let clear i = i.set ""
+
+  let make initial_value =
+    let (raw_signal, set_immediately) = S.create initial_value in
+    let set = S.delayed_setter 0.30 set_immediately in
+    let signal = S.bind raw_signal X.validator in
+    let html : html =
+      match X.type_ with
+      | Text | Password ->
+        let input =
+          input
+            ()
+            ~a: [
+              a_input_type (match X.type_ with Text -> `Text | Password -> `Password | _ -> assert false);
+              a_placeholder X.placeholder;
+              R.a_value raw_signal;
+              R.a_class (Component.case_errored ~no: ["form-control"; "is-valid"] ~yes: (const ["form-control"; "is-invalid"]) signal);
+              a_oninput (fun event ->
+                (
+                  Js.Opt.iter event##.target @@ fun elt ->
+                  Js.Opt.iter (Dom_html.CoerceTo.input elt) @@ fun input ->
+                  let input = Js.to_string input##.value in
+                  set input;
+                  X.oninput input
+                );
+                false
               );
-              false
-            );
-          ]
-      in
-      Text {input; input_dom = To_dom.of_input input}
-    | Textarea ->
-      let textarea =
-        textarea
-          (R.txt raw_signal)
-          ~a: [
-            a_rows 15;
-            a_placeholder placeholder;
-            (* R.a_value state.raw_signal; FIXME: not possible in textarea but necessary for cleanup *)
-            R.a_class (Component.case_errored ~no: ["form-control"; "is-valid"] ~yes: (const ["form-control"; "is-invalid"]) signal);
-            a_oninput (fun event ->
-              (
-                Js.Opt.iter event##.target @@ fun elt ->
-                Js.Opt.iter (Dom_html.CoerceTo.textarea elt) @@ fun input ->
-                let input = Js.to_string input##.value in
-                set input;
-                oninput input
+            ]
+        in
+        Text {input; input_dom = To_dom.of_input input}
+      | Textarea ->
+        let textarea =
+          textarea
+            (R.txt raw_signal)
+            ~a: [
+              a_rows 15;
+              a_placeholder X.placeholder;
+              (* R.a_value state.raw_signal; FIXME: not possible in textarea but necessary for cleanup *)
+              R.a_class (Component.case_errored ~no: ["form-control"; "is-valid"] ~yes: (const ["form-control"; "is-invalid"]) signal);
+              a_oninput (fun event ->
+                (
+                  Js.Opt.iter event##.target @@ fun elt ->
+                  Js.Opt.iter (Dom_html.CoerceTo.textarea elt) @@ fun input ->
+                  let input = Js.to_string input##.value in
+                  set input;
+                  X.oninput input
+                );
+                false
               );
-              false
-            );
-          ]
-      in
-      Textarea {textarea; textarea_dom = To_dom.of_textarea textarea}
-  in
-    {label; raw_signal; signal; set; html}
+            ]
+        in
+        Textarea {textarea; textarea_dom = To_dom.of_textarea textarea}
+    in
+      {raw_signal; signal; set; html}
 
-let make ?label ?placeholder ?oninput ~type_ ~initial_value ~validator () =
-  make' ?label ?placeholder ?oninput ~type_ ~initial_value ~validator: (S.const % validator) ()
+  let inner_html i =
+    match i.html with
+    | Text {input; _} -> input
+    | Textarea {textarea; _} -> textarea
 
-let inner_html textInput =
-  match textInput.html with
-  | Text {input; _} -> input
-  | Textarea {textarea; _} -> textarea
-
-let html textInput =
-  Component.render ?label: textInput.label ~signal: textInput.signal (inner_html textInput)
+  let html i =
+    Component.render ~label ~signal: i.signal (inner_html i)
+end
 
 let inactive ?label value =
   Component.render ?label ~signal: (S.const (Ok ())) @@

--- a/src/client/components/input.ml
+++ b/src/client/components/input.ml
@@ -8,8 +8,15 @@ type html =
 
 type type_ = Text | Password | Textarea
 
-let prepare (type value) ~type_ ~label ?(placeholder = "") ~validator ?(oninput = fun _ -> ()) () =
-((module struct
+let prepare (type value)
+  ~type_
+  ~label
+  ?(placeholder = "")
+  ~validator
+  ?(oninput = fun _ -> ())
+  ()
+  : (value, string) Component.s
+= (module struct
   let label = label
 
   type nonrec value = value
@@ -98,8 +105,7 @@ let prepare (type value) ~type_ ~label ?(placeholder = "") ~validator ?(oninput 
     match i.html with
     | Text {input; _} -> input
     | Textarea {textarea; _} -> textarea
-end):
-  (value, string) Component.s)
+end)
 
 let make' ~type_ ~label ?placeholder ~validator ?oninput initial_value =
   Component.initialise (prepare ~type_ ~label ?placeholder ~validator ?oninput ()) initial_value

--- a/src/client/components/input.mli
+++ b/src/client/components/input.mli
@@ -48,6 +48,11 @@ val clear : 'a t -> unit
 val focus : 'a t -> unit
 (** Focus a text input component. *)
 
+val trigger : 'a t -> unit
+
+val inner_html : 'a t -> Html_types.div_content_fun Html.elt
+(** Render a text input component as HTML. *)
+
 val html : 'a t -> [> Html_types.div] Html.elt
 (** Render a text input component as HTML. *)
 

--- a/src/client/components/input.mli
+++ b/src/client/components/input.mli
@@ -5,22 +5,41 @@ open Js_of_ocaml_tyxml.Tyxml_js
 
 type type_ = Text | Password | Textarea
 
-module type Constants = sig
-  type value
-  val label : string
-  val placeholder : string
-  val type_ : type_
-  val validator : string -> (value, string) result S.t
-  val oninput : string -> unit
-end
+val make :
+  type_: type_ ->
+  label: string ->
+  ?placeholder: string ->
+  validator: (string -> ('value, string) result) ->
+  ?oninput: (string -> unit) ->
+  string ->
+  ('value, string) Component.t
 
-module Make : functor (X : Constants) ->
-  Component.S with
-  type value = X.value
-  and type raw_value = string
+val make' :
+  type_: type_ ->
+  label: string ->
+  ?placeholder: string ->
+  validator: (string -> ('value, string) result S.t) ->
+  ?oninput: (string -> unit) ->
+  string ->
+  ('value, string) Component.t
+(** Variant of {!make} in which the validator gets access to the inner signal. *)
 
 val inactive :
-  ?label: string ->
+  label: string ->
   string ->
   [> Html_types.div] Html.elt
 (** An inactive text input, compatible graphically with [make ~type_: Text]. *)
+
+(** {2 Internal use} *)
+
+val prepare :
+  type_: type_ ->
+  label: string ->
+  ?placeholder: string ->
+  validator: (string -> ('value, string) result S.t) ->
+  ?oninput: (string -> unit) ->
+  unit ->
+  ('value, string) Component.s
+(** Variant of {!make} that only prepares the component. It must still be
+    {!Component.initialise}d. This is used for composition with eg.
+    {!ComponentList}. *)

--- a/src/client/components/input.mli
+++ b/src/client/components/input.mli
@@ -5,56 +5,19 @@ open Js_of_ocaml_tyxml.Tyxml_js
 
 type type_ = Text | Password | Textarea
 
-type 'a t
-(** Abstract type of a text input component. *)
+module type Constants = sig
+  type value
+  val label : string
+  val placeholder : string
+  val type_ : type_
+  val validator : string -> (value, string) result S.t
+  val oninput : string -> unit
+end
 
-val make :
-  ?label: string ->
-  ?placeholder: string ->
-  ?oninput: (string -> unit) ->
-  type_: type_ ->
-  initial_value: string ->
-  validator: (string -> ('a, string) Result.t) ->
-  unit ->
-  'a t
-(** Make a text input component from the initial input string and a validator
-    function. *)
-
-val make' :
-  ?label: string ->
-  ?placeholder: string ->
-  ?oninput: (string -> unit) ->
-  type_: type_ ->
-  initial_value: string ->
-  validator: (string -> ('a, string) Result.t S.t) ->
-  unit ->
-  'a t
-(** Variant of {!make} where the validator gets access to the internal signal.
-    In fact, [make x v = make' x (S.const % v)]. *)
-
-val raw_signal : 'a t -> string S.t
-(** A signal to the raw value of the input text component. *)
-
-val signal : 'a t -> ('a, string) Result.t S.t
-(** A signal to the value of the input text component as validated by the
-    validator. *)
-
-val value : 'a t -> ('a, string) Result.t
-(** Short for [S.value % signal]. *)
-
-val clear : 'a t -> unit
-(** Clear a text input component to an empty value . *)
-
-val focus : 'a t -> unit
-(** Focus a text input component. *)
-
-val trigger : 'a t -> unit
-
-val inner_html : 'a t -> Html_types.div_content_fun Html.elt
-(** Render a text input component as HTML. *)
-
-val html : 'a t -> [> Html_types.div] Html.elt
-(** Render a text input component as HTML. *)
+module Make : functor (X : Constants) ->
+  Component.S with
+  type value = X.value
+  and type raw_value = string
 
 val inactive :
   ?label: string ->

--- a/src/client/components/selector.ml
+++ b/src/client/components/selector.ml
@@ -28,8 +28,8 @@ let prepare (type model)
     Page.t Lwt.t
   )
   ()
-=
-((module struct
+  : (model Entry.t, model Entry.Id.t option) Component.s
+= (module struct
   let label = label
 
   type value = model Entry.t
@@ -134,8 +134,7 @@ let prepare (type model)
       )
     in
       {signal; set; serialise; inner_html; select_button_dom}
-end):
-  (model Entry.t, model Entry.Id.t option) Component.s)
+end)
 
 let make
     ~label

--- a/src/client/views/bookDownloadDialog.ml
+++ b/src/client/views/bookDownloadDialog.ml
@@ -20,6 +20,7 @@ let create () =
   let booklet_choices =
     Choices.(
       make_radios
+        ~label: "Mode"
         [
           choice' [txt "Normal"] ~checked: true;
           choice'
@@ -38,7 +39,7 @@ let create () =
   {
     choice_rows = (
       set_dialog.choice_rows @ [
-        tr [td [label [txt "Mode:"]]; td [Choices.render booklet_choices]]
+        tr [td [label [txt "Mode:"]]; td [Component.inner_html booklet_choices]]
       ]
     );
     parameters_signal = S.map (Option.value ~default: BookParameters.none) @@
@@ -47,7 +48,7 @@ let create () =
         None
         [
           S.map (some % lift_set_parameters) set_dialog.parameters_signal;
-          Choices.signal booklet_choices;
+          S.map Result.get_ok (Component.signal booklet_choices);
         ]
   }
 

--- a/src/client/views/bookEditor.ml
+++ b/src/client/views/bookEditor.ml
@@ -18,8 +18,11 @@ module RawState = struct
   let set_to_yojson _ = assert false
   let set_of_yojson _ = assert false
 
-  type t =
-  (string, string, set Entry.Id.t list) gen
+  type t = (
+    string,
+    string,
+    set Entry.Id.t option list
+  ) gen
   [@@deriving yojson]
 
   let empty = {
@@ -30,13 +33,16 @@ module RawState = struct
 end
 
 module State = struct
-  type t =
-  (string, PartialDate.t option, Model.Set.t Entry.t list) gen
+  type t = (
+    string,
+    PartialDate.t option,
+    Model.Set.t Entry.t list
+  ) gen
 
   let to_raw_state (state : t) : RawState.t = {
     name = state.name;
     date = Option.fold ~none: "" ~some: PartialDate.to_string state.date;
-    sets = List.map Entry.id state.sets;
+    sets = List.map (some % Entry.id) state.sets;
   }
 
   exception Non_convertible
@@ -64,21 +70,21 @@ module Editor = struct
     elements: (
       (string, string) Component.t,
       (PartialDate.t option, string) Component.t,
-      (Selector.many, Model.Set.t) Selector.t
+      (Model.Set.t Entry.t list, Model.Set.t Entry.Id.t option list) Component.t
     ) gen;
   }
 
   let raw_state (editor : t) : RawState.t S.t =
     S.bind (Component.raw_signal editor.elements.name) @@ fun name ->
     S.bind (Component.raw_signal editor.elements.date) @@ fun date ->
-    S.bind (Selector.raw_signal editor.elements.sets) @@ fun sets ->
+    S.bind (Component.raw_signal editor.elements.sets) @@ fun sets ->
     S.const {name; date; sets}
 
   let state (editor : t) : State.t option S.t =
     S.map Result.to_option @@
     RS.bind (Component.signal editor.elements.name) @@ fun name ->
     RS.bind (Component.signal editor.elements.date) @@ fun date ->
-    RS.bind (Selector.signal_many editor.elements.sets) @@ fun sets ->
+    RS.bind (Component.signal editor.elements.sets) @@ fun sets ->
     RS.pure {name; date; sets}
 
   let with_or_without_local_storage ~text ~edit f =
@@ -117,14 +123,22 @@ module Editor = struct
         initial_state.date
     in
     let sets =
-      Selector.make
-        ~arity: Selector.many
-        ~search: (fun slice input ->
-          let%rlwt filter = lwt (Filter.Set.from_string input) in
-          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Set Search) slice filter
+      ComponentList.make
+        (
+          Selector.prepare
+            ~make_result: AnyResult.make_set_result'
+            ~make_more_results: (fun set -> [Utils.ResultRow.(make [cell ~a: [a_colspan 9999] [Formatters.Set.tunes' set]])])
+            ~label: "Set"
+            ~model_name: "set"
+            ~create_dialog_content: (fun ?on_save text -> SetEditor.create ?on_save ~text ())
+            ~search: (fun slice input ->
+              let%rlwt filter = lwt (Filter.Set.from_string input) in
+              ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Set Search) slice filter
+            )
+            ~serialise: Entry.id
+            ~unserialise: Model.Set.get
+            ()
         )
-        ~serialise: Entry.id
-        ~unserialise: Model.Set.get
         initial_state.sets
     in
     {
@@ -138,7 +152,7 @@ module Editor = struct
   let clear (editor : t) =
     Component.clear editor.elements.name;
     Component.clear editor.elements.date;
-    Selector.clear editor.elements.sets
+    Component.clear editor.elements.sets
 
   let submit ~edit (editor : t) =
     match (S.value (state editor), edit) with
@@ -167,13 +181,7 @@ let create ?on_save ?text ?edit () =
     ~on_load: (fun () -> Component.focus editor.elements.name)
     [Component.html editor.elements.name;
     Component.html editor.elements.date;
-    Selector.render
-      ~make_result: AnyResult.make_set_result'
-      ~make_more_results: (fun set -> [Utils.ResultRow.(make [cell ~a: [a_colspan 9999] [Formatters.Set.tunes' set]])])
-      ~field_name: "Sets"
-      ~model_name: "set"
-      ~create_dialog_content: (fun ?on_save text -> SetEditor.create ?on_save ~text ())
-      editor.elements.sets;
+    Component.html editor.elements.sets;
     ]
     ~buttons: [
       Button.clear

--- a/src/client/views/danceEditor.ml
+++ b/src/client/views/danceEditor.ml
@@ -48,31 +48,38 @@ end
 
 module Editor = struct
   type t = {
-    elements:
-    (string Input.t, Kind.Dance.t Input.t, (Selector.many, Model.Person.t) Selector.t, PartialDate.t option Input.t, string option Input.t, bool option Choices.t, SCDDB.entry_id option Input.t) gen;
+    elements: (
+      (string, string) Component.t,
+      (Kind.Dance.t, string) Component.t,
+      (Selector.many, Model.Person.t) Selector.t,
+      (PartialDate.t option, string) Component.t,
+      (string option, string) Component.t,
+      bool option Choices.t,
+      (SCDDB.entry_id option, string) Component.t
+    ) gen;
   }
 
   let raw_state (editor : t) : RawState.t S.t =
-    S.bind (Input.raw_signal editor.elements.name) @@ fun name ->
-    S.bind (Input.raw_signal editor.elements.kind) @@ fun kind ->
+    S.bind (Component.raw_signal editor.elements.name) @@ fun name ->
+    S.bind (Component.raw_signal editor.elements.kind) @@ fun kind ->
     S.bind (Selector.raw_signal editor.elements.devisers) @@ fun devisers ->
-    S.bind (Input.raw_signal editor.elements.date) @@ fun date ->
-    S.bind (Input.raw_signal editor.elements.disambiguation) @@ fun disambiguation ->
+    S.bind (Component.raw_signal editor.elements.date) @@ fun date ->
+    S.bind (Component.raw_signal editor.elements.disambiguation) @@ fun disambiguation ->
     (* S.bind (Choices.raw_signal editor.elements.two_chords) @@ fun two_chords -> *)
     let two_chords = () in
     (* FIXME *)
-    S.bind (Input.raw_signal editor.elements.scddb_id) @@ fun scddb_id ->
+    S.bind (Component.raw_signal editor.elements.scddb_id) @@ fun scddb_id ->
     S.const {name; kind; devisers; date; disambiguation; two_chords; scddb_id}
 
   let state (editor : t) =
     S.map Result.to_option @@
-    RS.bind (Input.signal editor.elements.name) @@ fun name ->
-    RS.bind (Input.signal editor.elements.kind) @@ fun kind ->
+    RS.bind (Component.signal editor.elements.name) @@ fun name ->
+    RS.bind (Component.signal editor.elements.kind) @@ fun kind ->
     RS.bind (Selector.signal_many editor.elements.devisers) @@ fun devisers ->
-    RS.bind (Input.signal editor.elements.date) @@ fun date ->
-    RS.bind (Input.signal editor.elements.disambiguation) @@ fun disambiguation ->
+    RS.bind (Component.signal editor.elements.date) @@ fun date ->
+    RS.bind (Component.signal editor.elements.disambiguation) @@ fun disambiguation ->
     RS.bind (S.map ok @@ Choices.signal editor.elements.two_chords) @@ fun two_chords ->
-    RS.bind (Input.signal editor.elements.scddb_id) @@ fun scddb_id ->
+    RS.bind (Component.signal editor.elements.scddb_id) @@ fun scddb_id ->
     RS.pure {name; kind; devisers; date; disambiguation; two_chords; scddb_id}
 
   let with_or_without_local_storage ~text f =
@@ -88,20 +95,18 @@ module Editor = struct
     let name =
       Input.make
         ~type_: Text
-        ~initial_value: initial_state.name
         ~label: "Name"
         ~placeholder: "eg. The Dusty Miller"
         ~validator: (Result.of_string_nonempty ~empty: "The name cannot be empty.")
-        ()
+        initial_state.name
     in
     let kind =
       Input.make
         ~type_: Text
-        ~initial_value: initial_state.kind
         ~label: "Kind"
         ~placeholder: "eg. 8x32R or 2x(16R+16S)"
         ~validator: (Option.to_result ~none: "Enter a valid kind, eg. 8x32R or 2x(16R+16S)." % Kind.Dance.of_string_opt)
-        ()
+        initial_state.kind
     in
     let devisers =
       Selector.make
@@ -117,7 +122,6 @@ module Editor = struct
     let date =
       Input.make
         ~type_: Text
-        ~initial_value: initial_state.date
         ~label: "Date of devising"
         ~placeholder: "eg. 2019 or 2012-03-14"
         ~validator: (
@@ -126,16 +130,15 @@ module Editor = struct
             ~some: (Result.map some % Option.to_result ~none: "Enter a valid date, eg. 2019, 2015-10, or 2012-03-14." % PartialDate.from_string) %
             Option.of_string_nonempty
         )
-        ()
+        initial_state.date
     in
     let disambiguation =
       Input.make
         ~type_: Text
-        ~initial_value: initial_state.disambiguation
         ~label: "Disambiguation"
         ~placeholder: "If there are multiple dances with the same name, this field must be used to distinguish them."
         ~validator: (ok % Option.of_string_nonempty)
-        ()
+        initial_state.disambiguation
     in
     let two_chords =
       Choices.make_radios
@@ -148,7 +151,6 @@ module Editor = struct
     let scddb_id =
       Input.make
         ~type_: Text
-        ~initial_value: initial_state.scddb_id
         ~label: "SCDDB ID"
         ~placeholder: "eg. 14298 or https://my.strathspey.org/dd/dance/14298/"
         ~validator: (
@@ -157,18 +159,18 @@ module Editor = struct
             ~some: (Result.map some % SCDDB.entry_from_string SCDDB.Dance) %
             Option.of_string_nonempty
         )
-        ()
+        initial_state.scddb_id
     in
       {elements = {name; kind; devisers; date; disambiguation; two_chords; scddb_id}}
 
   let clear (editor : t) =
-    Input.clear editor.elements.name;
-    Input.clear editor.elements.kind;
+    Component.clear editor.elements.name;
+    Component.clear editor.elements.kind;
     Selector.clear editor.elements.devisers;
-    Input.clear editor.elements.date;
-    Input.clear editor.elements.disambiguation;
+    Component.clear editor.elements.date;
+    Component.clear editor.elements.disambiguation;
     (* FIXME: clear two chords *)
-    Input.clear editor.elements.scddb_id
+    Component.clear editor.elements.scddb_id
 
   let submit (editor : t) =
     match S.value (state editor) with
@@ -192,20 +194,20 @@ let create ?on_save ?text () =
   let%lwt editor = Editor.create ~text in
   Page.make'
     ~title: (lwt "Add a dance")
-    ~on_load: (fun () -> Input.focus editor.elements.name)
-    [Input.html editor.elements.name;
-    Input.html editor.elements.kind;
+    ~on_load: (fun () -> Component.focus editor.elements.name)
+    [Component.html editor.elements.name;
+    Component.html editor.elements.kind;
     Selector.render
       ~make_result: AnyResult.make_person_result'
       ~field_name: "Devisers"
       ~model_name: "person"
       ~create_dialog_content: (fun ?on_save text -> PersonEditor.create ?on_save ~text ())
       editor.elements.devisers;
-    Input.html editor.elements.date;
+    Component.html editor.elements.date;
     Choices.render
       editor.elements.two_chords;
-    Input.html editor.elements.scddb_id;
-    Input.html editor.elements.disambiguation;
+    Component.html editor.elements.scddb_id;
+    Component.html editor.elements.disambiguation;
     ]
     ~buttons: [
       Button.clear

--- a/src/client/views/danceEditor.ml
+++ b/src/client/views/danceEditor.ml
@@ -54,7 +54,7 @@ module Editor = struct
       (Model.Person.t Entry.t list, Model.Person.t Entry.Id.t option list) Component.t,
       (PartialDate.t option, string) Component.t,
       (string option, string) Component.t,
-      bool option Choices.t,
+      (bool option, string) Component.t,
       (SCDDB.entry_id option, string) Component.t
     ) gen;
   }
@@ -78,7 +78,7 @@ module Editor = struct
     RS.bind (Component.signal editor.elements.devisers) @@ fun devisers ->
     RS.bind (Component.signal editor.elements.date) @@ fun date ->
     RS.bind (Component.signal editor.elements.disambiguation) @@ fun disambiguation ->
-    RS.bind (S.map ok @@ Choices.signal editor.elements.two_chords) @@ fun two_chords ->
+    RS.bind (Component.signal editor.elements.two_chords) @@ fun two_chords ->
     RS.bind (Component.signal editor.elements.scddb_id) @@ fun scddb_id ->
     RS.pure {name; kind; devisers; date; disambiguation; two_chords; scddb_id}
 
@@ -149,11 +149,12 @@ module Editor = struct
     in
     let two_chords =
       Choices.make_radios
-        [Choices.choice' [txt "I don't know"] ~checked: true;
-        Choices.choice' ~value: false [txt "One chord"];
-        Choices.choice' ~value: true [txt "Two chords"];
+        ~label: "Number of chords"
+        [
+          Choices.choice' [txt "I don't know"] ~checked: true;
+          Choices.choice' ~value: false [txt "One chord"];
+          Choices.choice' ~value: true [txt "Two chords"];
         ]
-        ~name: "Number of chords"
     in
     let scddb_id =
       Input.make
@@ -206,8 +207,7 @@ let create ?on_save ?text () =
     Component.html editor.elements.kind;
     Component.html editor.elements.devisers;
     Component.html editor.elements.date;
-    Choices.render
-      editor.elements.two_chords;
+    Component.html editor.elements.two_chords;
     Component.html editor.elements.scddb_id;
     Component.html editor.elements.disambiguation;
     ]

--- a/src/client/views/issueReport.ml
+++ b/src/client/views/issueReport.ml
@@ -24,14 +24,14 @@ let open_dialog page =
     flip Lwt.map (describe page) @@ function
       | None ->
         Choices.make_radios'
-          ~name: "Source of the issue"
+          ~label: "Source of the issue"
           ~validate: (Option.to_result ~none: "You must make a choice.")
           [
             Choices.choice' ~value: true [txt "Dancelor itself"] ~checked: true;
           ]
       | Some (kind, name) ->
         Choices.make_radios'
-          ~name: "Source of the issue"
+          ~label: "Source of the issue"
           ~validate: (Option.to_result ~none: "You must make a choice.")
           [
             Choices.choice'
@@ -65,7 +65,7 @@ let open_dialog page =
     RS.bind (match maybe_reporter_input with Left (user, _) -> S.const (ok (left user)) | Right reporter_input -> S.map (Result.map right) (Component.signal reporter_input)) @@ fun reporter ->
     RS.bind (Component.signal title_input) @@ fun title ->
     RS.bind (Component.signal description_input) @@ fun description ->
-    RS.bind (Choices.signal source) @@ fun source ->
+    RS.bind (Component.signal source) @@ fun source ->
     RS.pure Endpoints.IssueReport.Request.{reporter; page; source_is_dancelor = source; title; description}
   in
   let%lwt response =
@@ -78,7 +78,7 @@ let open_dialog page =
         | Left (_, inactive_reporter_input) -> inactive_reporter_input
         | Right reporter_input -> Component.html reporter_input
       );
-      Choices.render source;
+      Component.html source;
       Component.html title_input;
       Component.html description_input;
       ]

--- a/src/client/views/issueReport.ml
+++ b/src/client/views/issueReport.ml
@@ -15,11 +15,10 @@ let open_dialog page =
       right @@
         Input.make
           ~type_: Text
-          ~initial_value: ""
           ~label: "Reporter"
           ~placeholder: "Dr Jean Milligan"
           ~validator: (Result.of_string_nonempty ~empty: "You must specify the reporter.")
-          ()
+          ""
   in
   let%lwt source =
     flip Lwt.map (describe page) @@ function
@@ -47,27 +46,25 @@ let open_dialog page =
   let title_input =
     Input.make
       ~type_: Text
-      ~initial_value: ""
       ~label: "Title"
       ~placeholder: "Blimey, 'tis not working!"
       ~validator: (Result.of_string_nonempty ~empty: "The title cannot be empty.")
-      ()
+      ""
   in
   let description_input =
     Input.make
       ~type_: Textarea
-      ~initial_value: ""
       ~label: "Description"
       ~placeholder: "I am gutted; this knock off tune is wonky at best!"
       ~validator: (Result.of_string_nonempty ~empty: "The description cannot be empty.")
-      ()
+      ""
   in
   let request_signal =
     let page = Uri.to_string page in
     S.map Result.to_option @@
-    RS.bind (match maybe_reporter_input with Left (user, _) -> S.const (ok (left user)) | Right reporter_input -> S.map (Result.map right) (Input.signal reporter_input)) @@ fun reporter ->
-    RS.bind (Input.signal title_input) @@ fun title ->
-    RS.bind (Input.signal description_input) @@ fun description ->
+    RS.bind (match maybe_reporter_input with Left (user, _) -> S.const (ok (left user)) | Right reporter_input -> S.map (Result.map right) (Component.signal reporter_input)) @@ fun reporter ->
+    RS.bind (Component.signal title_input) @@ fun title ->
+    RS.bind (Component.signal description_input) @@ fun description ->
     RS.bind (Choices.signal source) @@ fun source ->
     RS.pure Endpoints.IssueReport.Request.{reporter; page; source_is_dancelor = source; title; description}
   in
@@ -75,15 +72,15 @@ let open_dialog page =
     Page.open_dialog @@ fun return ->
     Page.make'
       ~title: (lwt "Report an issue")
-      ~on_load: (fun () -> Input.focus @@ match maybe_reporter_input with Left _ -> title_input | Right reporter_input -> reporter_input)
+      ~on_load: (fun () -> Component.focus @@ match maybe_reporter_input with Left _ -> title_input | Right reporter_input -> reporter_input)
       [(
         match maybe_reporter_input with
         | Left (_, inactive_reporter_input) -> inactive_reporter_input
-        | Right reporter_input -> Input.html reporter_input
+        | Right reporter_input -> Component.html reporter_input
       );
       Choices.render source;
-      Input.html title_input;
-      Input.html description_input;
+      Component.html title_input;
+      Component.html description_input;
       ]
       ~buttons: [
         Button.cancel' ~return ();

--- a/src/client/views/searchComplexFiltersDialog.ml
+++ b/src/client/views/searchComplexFiltersDialog.ml
@@ -90,6 +90,7 @@ let type_choices filter =
   in
   Choices.(
     make_radios
+      ~label: "Type"
       (
         choice' [txt "All"] ~checked: (filter = None) :: List.map
           (fun type_ ->
@@ -111,6 +112,7 @@ let kind_choices filter =
   in
   Choices.(
     make_checkboxes
+      ~label: "Kind"
       (
         List.map
           (fun kind ->
@@ -139,12 +141,12 @@ let dance_bundled_choices ~kind_choices _filter =
       S.all
         [
           choices_formula
-            ~s: (Choices.signal kind_choices)
+            ~s: (S.map Result.get_ok (Component.signal kind_choices))
             ~f: (Filter.Dance.kind' % Kind.Dance.Filter.baseIs');
         ]
   in
   let html = [
-    Choices.render kind_choices;
+    Component.inner_html kind_choices;
   ]
   in
     (formula, html)
@@ -161,12 +163,12 @@ let set_bundled_choices ~kind_choices _filter =
       S.all
         [
           choices_formula
-            ~s: (Choices.signal kind_choices)
+            ~s: (S.map Result.get_ok (Component.signal kind_choices))
             ~f: (Filter.Set.kind' % Kind.Dance.Filter.baseIs');
         ]
   in
   let html = [
-    Choices.render kind_choices;
+    Component.inner_html kind_choices;
   ]
   in
     (formula, html)
@@ -179,12 +181,12 @@ let tune_bundled_choices ~kind_choices _filter =
       S.all
         [
           choices_formula
-            ~s: (Choices.signal kind_choices)
+            ~s: (S.map Result.get_ok (Component.signal kind_choices))
             ~f: (Filter.Tune.kind' % Kind.Base.Filter.is');
         ]
   in
   let html = [
-    Choices.render kind_choices;
+    Component.inner_html kind_choices;
   ]
   in
     (formula, html)
@@ -220,6 +222,7 @@ let major_key_choices filter =
   in
   Choices.(
     make_checkboxes
+      ~label: "Major keys"
       (
         List.map
           (fun key ->
@@ -261,6 +264,7 @@ let minor_key_choices filter =
   in
   Choices.(
     make_checkboxes
+      ~label: "Minor keys"
       (
         List.map
           (fun key ->
@@ -281,17 +285,22 @@ let version_bundled_choices ~kind_choices filter =
       S.all
         [
           choices_formula
-            ~s: (Choices.signal kind_choices)
+            ~s: (S.map Result.get_ok (Component.signal kind_choices))
             ~f: (Filter.Version.kind' % Kind.Version.Filter.baseIs');
           choices_formula
-            ~s: (S.l2 (@) (Choices.signal major_key_choices) (Choices.signal minor_key_choices))
+            ~s: (
+              S.l2
+                (@)
+                (S.map Result.get_ok (Component.signal major_key_choices))
+                (S.map Result.get_ok (Component.signal minor_key_choices))
+            )
             ~f: Filter.Version.key';
         ]
   in
   let html = [
-    Choices.render kind_choices;
-    Choices.render major_key_choices;
-    Choices.render minor_key_choices;
+    Component.inner_html kind_choices;
+    Component.inner_html major_key_choices;
+    Component.inner_html minor_key_choices;
   ]
   in
     (formula, html)
@@ -319,14 +328,14 @@ let open_ text raws filter =
         [
           (
             (* [type:version] if any type has been selected *)
-            flip S.map (Choices.signal type_choices) @@ function
+            flip S.map (S.map Result.get_ok (Component.signal type_choices)) @@ function
               | None -> Formula.true_
               | Some type_ -> Filter.Any.type_' type_
           );
 
           (* model-specific formulas *)
           (
-            S.bind (Choices.signal type_choices) @@ function
+            S.bind (S.map Result.get_ok (Component.signal type_choices)) @@ function
               | None -> S.const Formula.true_
               | Some Source -> source_formula
               | Some Person -> person_formula
@@ -347,13 +356,13 @@ let open_ text raws filter =
     [div
       ~a: [a_class ["d-flex"; "justify-content-center"]]
       [
-        Choices.render type_choices
+        Component.inner_html type_choices
       ];
     hr ();
     R.div
       ~a: [a_class ["d-flex"; "justify-content-center"]]
       (
-        flip S.map (Choices.signal type_choices) @@ function
+        flip S.map (S.map Result.get_ok (Component.signal type_choices)) @@ function
           | None -> []
           | Some Source -> source_html
           | Some Person -> person_html

--- a/src/client/views/setViewer.ml
+++ b/src/client/views/setViewer.ml
@@ -57,7 +57,7 @@ let create ?context id =
                     ~a: [
                       a_class ["dropdown-item"];
                       a_href Endpoints.Page.(href BookAdd);
-                      a_onclick (fun _ -> BookEditor.Editor.add_to_storage id; true);
+                      a_onclick (fun _ -> BookEditor.Editor.add_to_storage (Some id); true);
                     ]
                     [
                       i ~a: [a_class ["bi"; "bi-plus-square"]] [];

--- a/src/client/views/sourceEditor.ml
+++ b/src/client/views/sourceEditor.ml
@@ -25,21 +25,24 @@ end
 
 module Editor = struct
   type t = {
-    elements:
-    (string Input.t, SCDDB.entry_id option Input.t, string option Input.t) gen
+    elements: (
+      (string, string) Component.t,
+      (SCDDB.entry_id option, string) Component.t,
+      (string option, string) Component.t
+    ) gen
   }
 
   let raw_state (editor : t) : RawState.t S.t =
-    S.bind (Input.raw_signal editor.elements.name) @@ fun name ->
-    S.bind (Input.raw_signal editor.elements.scddb_id) @@ fun scddb_id ->
-    S.bind (Input.raw_signal editor.elements.description) @@ fun description ->
+    S.bind (Component.raw_signal editor.elements.name) @@ fun name ->
+    S.bind (Component.raw_signal editor.elements.scddb_id) @@ fun scddb_id ->
+    S.bind (Component.raw_signal editor.elements.description) @@ fun description ->
     S.const {name; scddb_id; description}
 
   let state (editor : t) =
     S.map Result.to_option @@
-    RS.bind (Input.signal editor.elements.name) @@ fun name ->
-    RS.bind (Input.signal editor.elements.scddb_id) @@ fun scddb_id ->
-    RS.bind (Input.signal editor.elements.description) @@ fun description ->
+    RS.bind (Component.signal editor.elements.name) @@ fun name ->
+    RS.bind (Component.signal editor.elements.scddb_id) @@ fun scddb_id ->
+    RS.bind (Component.signal editor.elements.description) @@ fun description ->
     RS.pure {name; scddb_id; description}
 
   let with_or_without_local_storage ~text f =
@@ -55,16 +58,14 @@ module Editor = struct
     let name =
       Input.make
         ~type_: Text
-        ~initial_value: initial_state.name
         ~label: "Name"
         ~placeholder: "eg. The Paris Book of Scottish Country Dances, volume 2"
         ~validator: (Result.of_string_nonempty ~empty: "The name cannot be empty.")
-        ()
+        initial_state.name
     in
     let scddb_id =
       Input.make
         ~type_: Text
-        ~initial_value: initial_state.scddb_id
         ~label: "SCDDB ID"
         ~placeholder: "eg. 9999 or https://my.strathspey.org/dd/publication/9999/"
         ~validator: (
@@ -73,22 +74,21 @@ module Editor = struct
             ~some: (Result.map some % SCDDB.entry_from_string SCDDB.Publication) %
             Option.of_string_nonempty
         )
-        ()
+        initial_state.scddb_id
     in
     let description =
       Input.make
         ~type_: Textarea
-        ~initial_value: initial_state.name
         ~label: "Description"
         ~placeholder: "eg. Book provided by the RSCDS and containing almost all of the original tunes for the RSCDS dances. New editions come every now and then to add tunes for newly introduced RSCDS dances."
         ~validator: (function "" -> Ok None | s -> Ok (Some s))
-        ()
+        initial_state.name
     in
       {elements = {name; scddb_id; description}}
 
   let clear (editor : t) : unit =
-    Input.clear editor.elements.name;
-    Input.clear editor.elements.scddb_id
+    Component.clear editor.elements.name;
+    Component.clear editor.elements.scddb_id
 
   let submit (editor : t) : Model.Source.t Entry.t option Lwt.t =
     match S.value (state editor) with
@@ -104,10 +104,10 @@ let create ?on_save ?text () =
   let%lwt editor = Editor.create ~text in
   Page.make'
     ~title: (lwt "Add a source")
-    ~on_load: (fun () -> Input.focus editor.elements.name)
-    [Input.html editor.elements.name;
-    Input.html editor.elements.scddb_id;
-    Input.html editor.elements.description;
+    ~on_load: (fun () -> Component.focus editor.elements.name)
+    [Component.html editor.elements.name;
+    Component.html editor.elements.scddb_id;
+    Component.html editor.elements.description;
     ]
     ~buttons: [
       Button.clear

--- a/src/client/views/userCreator.ml
+++ b/src/client/views/userCreator.ml
@@ -30,14 +30,13 @@ let create () =
   let username_input =
     Input.make
       ~type_: Text
-      ~initial_value: ""
       ~placeholder: "JeanMilligan"
       ~label: "Username"
       ~validator: (fun username ->
         if username = "" then Error "The username cannot be empty."
         else Ok username (* FIXME: limit possibilities? FIXME: a module for usernames *)
       )
-      ()
+      ""
   in
   let person_selector =
     Selector.make
@@ -51,13 +50,13 @@ let create () =
       []
   in
   let signal =
-    RS.bind (Input.signal username_input) @@ fun username ->
+    RS.bind (Component.signal username_input) @@ fun username ->
     RS.bind (Selector.signal_one person_selector) @@ fun person ->
     S.const @@ Ok (Model.User.make ~username ~person ())
   in
   Page.make'
     ~title: (lwt "Create user")
-    [Input.html username_input;
+    [Component.html username_input;
     Selector.render
       ~make_result: Utils.AnyResult.make_person_result'
       ~field_name: "Person"
@@ -75,7 +74,7 @@ let create () =
           let user = Result.get_ok @@ S.value signal in
           let%lwt (user, token) = Madge_client.call_exn Endpoints.Api.(route @@ User Create) user in
           open_token_result_dialog user token;%lwt
-          Input.clear username_input;
+          Component.clear username_input;
           Selector.clear person_selector;
           lwt_unit
         )

--- a/src/client/views/userHeader.ml
+++ b/src/client/views/userHeader.ml
@@ -43,7 +43,7 @@ let open_sign_in_dialog () =
   let remember_me_input =
     Choices.(
       make_radios'
-        ~name: "Sign in..."
+        ~label: "Sign in..."
         ~validate: (Option.to_result ~none: "You must make a choice.")
         [
           choice' [txt "Just this once"] ~value: false ~checked: true;
@@ -55,7 +55,7 @@ let open_sign_in_dialog () =
     S.map Result.to_option @@
     RS.bind (Component.signal username_input) @@ fun username ->
     RS.bind (Component.signal password_input) @@ fun password ->
-    RS.bind (Choices.signal remember_me_input) @@ fun remember_me ->
+    RS.bind (Component.signal remember_me_input) @@ fun remember_me ->
     RS.pure (username, password, remember_me)
   in
   let%lwt _ =
@@ -65,7 +65,7 @@ let open_sign_in_dialog () =
       ~on_load: (fun () -> Component.focus username_input)
       [Component.html username_input;
       Component.html password_input;
-      Choices.render remember_me_input;
+      Component.html remember_me_input;
       ]
       ~buttons: [
         Button.cancel' ~return ();

--- a/src/client/views/userHeader.ml
+++ b/src/client/views/userHeader.ml
@@ -11,7 +11,6 @@ let open_sign_in_dialog () =
     Input.make'
       ~type_: Text
       ~label: "Username"
-      ~initial_value: ""
       ~placeholder: "JeanMilligan"
       ~oninput: (fun _ -> set_status_signal DontKnow)
       ~validator: (fun username ->
@@ -23,13 +22,12 @@ let open_sign_in_dialog () =
             | Invalid -> Error "Invalid username or password."
             | DontKnow -> Ok username
       )
-      ()
+      ""
   in
   let password_input =
     Input.make'
       ~type_: Password
       ~label: "Password"
-      ~initial_value: ""
       ~placeholder: "1234567"
       ~oninput: (fun _ -> set_status_signal DontKnow)
       ~validator: (fun password ->
@@ -40,7 +38,7 @@ let open_sign_in_dialog () =
           | _, Invalid -> Error "Invalid username or password."
           | _, DontKnow -> Ok password
       )
-      ()
+      ""
   in
   let remember_me_input =
     Choices.(
@@ -55,8 +53,8 @@ let open_sign_in_dialog () =
   in
   let request_signal =
     S.map Result.to_option @@
-    RS.bind (Input.signal username_input) @@ fun username ->
-    RS.bind (Input.signal password_input) @@ fun password ->
+    RS.bind (Component.signal username_input) @@ fun username ->
+    RS.bind (Component.signal password_input) @@ fun password ->
     RS.bind (Choices.signal remember_me_input) @@ fun remember_me ->
     RS.pure (username, password, remember_me)
   in
@@ -64,9 +62,9 @@ let open_sign_in_dialog () =
     Page.open_dialog @@ fun return ->
     Page.make'
       ~title: (lwt "Sign in")
-      ~on_load: (fun () -> Input.focus username_input)
-      [Input.html username_input;
-      Input.html password_input;
+      ~on_load: (fun () -> Component.focus username_input)
+      [Component.html username_input;
+      Component.html password_input;
       Choices.render remember_me_input;
       ]
       ~buttons: [

--- a/src/client/views/userPasswordResetter.ml
+++ b/src/client/views/userPasswordResetter.ml
@@ -11,34 +11,32 @@ let create username token =
     Input.make
       ~type_: Password
       ~label: "Password"
-      ~initial_value: ""
       ~placeholder: "1234567"
       ~validator: (fun password1 -> Result.bind (Password.check password1) @@ fun () -> Ok password1)
-      ()
+      ""
   in
   let password2_input =
     Input.make'
       ~type_: Password
       ~label: "Password, again"
-      ~initial_value: ""
       ~placeholder: "1234678"
       ~validator: (fun password2 ->
-        flip S.map (Input.raw_signal password1_input) @@ fun password1 ->
+        flip S.map (Component.raw_signal password1_input) @@ fun password1 ->
         if password1 = password2 then Ok password2 else Error "The passwords do not match."
       )
-      ()
+      ""
   in
   let password =
-    RS.bind (Input.signal password1_input) @@ fun password1 ->
-    RS.bind (Input.signal password2_input) @@ fun password2 ->
+    RS.bind (Component.signal password1_input) @@ fun password1 ->
+    RS.bind (Component.signal password2_input) @@ fun password2 ->
     (* Cannot hurt to check twice. *)
     S.const @@ if password1 = password2 then Ok password2 else Error "The passwords do not match."
   in
   Page.make'
     ~title: (lwt "Reset password")
     [Input.inactive ~label: "Username" username;
-    Input.html password1_input;
-    Input.html password2_input;
+    Component.html password1_input;
+    Component.html password2_input;
     ]
     ~buttons: [
       Button.make

--- a/src/client/views/versionDownloadDialog.ml
+++ b/src/client/views/versionDownloadDialog.ml
@@ -14,6 +14,7 @@ let create () =
   let key_choices =
     Choices.(
       make_radios
+        ~label: "Key"
         [
           choice' [txt "C"] ~checked: true;
           choice'
@@ -28,6 +29,7 @@ let create () =
   let clef_choices =
     Choices.(
       make_radios
+        ~label: "Clef"
         [
           choice' [txt "𝄞"] ~checked: true;
           choice'
@@ -44,14 +46,14 @@ let create () =
         (Option.concat VersionParameters.compose)
         None
         [
-          Choices.signal key_choices;
-          Choices.signal clef_choices;
+          S.map Result.get_ok (Component.signal key_choices);
+          S.map Result.get_ok (Component.signal clef_choices);
         ]
   in
   {
     choice_rows = [
-      tr [td [label [txt "Key:"]]; td [Choices.render key_choices]];
-      tr [td [label [txt "Clef:"]]; td [Choices.render clef_choices]];
+      tr [td [label [txt "Key:"]]; td [Component.inner_html key_choices]];
+      tr [td [label [txt "Clef:"]]; td [Component.inner_html clef_choices]];
     ];
     parameters_signal;
   }

--- a/src/client/views/versionViewer.ml
+++ b/src/client/views/versionViewer.ml
@@ -71,7 +71,7 @@ let create ?context id =
                     ~icon: "plus-square"
                     ~classes: ["dropdown-item"]
                     ~onclick: (fun _ ->
-                      SetEditor.Editor.add_to_storage id;
+                      SetEditor.Editor.add_to_storage (Some id);
                       Components.Toast.open_
                         ~title: "Added to current set"
                         [


### PR DESCRIPTION
This PR introduces a common component API, that inputs, choices, selector, etc. respect. This makes the code of editors more repetitive and simpler. This unifies a bit the interfaces that were previously all over the place.

Using this common interface, this PR introduces a “list” component that repeats an existing component. Previously, only the selector had a mechanism of that kind, which therefore worked only for models. We can now have multiple inputs, for instance.

We use this list component to simplify the selector, as list of models can just be obtained by repeating a one-model selector, and we introduce the possibility in the interface to handle several names for tunes.

Future work that this PR opens up:

- We can now easily support multiple names in more models, for instance in dances as suggested by #514. We can finally manage multiple names via the interface.

- We can envision the creation of a “sum” component. By combining both, we should be able to catch up in the frontend on the expressivity of the backend, for instance when it comes to books that can contain either a version or a set.

- Since the code of the editors got significantly more repetitive, we can hope to factorise it under one big notion of “forms” where we only specify the components and all the things about state etc. are handle once and for all. This would simplify all this code and make it more maintainable and evolutive.

- The new code is already in need of some clean up: We lost a functionality in the Choices component, namely the type information that some variants of this component never fail; we should get that back. Also, we now need to care about the type `raw_value` of a component, but in fact, we don't really need that and we only need a way to serialise to and from JSON.