### PR TITLE
Consolidate tune names

### DIFF
--- a/assets/migrations/2025-08-tune-names.sh
+++ b/assets/migrations/2025-08-tune-names.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p yq
+
+set -euC
+
+## WARNING: Call from the root of the repository.
+
+printf >&2 'Rewrite tune names...\n'
+(
+    cd tune
+    total=$(ls -1 | wc -l)
+    index=0
+    for entry in *; do
+        index=$((index + 1))
+        printf >&2 '\r[%d/%d] \033[K%s...' "$index" "$total" "$entry"
+
+        yq --in-place --output-format yaml '
+            .names = [.name] + .["alternative-names"] |
+            del(.["name"]) | del(.["alternative-names"])
+        ' "$entry/meta.yaml"
+    done
+    printf >&2 '\r[%d/%d] \033[Kdone.\n' "$total" "$total"
+)
+printf >&2 'done.\n'

--- a/src/client/formatters/tune.ml
+++ b/src/client/formatters/tune.ml
@@ -9,9 +9,9 @@ let name_gen tune_gen =
     | Right (tune, true) ->
       a
         ~a: [a_href @@ Endpoints.Page.href_tune @@ Entry.id tune]
-        [txt @@ Model.Tune.name' tune]
-    | Right (tune, _) -> txt (Model.Tune.name' tune)
-    | Left tune -> txt (Model.Tune.name tune)
+        [txt @@ Model.Tune.one_name' tune]
+    | Right (tune, _) -> txt (Model.Tune.one_name' tune)
+    | Left tune -> txt (Model.Tune.one_name tune)
   ]
 
 let name = name_gen % Either.left
@@ -49,7 +49,7 @@ let description' = description % Entry.value
 
 let aka tune =
   span @@
-    match Model.Tune.alternative_names tune with
+    match Model.Tune.other_names tune with
     | [] -> []
     | names -> [txt @@ spf "Also known as %s" @@ String.concat ", " names]
 

--- a/src/client/formatters/version.ml
+++ b/src/client/formatters/version.ml
@@ -45,13 +45,13 @@ let name_gen version_gen =
   with_span_placeholder @@
     match version_gen with
     | Right (version, true) ->
-      let%lwt name = Model.Version.name' version in
+      let%lwt name = Model.Version.one_name' version in
       lwt [a ~a: [a_href @@ Endpoints.Page.href_version @@ Entry.id version] [txt name]]
     | Right (version, _) ->
-      let%lwt name = Model.Version.name' version in
+      let%lwt name = Model.Version.one_name' version in
       lwt [txt name]
     | Left version ->
-      let%lwt name = Model.Version.name version in
+      let%lwt name = Model.Version.one_name version in
       lwt [txt name]
 
 let name = name_gen % Either.left

--- a/src/client/tables.ml
+++ b/src/client/tables.ml
@@ -84,7 +84,7 @@ let versions_with_names versions =
     clickable_row
       ~href
       [
-        lwt [with_span_placeholder (List.singleton <$> (txt <$> (Tune.name' <$> Version.tune' version)))];
+        lwt [with_span_placeholder (List.singleton <$> (txt <$> (Tune.one_name' <$> Version.tune' version)))];
         (List.singleton <$> (Formatters.Kind.full_string version <$> Version.tune' version));
         lwt [txt @@ Music.key_to_pretty_string @@ Version.key' version];
         lwt [txt @@ Version.structure' version];

--- a/src/client/utils/anyResult.ml
+++ b/src/client/utils/anyResult.ml
@@ -141,7 +141,7 @@ let make_tune_result' ?classes ?action ?(prefix = []) ?(suffix = []) tune =
     ?action
     (
       prefix @
-      [ResultRow.cell [txt @@ Tune.name' tune];
+      [ResultRow.cell [txt @@ Tune.one_name' tune];
       ResultRow.cell [txt @@ Kind.Base.to_pretty_string ~capitalised: true @@ Tune.kind' tune];
       ResultRow.cell [Formatters.Tune.composers' tune];
       ] @

--- a/src/client/views/setViewer.ml
+++ b/src/client/views/setViewer.ml
@@ -103,7 +103,7 @@ let create ?context id =
                   div
                     ~a: [a_class ["text-center"; "mt-4"]]
                     [
-                      h4 [a ~a: [a_href (Endpoints.Page.href_version ~context id)] [txt @@ Tune.name' tune]];
+                      h4 [a ~a: [a_href (Endpoints.Page.href_version ~context id)] [txt @@ Tune.one_name' tune]];
                       Components.VersionSvg.make version;
                     ]
               )

--- a/src/client/views/tuneEditor.ml
+++ b/src/client/views/tuneEditor.ml
@@ -171,9 +171,10 @@ module Editor = struct
     match S.value (state editor) with
     | None -> lwt_none
     | Some {name; kind; composers; date; dances; remark; scddb_id} ->
+      let names = NonEmptyList.singleton name in
       some
       <$> Madge_client.call_exn Endpoints.Api.(route @@ Tune Create) @@
-          Model.Tune.make ~name ~kind ~composers ?date ~dances ?remark ?scddb_id ()
+          Model.Tune.make ~names ~kind ~composers ?date ~dances ?remark ?scddb_id ()
 end
 
 let create ?on_save ?text () =

--- a/src/client/views/tuneViewer.ml
+++ b/src/client/views/tuneViewer.ml
@@ -14,7 +14,7 @@ let create ?context id =
         ~this_page: (Endpoints.Page.href_tune id)
         (lwt @@ Any.tune tune);
     ]
-    ~title: (lwt @@ Tune.name' tune)
+    ~title: (lwt @@ Tune.one_name' tune)
     ~subtitles: [
       Formatters.Tune.aka' tune;
       Formatters.Tune.description' tune;

--- a/src/client/views/versionViewer.ml
+++ b/src/client/views/versionViewer.ml
@@ -28,7 +28,7 @@ let create ?context id =
         ~this_page: (Endpoints.Page.href_version id)
         (lwt @@ Any.version version);
     ]
-    ~title: (Version.name' version)
+    ~title: (Version.one_name' version)
     ~subtitles: [
       Formatters.Version.tune_aka' version;
       Formatters.Version.tune_description' version;

--- a/src/common/endpoints/page.ml
+++ b/src/common/endpoints/page.ml
@@ -113,12 +113,12 @@ module MakeDescribe (Model : ModelBuilder.S) = struct
       | UserPasswordReset -> const2 lwt_none
       | Version ->
         (fun _ id ->
-          let%lwt name = Model.Version.name' =<< Model.Version.get id in
+          let%lwt name = Model.Version.one_name' =<< Model.Version.get id in
           lwt_some ("version", name)
         )
       | Tune ->
         (fun _ id ->
-          let%lwt name = Model.Tune.name' <$> Model.Tune.get id in
+          let%lwt name = Model.Tune.one_name' <$> Model.Tune.get id in
           lwt_some ("tune", name)
         )
       | Set ->

--- a/src/common/filterBuilder/accepts.ml
+++ b/src/common/filterBuilder/accepts.ml
@@ -118,9 +118,9 @@ module Make (Model : ModelBuilder.S) = struct
       | Core.Tune.Is tune' ->
         lwt @@ Formula.interpret_bool @@ Entry.Id.equal' (Entry.id tune) tune'
       | Name string ->
-        lwt @@ String.proximity ~char_equal string @@ Model.Tune.name' tune
+        lwt @@ Formula.interpret_or_l @@ List.map (String.proximity ~char_equal string) @@ NonEmptyList.to_list @@ Model.Tune.names' tune
       | NameMatches string ->
-        lwt @@ String.inclusion_proximity ~char_equal ~needle: string @@ Model.Tune.name' tune
+        lwt @@ Formula.interpret_or_l @@ List.map (String.inclusion_proximity ~char_equal ~needle: string) @@ NonEmptyList.to_list @@ Model.Tune.names' tune
       | ExistsComposer pfilter ->
         let%lwt composers = Model.Tune.composers' tune in
         let%lwt scores = Lwt_list.map_s (accepts_person pfilter) composers in

--- a/src/common/modelBuilder/builder/any.ml
+++ b/src/common/modelBuilder/builder/any.ml
@@ -20,6 +20,6 @@ module Build (Getters : Getters.S) = struct
     | Dance d -> lwt @@ Core.Dance.name' d
     | Book b -> lwt @@ Core.Book.title' b
     | Set s -> lwt @@ Core.Set.name' s
-    | Tune t -> lwt @@ Core.Tune.name' t
-    | Version v -> Core.Tune.name' <$> Getters.get_tune @@ Core.Version.tune @@ Entry.value v
+    | Tune t -> lwt @@ Core.Tune.one_name' t
+    | Version v -> Core.Tune.one_name' <$> Getters.get_tune @@ Core.Version.tune @@ Entry.value v
 end

--- a/src/common/modelBuilder/builder/version.ml
+++ b/src/common/modelBuilder/builder/version.ml
@@ -19,9 +19,15 @@ module Build (Getters : Getters.S) = struct
     (bars version, Core.Tune.kind' tune)
   let kind' = kind % Entry.value
 
-  let name version = Core.Tune.name' <$> tune version
-  let name' = name % Entry.value
+  let names version = Core.Tune.names' <$> tune version
+  let names' = names % Entry.value
 
-  let slug version = Entry.Slug.of_string <$> name version
+  let one_name version = Core.Tune.one_name' <$> tune version
+  let one_name' = one_name % Entry.value
+
+  let other_names version = Core.Tune.other_names' <$> tune version
+  let other_names' = other_names % Entry.value
+
+  let slug version = Entry.Slug.of_string <$> one_name version
   let slug' = slug % Entry.value
 end

--- a/src/common/modelBuilder/signature/tune.ml
+++ b/src/common/modelBuilder/signature/tune.ml
@@ -6,8 +6,7 @@ module type S = sig
   type t = Core.Tune.t
 
   val make :
-    name: string ->
-    ?alternative_names: string list ->
+    names: string NonEmptyList.t ->
     kind: Kind.Base.t ->
     ?composers: Core.Person.t Entry.t list ->
     ?dances: Core.Dance.t Entry.t list ->
@@ -19,11 +18,16 @@ module type S = sig
 
   (** {2 Field getters} *)
 
-  val name : t -> string
-  val name' : t Entry.t -> string
+  val names : t -> string NonEmptyList.t
+  val names' : t Entry.t -> string NonEmptyList.t
 
-  val alternative_names : t -> string list
-  val alternative_names' : t Entry.t -> string list
+  (** One name in the list of name. Picking it is deterministic. *)
+  val one_name : t -> string
+  val one_name' : t Entry.t -> string
+
+  (** {!names} minus {!one_name}. *)
+  val other_names : t -> string list
+  val other_names' : t Entry.t -> string list
 
   val kind : t -> Kind.Base.t
   val kind' : t Entry.t -> Kind.Base.t

--- a/src/common/modelBuilder/signature/version.ml
+++ b/src/common/modelBuilder/signature/version.ml
@@ -49,9 +49,17 @@ module type S = sig
   val kind' : t Entry.t -> Kind.Version.t Lwt.t
   (** Convenient wrapper around {!bars} and {!Tune.kind}. *)
 
-  val name : t -> string Lwt.t
-  val name' : t Entry.t -> string Lwt.t
-  (** Convenient wrapper around {!tune} and {!Tune.name}. *)
+  val names : t -> string NonEmptyList.t Lwt.t
+  val names' : t Entry.t -> string NonEmptyList.t Lwt.t
+  (** Convenient wrapper around {!tune} and {!Tune.names}. *)
+
+  val one_name : t -> string Lwt.t
+  val one_name' : t Entry.t -> string Lwt.t
+  (** Convenient wrapper around {!tune} and {!Tune.one_name}. *)
+
+  val other_names : t -> string list Lwt.t
+  val other_names' : t Entry.t -> string list Lwt.t
+  (** Convenient wrapper around {!tune} and {!Tune.other_names}. *)
 
   val slug : t -> Entry.Slug.t Lwt.t
   val slug' : t Entry.t -> Entry.Slug.t Lwt.t

--- a/src/nes/nes.ml
+++ b/src/nes/nes.ml
@@ -30,6 +30,7 @@ module Void = NesVoid
 module Lwt_option = NesLwt_option
 module Password = NesPassword
 module HashedSecret = NesHashedSecret
+module NonEmptyList = NesNonEmptyList
 
 (* Monads *)
 

--- a/src/nes/nesNonEmptyList.ml
+++ b/src/nes/nesNonEmptyList.ml
@@ -1,0 +1,25 @@
+type 'a t = L of 'a list [@@deriving eq, show]
+
+let to_list (L xs) = xs
+
+let of_list = function [] -> None | xs -> Some (L xs)
+
+let of_list_exn = function
+  | [] -> invalid_arg "NesNonEmptyList.of_list_exn: empty list"
+  | xs -> L xs
+
+type 'a mylist = 'a list [@@deriving yojson]
+
+let of_yojson a_of_yojson json =
+  Result.bind (mylist_of_yojson a_of_yojson json) @@ fun xs ->
+  Option.to_result ~none: "empty list" (of_list xs)
+
+let to_yojson a_to_yojson (L xs) =
+  mylist_to_yojson a_to_yojson xs
+
+let map f (L xs) = L (List.map f xs)
+
+let hd (L xs) = List.hd xs
+let tl (L xs) = List.tl xs
+
+let singleton x = L [x]

--- a/src/nes/nesNonEmptyList.mli
+++ b/src/nes/nesNonEmptyList.mli
@@ -1,0 +1,27 @@
+(** {1 Non-empty list} *)
+
+type 'a t [@@deriving eq, show, yojson]
+(** A non-empty list. *)
+
+val to_list : 'a t -> 'a list
+(** Convert a non-empty list to a regular list. *)
+
+val of_list : 'a list -> 'a t option
+(** Convert a list to a non-empty list. *)
+
+val of_list_exn : 'a list -> 'a t
+(** Convert a list to a non-empty list, or raise {!Invalid_argument} if the list
+    is empty. *)
+
+val hd : 'a t -> 'a
+(** Get the head of a non-empty list, that is the first element of the list. *)
+
+val tl : 'a t -> 'a list
+(** Get the tail of a non-empty list, that is the list without its first
+    element. *)
+
+val map : ('a -> 'b) -> 'a t -> 'b t
+(** Map a function over a non-empty list. *)
+
+val singleton : 'a -> 'a t
+(** Create a non-empty list with a single element. *)

--- a/src/server/controller/book/ly.ml
+++ b/src/server/controller/book/ly.ml
@@ -128,7 +128,7 @@ let render book book_parameters rendering_parameters =
         flip Lwt_list.map_p contents @@ function
           | Model.Book.Version (version, parameters) ->
             let%lwt tune = Model.Version.tune' version in
-            let name = Model.VersionParameters.display_name' ~default: (Model.Tune.name' tune) parameters in
+            let name = Model.VersionParameters.display_name' ~default: (Model.Tune.one_name' tune) parameters in
             let trivia = Model.VersionParameters.trivia' ~default: " " parameters in
             let parameters = Model.VersionParameters.set_display_name trivia parameters in
             let set =
@@ -199,7 +199,7 @@ let render book book_parameters rendering_parameters =
         in
         let%lwt tune = Model.Version.tune' version in
         let key = Model.Version.key' version in
-        let name = Model.VersionParameters.display_name' ~default: (Model.Tune.name' tune) version_parameters in
+        let name = Model.VersionParameters.display_name' ~default: (Model.Tune.one_name' tune) version_parameters in
         let%lwt composer = (String.concat ", " ~last: " and " % List.map Model.Person.name') <$> Model.Tune.composers' tune in
         let composer = Model.VersionParameters.display_composer' ~default: composer version_parameters in
         let first_bar = Model.VersionParameters.first_bar' version_parameters in

--- a/src/server/controller/tune.ml
+++ b/src/server/controller/tune.ml
@@ -25,8 +25,8 @@ include Search.Build(struct
   let filter_accepts = Filter.Tune.accepts
 
   let tiebreakers =
-    Lwt_list.[increasing (lwt % Model.Tune.name') String.Sensible.compare;
-    increasing (lwt % Model.Tune.name') String.compare_lengths;
+    Lwt_list.[increasing (lwt % Model.Tune.one_name') String.Sensible.compare;
+    increasing (lwt % Model.Tune.one_name') String.compare_lengths;
     ]
 end)
 

--- a/src/server/controller/version/ly.ml
+++ b/src/server/controller/version/ly.ml
@@ -14,7 +14,7 @@ let prepare_file parameters ?(show_meta = false) ?(meta_in_title = false) ~fname
   let fname_scm = Filename.chop_extension fname ^ ".scm" in
   let%lwt tune = Model.Version.tune' version in
   let key = Model.Version.key' version in
-  let name = Model.VersionParameters.display_name' ~default: (Model.Tune.name' tune) parameters in
+  let name = Model.VersionParameters.display_name' ~default: (Model.Tune.one_name' tune) parameters in
   let%lwt composer = (String.concat ", " ~last: " and " % List.map Model.Person.name') <$> Model.Tune.composers' tune in
   let composer = Model.VersionParameters.display_composer' ~default: composer parameters in
   let title, piece =

--- a/src/server/controller/version/pdf.ml
+++ b/src/server/controller/version/pdf.ml
@@ -5,7 +5,7 @@ module Log = (val Logger.create "controller.version.pdf": Logs.LOG)
 
 let render version version_parameters rendering_parameters =
   let%lwt set =
-    let%lwt name = Model.Version.name' version in
+    let%lwt name = Model.Version.one_name' version in
     let%lwt kind = Model.Version.kind' version in
     let kind = Kind.Dance.Version kind in
     let version_parameters = Model.VersionParameters.set_display_name "" version_parameters in
@@ -21,7 +21,7 @@ let render version version_parameters rendering_parameters =
   let%lwt rendering_parameters =
     let%lwt pdf_metadata =
       let%lwt tune = Model.Version.tune' version in
-      let name = Option.value (Model.VersionParameters.display_name version_parameters) ~default: (Model.Tune.name' tune) in
+      let name = Option.value (Model.VersionParameters.display_name version_parameters) ~default: (Model.Tune.one_name' tune) in
       let%lwt composers = List.map Model.Person.name' <$> Model.Tune.composers' tune in
       let subjects = [KindBase.to_pretty_string ~capitalised: true @@ Model.Tune.kind' tune] in
       lwt @@

--- a/src/server/controller/version/version.ml
+++ b/src/server/controller/version/version.ml
@@ -57,7 +57,7 @@ include Search.Build(struct
   let filter_accepts = Filter.Version.accepts
 
   let tiebreakers =
-    Lwt_list.[increasing (Lwt.map Model.Tune.name' % Model.Version.tune') String.Sensible.compare]
+    Lwt_list.[increasing Model.Version.one_name' String.Sensible.compare]
 end)
 
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Version.t -> a = fun env endpoint ->

--- a/src/server/routine.ml
+++ b/src/server/routine.ml
@@ -12,7 +12,7 @@ let preload_versions ?max_concurrency () =
       ?max_concurrency
       (fun version ->
         let%lwt tune = Model.Version.tune' version in
-        let name = Model.Tune.name' tune in
+        let name = Model.Tune.one_name' tune in
         Log.debug (fun m -> m "Prerendering %s" name);
         let%lwt _ = Controller.Version.Svg.render version Model.VersionParameters.none RenderingParameters.none in
         let%lwt _ = Controller.Version.Ogg.render version Model.VersionParameters.none RenderingParameters.none in

--- a/tests/database/tune/qdod-ad7l-8gr2/meta.yaml
+++ b/tests/database/tune/qdod-ad7l-8gr2/meta.yaml
@@ -1,4 +1,5 @@
-name: Tam Lin
+names:
+  - Tam Lin
 kind: R
 composers:
   - 4plf-srss-ihav


### PR DESCRIPTION
This PR is a spin-off of #524. It consolidates the tune names by merging the
fields `name` and `alternative-names` into one field `names` containing a
non-empty list. This requires database migration.