### PR TITLE
Make magic getters return options

### DIFF
--- a/src/client/components/contextLinks.ml
+++ b/src/client/components/contextLinks.ml
@@ -20,12 +20,12 @@ let get_neighbours any = function
     in
     lwt List.{total; previous; index; next; element = any}
   | Endpoints.Page.InSet (set, index) ->
-    let%lwt set = Set.get set in
+    let%lwt set = Option.get <$> Set.get set in
     let%lwt context = Option.get <$> Set.find_context' index set in
     assert (any = Any.Version context.element);
     lwt @@ List.map_context Any.version context
   | Endpoints.Page.InBook (book, index) ->
-    let%lwt book = Book.get book in
+    let%lwt book = Option.get <$> Book.get book in
     let%lwt context =
       List.map_context book_page_to_any
       <$> (Option.get <$> Book.find_context_no_inline' index book)
@@ -84,10 +84,10 @@ let make_and_render ?context ~this_page any_lwt =
                             | InSearch query ->
                               lwt [txt "search for: "; parent_a [txt query]]
                             | InSet (id, _) ->
-                              let%lwt name = Set.name' <$> Set.get id in
+                              let%lwt name = Set.name' % Option.get <$> Set.get id in
                               lwt [txt "set: "; parent_a [txt name]]
                             | InBook (id, _) ->
-                              let%lwt name = Book.title' <$> Book.get id in
+                              let%lwt name = Book.title' % Option.get <$> Book.get id in
                               lwt [txt "book: "; parent_a [txt name]]
                           );
                       ];

--- a/src/client/components/editor.ml
+++ b/src/client/components/editor.ml
@@ -117,7 +117,7 @@ let mode_from_text_or_id get initial_text maybe_id =
   match initial_text, maybe_id with
   | None, None -> lwt @@ CreateWithLocalStorage
   | Some initial_text, None -> lwt @@ QuickCreate initial_text
-  | None, Some id -> edit <$> get id
+  | None, Some id -> edit % Option.get <$> get id
   | _ -> invalid_arg "mode_from_text_and_edit"
 
 let make_page (type value)(type raw_value)

--- a/src/client/components/editor.mli
+++ b/src/client/components/editor.mli
@@ -29,7 +29,7 @@ type 'result mode =
 [@@deriving variants]
 
 val mode_from_text_or_id :
-  ('id -> 'result Lwt.t) ->
+  ('id -> 'result option Lwt.t) ->
   string option ->
   'id option ->
   'result mode Lwt.t

--- a/src/client/components/selector.ml
+++ b/src/client/components/selector.ml
@@ -88,7 +88,7 @@ let prepare (type model)
       let%lwt initial_value =
         match initial_value with
         | None -> lwt_none
-        | Some initial_value -> some <$> unserialise initial_value
+        | Some initial_value -> unserialise initial_value
       in
       set initial_value;
       lwt_unit

--- a/src/client/components/selector.mli
+++ b/src/client/components/selector.mli
@@ -7,7 +7,7 @@ open Html
 val make :
   label: string ->
   search: (Slice.t -> string -> (int * 'model Entry.t list, string) Result.t Lwt.t) ->
-  unserialise: ('model Entry.Id.t -> 'model Entry.t Lwt.t) ->
+  unserialise: ('model Entry.Id.t -> 'model Entry.t option Lwt.t) ->
   make_result:
   (?classes: string list ->
   ?action: Utils.ResultRow.action ->
@@ -31,7 +31,7 @@ val make :
 val prepare :
   label: string ->
   search: (Slice.t -> string -> (int * 'model Entry.t list, string) Result.t Lwt.t) ->
-  unserialise: ('model Entry.Id.t -> 'model Entry.t Lwt.t) ->
+  unserialise: ('model Entry.Id.t -> 'model Entry.t option Lwt.t) ->
   make_result:
   (?classes: string list ->
   ?action: Utils.ResultRow.action ->

--- a/src/client/model.ml
+++ b/src/client/model.ml
@@ -1,10 +1,18 @@
+open Nes
 open Common
+
+let madge_call_or_option endpoint id =
+  flip Lwt.map (Madge_client.call (Endpoints.Api.route @@ endpoint) id) @@ function
+    | Ok v -> Some v
+    | Error (Madge_client.Http {status = `Not_found; _}) -> None
+    | Error e -> raise (Madge_client.Error e)
+
 include ModelBuilder.Build(struct
-  let get_book = Madge_client.call_exn Endpoints.Api.(route @@ Book Get)
-  let get_dance = Madge_client.call_exn Endpoints.Api.(route @@ Dance Get)
-  let get_person = Madge_client.call_exn Endpoints.Api.(route @@ Person Get)
-  let get_set = Madge_client.call_exn Endpoints.Api.(route @@ Set Get)
-  let get_source = Madge_client.call_exn Endpoints.Api.(route @@ Source Get)
-  let get_tune = Madge_client.call_exn Endpoints.Api.(route @@ Tune Get)
-  let get_version = Madge_client.call_exn Endpoints.Api.(route @@ Version Get)
+  let get_book = madge_call_or_option Endpoints.Api.(Book Get)
+  let get_dance = madge_call_or_option Endpoints.Api.(Dance Get)
+  let get_person = madge_call_or_option Endpoints.Api.(Person Get)
+  let get_set = madge_call_or_option Endpoints.Api.(Set Get)
+  let get_source = madge_call_or_option Endpoints.Api.(Source Get)
+  let get_tune = madge_call_or_option Endpoints.Api.(Tune Get)
+  let get_version = madge_call_or_option Endpoints.Api.(Version Get)
 end)

--- a/src/common/endpoints/page.ml
+++ b/src/common/endpoints/page.ml
@@ -134,37 +134,37 @@ module MakeDescribe (Model : ModelBuilder.S) = struct
       | Any -> (fun id -> lwt_some ("any", Entry.Id.to_string id))
       | Version ->
         (fun _ id ->
-          let%lwt name = Model.Version.one_name' =<< Model.Version.get id in
+          let%lwt name = Model.Version.one_name' % Option.get =<< Model.Version.get id in
           lwt_some ("version", name)
         )
       | Tune ->
         (fun _ id ->
-          let%lwt name = Model.Tune.one_name' <$> Model.Tune.get id in
+          let%lwt name = Model.Tune.one_name' % Option.get <$> Model.Tune.get id in
           lwt_some ("tune", name)
         )
       | Set ->
         (fun _ id ->
-          let%lwt name = Model.Set.name' <$> Model.Set.get id in
+          let%lwt name = Model.Set.name' % Option.get <$> Model.Set.get id in
           lwt_some ("set", name)
         )
       | Book ->
         (fun _ id ->
-          let%lwt title = Model.Book.title' <$> Model.Book.get id in
+          let%lwt title = Model.Book.title' % Option.get <$> Model.Book.get id in
           lwt_some ("book", title)
         )
       | Dance ->
         (fun _ id ->
-          let%lwt name = Model.Dance.one_name' <$> Model.Dance.get id in
+          let%lwt name = Model.Dance.one_name' % Option.get <$> Model.Dance.get id in
           lwt_some ("dance", name)
         )
       | Person ->
         (fun _ id ->
-          let%lwt name = Model.Person.name' <$> Model.Person.get id in
+          let%lwt name = Model.Person.name' % Option.get <$> Model.Person.get id in
           lwt_some ("person", name)
         )
       | Source ->
         (fun _ id ->
-          let%lwt name = Model.Source.name' <$> Model.Source.get id in
+          let%lwt name = Model.Source.name' % Option.get <$> Model.Source.get id in
           lwt_some ("source", name)
         )
     in

--- a/src/common/modelBuilder/builder/any.ml
+++ b/src/common/modelBuilder/builder/any.ml
@@ -22,6 +22,6 @@ module Build (Getters : Getters.S) = struct
     | Book b -> lwt @@ Core.Book.title' b
     | Set s -> lwt @@ Core.Set.name' s
     | Tune t -> lwt @@ Core.Tune.one_name' t
-    | Version v -> Core.Tune.one_name' <$> Getters.get_tune @@ Core.Version.tune @@ Entry.value v
+    | Version v -> (Core.Tune.one_name' % Option.get) <$> Getters.get_tune @@ Core.Version.tune @@ Entry.value v
     | User u -> lwt @@ Core.User.username' u
 end

--- a/src/common/modelBuilder/builder/dance.ml
+++ b/src/common/modelBuilder/builder/dance.ml
@@ -5,7 +5,7 @@ module Build (Getters : Getters.S) = struct
 
   let get = Getters.get_dance
 
-  let devisers = Lwt_list.map_p Getters.get_person % devisers
+  let devisers = Lwt_list.map_p (Lwt.map Option.get % Getters.get_person) % devisers
   let devisers' = devisers % Entry.value
 
   let equal dance1 dance2 = Entry.Id.equal' (Entry.id dance1) (Entry.id dance2)

--- a/src/common/modelBuilder/builder/setParameters.ml
+++ b/src/common/modelBuilder/builder/setParameters.ml
@@ -9,6 +9,6 @@ module Build (Getters : Getters.S) = struct
 
   let for_dance p =
     let%olwt dance_id = lwt (for_dance p) in
-    let%lwt dance = Getters.get_dance dance_id in
+    let%lwt dance = Option.get <$> Getters.get_dance dance_id in
     lwt_some dance
 end

--- a/src/common/modelBuilder/builder/source.ml
+++ b/src/common/modelBuilder/builder/source.ml
@@ -5,6 +5,6 @@ module Build (Getters : Getters.S) = struct
 
   let get = Getters.get_source
 
-  let editors = Lwt_list.map_p Getters.get_person % editors
+  let editors = Lwt_list.map_p (Lwt.map Option.get % Getters.get_person) % editors
   let editors' = editors % Entry.value
 end

--- a/src/common/modelBuilder/builder/tune.ml
+++ b/src/common/modelBuilder/builder/tune.ml
@@ -5,9 +5,9 @@ module Build (Getters : Getters.S) = struct
 
   let get = Getters.get_tune
 
-  let composers = Lwt_list.map_p Getters.get_person % composers
+  let composers = Lwt_list.map_p (Lwt.map Option.get % Getters.get_person) % composers
   let composers' = composers % Entry.value
 
-  let dances = Lwt_list.map_p Getters.get_dance % dances
+  let dances = Lwt_list.map_p (Lwt.map Option.get % Getters.get_dance) % dances
   let dances' = dances % Entry.value
 end

--- a/src/common/modelBuilder/builder/user.ml
+++ b/src/common/modelBuilder/builder/user.ml
@@ -6,12 +6,12 @@ module Build (Getters : Getters.S) = struct
   let update ?username ?person ?password ?password_reset_token ?remember_me_tokens user =
     update
       ?username
-      ?person: (Option.map (fun person id -> Lwt.map Entry.id % person =<< Getters.get_person id) person)
+      ?person: (Option.map (fun person id -> Lwt.map Entry.id % person % Option.get =<< Getters.get_person id) person)
       ?password
       ?password_reset_token
       ?remember_me_tokens
       user
 
-  let person = Getters.get_person % person
+  let person = Lwt.map Option.get % Getters.get_person % person
   let person' = person % Entry.value
 end

--- a/src/common/modelBuilder/builder/version.ml
+++ b/src/common/modelBuilder/builder/version.ml
@@ -5,13 +5,13 @@ module Build (Getters : Getters.S) = struct
 
   let get = Getters.get_version
 
-  let tune = Getters.get_tune % tune
+  let tune = Lwt.map Option.get % Getters.get_tune % tune
   let tune' = tune % Entry.value
 
-  let sources = Lwt_list.map_p Getters.get_source % sources
+  let sources = Lwt_list.map_p (Lwt.map Option.get % Getters.get_source) % sources
   let sources' = sources % Entry.value
 
-  let arrangers = Lwt_list.map_p Getters.get_person % arrangers
+  let arrangers = Lwt_list.map_p (Lwt.map Option.get % Getters.get_person) % arrangers
   let arrangers' = arrangers % Entry.value
 
   let kind version =

--- a/src/common/modelBuilder/builder/versionParameters.ml
+++ b/src/common/modelBuilder/builder/versionParameters.ml
@@ -5,6 +5,6 @@ module Build (Getters : Getters.S) = struct
 
   let for_dance p =
     let%olwt dance_id = lwt (for_dance p) in
-    let%lwt dance = Getters.get_dance dance_id in
+    let%lwt dance = Option.get <$> Getters.get_dance dance_id in
     lwt_some dance
 end

--- a/src/common/modelBuilder/getters.ml
+++ b/src/common/modelBuilder/getters.ml
@@ -1,11 +1,11 @@
 open Nes
 
 module type S = sig
-  val get_book : Core.Book.t Entry.Id.t -> Core.Book.t Entry.t Lwt.t
-  val get_dance : Core.Dance.t Entry.Id.t -> Core.Dance.t Entry.t Lwt.t
-  val get_person : Core.Person.t Entry.Id.t -> Core.Person.t Entry.t Lwt.t
-  val get_set : Core.Set.t Entry.Id.t -> Core.Set.t Entry.t Lwt.t
-  val get_source : Core.Source.t Entry.Id.t -> Core.Source.t Entry.t Lwt.t
-  val get_tune : Core.Tune.t Entry.Id.t -> Core.Tune.t Entry.t Lwt.t
-  val get_version : Core.Version.t Entry.Id.t -> Core.Version.t Entry.t Lwt.t
+  val get_book : Core.Book.t Entry.Id.t -> Core.Book.t Entry.t option Lwt.t
+  val get_dance : Core.Dance.t Entry.Id.t -> Core.Dance.t Entry.t option Lwt.t
+  val get_person : Core.Person.t Entry.Id.t -> Core.Person.t Entry.t option Lwt.t
+  val get_set : Core.Set.t Entry.Id.t -> Core.Set.t Entry.t option Lwt.t
+  val get_source : Core.Source.t Entry.Id.t -> Core.Source.t Entry.t option Lwt.t
+  val get_tune : Core.Tune.t Entry.Id.t -> Core.Tune.t Entry.t option Lwt.t
+  val get_version : Core.Version.t Entry.Id.t -> Core.Version.t Entry.t option Lwt.t
 end

--- a/src/common/modelBuilder/signature/book.ml
+++ b/src/common/modelBuilder/signature/book.ml
@@ -108,5 +108,5 @@ module type S = sig
   (** Magic getter. On the client side, this hides an API call, which goes
       through the permissions mechanism. On the server side, this hides a call
       to the database. *)
-  val get : t Entry.Id.t -> t Entry.t Lwt.t
+  val get : t Entry.Id.t -> t Entry.t option Lwt.t
 end

--- a/src/common/modelBuilder/signature/dance.ml
+++ b/src/common/modelBuilder/signature/dance.ml
@@ -54,5 +54,5 @@ module type S = sig
   (** Magic getter. On the client side, this hides an API call, which goes
       through the permissions mechanism. On the server side, this hides a call
       to the database. *)
-  val get : t Entry.Id.t -> t Entry.t Lwt.t
+  val get : t Entry.Id.t -> t Entry.t option Lwt.t
 end

--- a/src/common/modelBuilder/signature/person.ml
+++ b/src/common/modelBuilder/signature/person.ml
@@ -28,5 +28,5 @@ module type S = sig
   (** Magic getter. On the client side, this hides an API call, which goes
       through the permissions mechanism. On the server side, this hides a call
       to the database. *)
-  val get : t Entry.Id.t -> t Entry.t Lwt.t
+  val get : t Entry.Id.t -> t Entry.t option Lwt.t
 end

--- a/src/common/modelBuilder/signature/set.ml
+++ b/src/common/modelBuilder/signature/set.ml
@@ -75,5 +75,5 @@ module type S = sig
   (** Magic getter. On the client side, this hides an API call, which goes
       through the permissions mechanism. On the server side, this hides a call
       to the database. *)
-  val get : t Entry.Id.t -> t Entry.t Lwt.t
+  val get : t Entry.Id.t -> t Entry.t option Lwt.t
 end

--- a/src/common/modelBuilder/signature/source.ml
+++ b/src/common/modelBuilder/signature/source.ml
@@ -42,5 +42,5 @@ module type S = sig
   (** Magic getter. On the client side, this hides an API call, which goes
       through the permissions mechanism. On the server side, this hides a call
       to the database. *)
-  val get : t Entry.Id.t -> t Entry.t Lwt.t
+  val get : t Entry.Id.t -> t Entry.t option Lwt.t
 end

--- a/src/common/modelBuilder/signature/tune.ml
+++ b/src/common/modelBuilder/signature/tune.ml
@@ -60,5 +60,5 @@ module type S = sig
   (** Magic getter. On the client side, this hides an API call, which goes
       through the permissions mechanism. On the server side, this hides a call
       to the database. *)
-  val get : t Entry.Id.t -> t Entry.t Lwt.t
+  val get : t Entry.Id.t -> t Entry.t option Lwt.t
 end

--- a/src/common/modelBuilder/signature/version.ml
+++ b/src/common/modelBuilder/signature/version.ml
@@ -71,5 +71,5 @@ module type S = sig
   (** Magic getter. On the client side, this hides an API call, which goes
       through the permissions mechanism. On the server side, this hides a call
       to the database. *)
-  val get : t Entry.Id.t -> t Entry.t Lwt.t
+  val get : t Entry.Id.t -> t Entry.t option Lwt.t
 end

--- a/src/server/controller/any.ml
+++ b/src/server/controller/any.ml
@@ -3,8 +3,7 @@ open Common
 
 let get env id =
   match Database.Any.get id with
-  | None ->
-    Madge_server.shortcut_not_found "This entry does not exist, or you do not have access to it."
+  | None -> Permission.reject_can_get ()
   | Some any ->
     Permission.assert_can_get env (Model.Any.to_entry any);%lwt
     lwt any

--- a/src/server/controller/book/book.ml
+++ b/src/server/controller/book/book.ml
@@ -5,9 +5,11 @@ module Ly = Ly
 module Pdf = Pdf
 
 let get env id =
-  let%lwt book = Model.Book.get id in
-  Permission.assert_can_get env book;%lwt
-  lwt book
+  match%lwt Database.Book.get id with
+  | None -> Permission.reject_can_get ()
+  | Some book ->
+    Permission.assert_can_get env book;%lwt
+    lwt book
 
 let create env book =
   Permission.assert_can_create env;%lwt

--- a/src/server/controller/book/pdf.ml
+++ b/src/server/controller/book/pdf.ml
@@ -43,7 +43,9 @@ let render book book_parameters rendering_parameters =
   lwt path_pdf
 
 let get env id _slug book_parameters rendering_parameters =
-  let%lwt book = Model.Book.get id in
-  Permission.assert_can_get env book;%lwt
-  let%lwt path_pdf = render (Entry.value book) book_parameters rendering_parameters in
-  Madge_server.respond_file ~content_type: "application/pdf" ~fname: path_pdf
+  match%lwt Model.Book.get id with
+  | None -> Permission.reject_can_get ()
+  | Some book ->
+    Permission.assert_can_get env book;%lwt
+    let%lwt path_pdf = render (Entry.value book) book_parameters rendering_parameters in
+    Madge_server.respond_file ~content_type: "application/pdf" ~fname: path_pdf

--- a/src/server/controller/permission.ml
+++ b/src/server/controller/permission.ml
@@ -31,6 +31,11 @@ let can_get env entry =
     ~none: (fun () -> Entry.(privacy % meta) entry = Public)
     ~some: (fun _user -> true)
 
+(** The rejection of {!asert_can_get}. May be used by external code to behave in
+    the exact same way and avoid leaking information. *)
+let reject_can_get () =
+  Madge_server.shortcut_not_found "This entry does not exist, or you do not have access to it."
+
 let assert_can_get env entry =
   if can_get env entry then
     (
@@ -40,7 +45,7 @@ let assert_can_get env entry =
   else
     (
       Log.info (fun m -> m "Refusing get access for entry `%a` to %a." Entry.Id.pp' (Common.Entry.id entry) Environment.pp env);
-      Madge_server.shortcut_not_found "This entry does not exist, or you do not have access to it."
+      reject_can_get ()
     )
 
 (** {2 Creating} *)

--- a/src/server/controller/person.ml
+++ b/src/server/controller/person.ml
@@ -2,9 +2,11 @@ open Nes
 open Common
 
 let get env id =
-  let%lwt person = Model.Person.get id in
-  Permission.assert_can_get env person;%lwt
-  lwt person
+  match%lwt Database.Person.get id with
+  | None -> Permission.reject_can_get ()
+  | Some person ->
+    Permission.assert_can_get env person;%lwt
+    lwt person
 
 let create env person =
   Permission.assert_can_create env;%lwt

--- a/src/server/controller/set/pdf.ml
+++ b/src/server/controller/set/pdf.ml
@@ -35,7 +35,9 @@ let render set set_parameters rendering_parameters =
   Book.Pdf.render book book_parameters rendering_parameters
 
 let get env id _slug set_parameters rendering_parameters =
-  let%lwt set = Model.Set.get id in
-  Permission.assert_can_get env set;%lwt
-  let%lwt path_pdf = render (Entry.value set) set_parameters rendering_parameters in
-  Madge_server.respond_file ~content_type: "application/pdf" ~fname: path_pdf
+  match%lwt Model.Set.get id with
+  | None -> Permission.reject_can_get ()
+  | Some set ->
+    Permission.assert_can_get env set;%lwt
+    let%lwt path_pdf = render (Entry.value set) set_parameters rendering_parameters in
+    Madge_server.respond_file ~content_type: "application/pdf" ~fname: path_pdf

--- a/src/server/controller/set/set.ml
+++ b/src/server/controller/set/set.ml
@@ -4,9 +4,11 @@ open Common
 module Pdf = Pdf
 
 let get env id =
-  let%lwt set = Model.Set.get id in
-  Permission.assert_can_get env set;%lwt
-  lwt set
+  match%lwt Database.Set.get id with
+  | None -> Permission.reject_can_get ()
+  | Some set ->
+    Permission.assert_can_get env set;%lwt
+    lwt set
 
 let create env set =
   Permission.assert_can_create env;%lwt

--- a/src/server/controller/source.ml
+++ b/src/server/controller/source.ml
@@ -2,9 +2,11 @@ open Nes
 open Common
 
 let get env id =
-  let%lwt source = Model.Source.get id in
-  Permission.assert_can_get env source;%lwt
-  lwt source
+  match%lwt Database.Source.get id with
+  | None -> Permission.reject_can_get ()
+  | Some source ->
+    Permission.assert_can_get env source;%lwt
+    lwt source
 
 let create env source =
   Permission.assert_can_create env;%lwt

--- a/src/server/controller/tune.ml
+++ b/src/server/controller/tune.ml
@@ -2,9 +2,11 @@ open Nes
 open Common
 
 let get env id =
-  let%lwt tune = Model.Tune.get id in
-  Permission.assert_can_get env tune;%lwt
-  lwt tune
+  match%lwt Database.Tune.get id with
+  | None -> Permission.reject_can_get ()
+  | Some tune ->
+    Permission.assert_can_get env tune;%lwt
+    lwt tune
 
 let create env tune =
   Permission.assert_can_create env;%lwt

--- a/src/server/controller/version/ly.ml
+++ b/src/server/controller/version/ly.ml
@@ -4,9 +4,11 @@ open Common
 module Log = (val Logger.create "controller.version.ly": Logs.LOG)
 
 let get env id =
-  let%lwt version = Model.Version.get id in
-  Permission.assert_can_get env version;%lwt
-  lwt @@ Model.Version.content' version
+  match%lwt Database.Version.get id with
+  | None -> Permission.reject_can_get ()
+  | Some version ->
+    Permission.assert_can_get env version;%lwt
+    lwt @@ Model.Version.content' version
 
 let prepare_file parameters ?(show_meta = false) ?(meta_in_title = false) ~fname version =
   Log.debug (fun m -> m "Preparing Lilypond file");

--- a/src/server/controller/version/ogg.ml
+++ b/src/server/controller/version/ogg.ml
@@ -28,10 +28,12 @@ let render version version_parameters rendering_parameters =
 
 let get env id _slug version_parameters rendering_parameters =
   Log.debug (fun m -> m "Model.Version.Ogg.get %a" Entry.Id.pp' id);
-  let%lwt version = Model.Version.get id in
-  Permission.assert_can_get env version;%lwt
-  let%lwt path_ogg = render version version_parameters rendering_parameters in
-  Madge_server.respond_file ~content_type: "audio/ogg" ~fname: path_ogg
+  match%lwt Database.Version.get id with
+  | None -> Permission.reject_can_get ()
+  | Some version ->
+    Permission.assert_can_get env version;%lwt
+    let%lwt path_ogg = render version version_parameters rendering_parameters in
+    Madge_server.respond_file ~content_type: "audio/ogg" ~fname: path_ogg
 
 let preview env version version_parameters rendering_parameters =
   Log.debug (fun m -> m "Model.Version.Ogg.preview");

--- a/src/server/controller/version/pdf.ml
+++ b/src/server/controller/version/pdf.ml
@@ -35,7 +35,9 @@ let render version version_parameters rendering_parameters =
   Set.Pdf.render set set_parameters rendering_parameters
 
 let get env id _slug version_parameters rendering_parameters =
-  let%lwt version = Model.Version.get id in
-  Permission.assert_can_get env version;%lwt
-  let%lwt path_pdf = render version version_parameters rendering_parameters in
-  Madge_server.respond_file ~content_type: "application/pdf" ~fname: path_pdf
+  match%lwt Model.Version.get id with
+  | None -> Permission.reject_can_get ()
+  | Some version ->
+    Permission.assert_can_get env version;%lwt
+    let%lwt path_pdf = render version version_parameters rendering_parameters in
+    Madge_server.respond_file ~content_type: "application/pdf" ~fname: path_pdf

--- a/src/server/controller/version/svg.ml
+++ b/src/server/controller/version/svg.ml
@@ -34,10 +34,12 @@ let render version version_parameters rendering_parameters =
 
 let get env id _slug version_parameters rendering_parameters =
   Log.debug (fun m -> m "Model.Version.Svg.get %a" Entry.Id.pp' id);
-  let%lwt version = Model.Version.get id in
-  Permission.assert_can_get env version;%lwt
-  let%lwt path_svg = render version version_parameters rendering_parameters in
-  Madge_server.respond_file ~content_type: "image/svg+xml" ~fname: path_svg
+  match%lwt Database.Version.get id with
+  | None -> Permission.reject_can_get ()
+  | Some version ->
+    Permission.assert_can_get env version;%lwt
+    let%lwt path_svg = render version version_parameters rendering_parameters in
+    Madge_server.respond_file ~content_type: "image/svg+xml" ~fname: path_svg
 
 let preview env version version_parameters rendering_parameters =
   Log.debug (fun m -> m "Model.Version.Svg.preview");

--- a/src/server/controller/version/version.ml
+++ b/src/server/controller/version/version.ml
@@ -7,9 +7,11 @@ module Ogg = Ogg
 module Pdf = Pdf
 
 let get env id =
-  let%lwt version = Model.Version.get id in
-  Permission.assert_can_get env version;%lwt
-  lwt version
+  match%lwt Database.Version.get id with
+  | None -> Permission.reject_can_get ()
+  | Some version ->
+    Permission.assert_can_get env version;%lwt
+    lwt version
 
 let create env version =
   Permission.assert_can_create env;%lwt

--- a/src/server/environment.ml
+++ b/src/server/environment.ml
@@ -83,7 +83,7 @@ let process_remember_me_cookie env remember_me_cookie =
       register_response_cookie env (delete_cookie ~path: "/" "rememberMe");
       lwt_unit
     | Some id ->
-      match%lwt Database.User.get_opt id with
+      match%lwt Database.User.get id with
       | None ->
         Log.info (fun m -> m "Rejecting because of wrong username.");
         register_response_cookie env (delete_cookie ~path: "/" "rememberMe");


### PR DESCRIPTION
This will force better behaviour down the line. We already gained
control of a few situations, but mostly we had to make explicit (with a
great deal of `Option.get` calls) where exceptions lie.