### PR TITLE
Various improvements to components

### DIFF
--- a/src/client/components/choices.ml
+++ b/src/client/components/choices.ml
@@ -34,7 +34,7 @@ let prepare_gen_unsafe (type value)(type choice_value)
 
   let empty = ""
   let from_initial_text _ = ""
-  let serialise _ = lwt "" (* FIXME *)
+  let value_to_state _ = lwt "" (* FIXME *)
 
   type t = {
     inner_html: 'a. ([> Html_types.div] as 'a) elt;

--- a/src/client/components/choices.ml
+++ b/src/client/components/choices.ml
@@ -30,10 +30,10 @@ let prepare_gen_unsafe (type value)(type choice_value)
   let label = label
 
   type nonrec value = value
-  type raw_value = string [@@deriving yojson]
+  type state = string [@@deriving yojson]
 
-  let empty_value = ""
-  let raw_value_from_initial_text _ = ""
+  let empty = ""
+  let from_initial_text _ = ""
   let serialise _ = lwt "" (* FIXME *)
 
   type t = {
@@ -41,7 +41,7 @@ let prepare_gen_unsafe (type value)(type choice_value)
     values: choice_value list S.t;
   }
 
-  let raw_signal _ = S.const "" (* FIXME: handle raw_signal *)
+  let state _ = S.const "" (* FIXME: handle state *)
   let signal c = S.map validate c.values
   let inner_html c = c.inner_html
   let actions _ = S.const []

--- a/src/client/components/choices.ml
+++ b/src/client/components/choices.ml
@@ -49,7 +49,7 @@ let prepare_gen_unsafe (type value)(type choice_value)
   let focus _ = () (* FIXME *)
   let trigger _ = () (* FIXME *)
   let clear _ = () (* FIXME *)
-  let set _ _ = () (* FIXME *)
+  let set _ _ = lwt_unit (* FIXME *)
 
   (* Helper returning a list of the values held by choices satisfying a certain
      predicate, eg. “this choice is checked”. *)

--- a/src/client/components/component.ml
+++ b/src/client/components/component.ml
@@ -3,26 +3,19 @@ open Html
 
 module type S = sig
   val label : string
-
-  type value
-  type state
-
+  type state [@@deriving yojson]
   val empty : state
   val from_initial_text : string -> state
-  val state_to_yojson : state -> Yojson.Safe.t
-  val state_of_yojson : Yojson.Safe.t -> (state, string) result
+  type value
   val serialise : value -> state Lwt.t
-
   type t
-
   val initialise : state -> t Lwt.t
-
-  val signal : t -> (value, string) result S.t
   val state : t -> state S.t
-  val focus : t -> unit
+  val signal : t -> (value, string) result S.t
   val set : t -> value -> unit Lwt.t
-  val trigger : t -> unit
   val clear : t -> unit
+  val focus : t -> unit
+  val trigger : t -> unit
   val inner_html : t -> Html_types.div_content_fun elt
   val actions : t -> Html_types.div_content_fun elt list S.t
 end

--- a/src/client/components/component.ml
+++ b/src/client/components/component.ml
@@ -20,7 +20,7 @@ module type S = sig
   val signal : t -> (value, string) result S.t
   val state : t -> state S.t
   val focus : t -> unit
-  val set : t -> state -> unit
+  val set : t -> value -> unit Lwt.t
   val trigger : t -> unit
   val clear : t -> unit
   val inner_html : t -> Html_types.div_content_fun elt
@@ -48,7 +48,7 @@ let trigger : type value state. (value, state) t -> unit = function Component ((
 let clear : type value state. (value, state) t -> unit = function Component ((module C), c) -> C.clear c
 let signal : type value state. (value, state) t -> (value, string) result S.t = function Component ((module C), c) -> C.signal c
 let state : type value state. (value, state) t -> state S.t = function Component ((module C), c) -> C.state c
-let set : type value state. (value, state) t -> state -> unit = function Component ((module C), c) -> C.set c
+let set : type value state. (value, state) t -> value -> unit Lwt.t = function Component ((module C), c) -> C.set c
 let inner_html : type value state. (value, state) t -> Html_types.div_content_fun elt = function Component ((module C), c) -> C.inner_html c
 let actions : type value state. (value, state) t -> Html_types.div_content_fun elt list S.t = function Component ((module C), c) -> C.actions c
 

--- a/src/client/components/component.ml
+++ b/src/client/components/component.ml
@@ -5,52 +5,52 @@ module type S = sig
   val label : string
 
   type value
-  type raw_value
+  type state
 
-  val empty_value : raw_value
-  val raw_value_from_initial_text : string -> raw_value
-  val raw_value_to_yojson : raw_value -> Yojson.Safe.t
-  val raw_value_of_yojson : Yojson.Safe.t -> (raw_value, string) result
-  val serialise : value -> raw_value Lwt.t
+  val empty : state
+  val from_initial_text : string -> state
+  val state_to_yojson : state -> Yojson.Safe.t
+  val state_of_yojson : Yojson.Safe.t -> (state, string) result
+  val serialise : value -> state Lwt.t
 
   type t
 
-  val initialise : raw_value -> t Lwt.t
+  val initialise : state -> t Lwt.t
 
   val signal : t -> (value, string) result S.t
-  val raw_signal : t -> raw_value S.t
+  val state : t -> state S.t
   val focus : t -> unit
-  val set : t -> raw_value -> unit
+  val set : t -> state -> unit
   val trigger : t -> unit
   val clear : t -> unit
   val inner_html : t -> Html_types.div_content_fun elt
   val actions : t -> Html_types.div_content_fun elt list S.t
 end
 
-type ('value, 'raw_value) s = (module S with type value = 'value and type raw_value = 'raw_value)
+type ('value, 'state) s = (module S with type value = 'value and type state = 'state)
 
-type ('value, 'raw_value) t =
+type ('value, 'state) t =
   Component :
-      (module S with type t = 'a and type value = 'value and type raw_value = 'raw_value)
+      (module S with type t = 'a and type value = 'value and type state = 'state)
     * 'a ->
-      ('value, 'raw_value) t
+      ('value, 'state) t
 
-let initialise (type value)(type raw_value)
-    (module C : S with type value = value and type raw_value = raw_value)
-    (initial_value : raw_value)
-    : (value, raw_value) t Lwt.t
+let initialise (type value)(type state)
+    (module C : S with type value = value and type state = state)
+    (initial_value : state)
+    : (value, state) t Lwt.t
   =
   let%lwt component = C.initialise initial_value in
   lwt @@ Component ((module C), component)
 
-let focus : type value raw_value. (value, raw_value) t -> unit = function Component ((module C), c) -> C.focus c
-let trigger : type value raw_value. (value, raw_value) t -> unit = function Component ((module C), c) -> C.trigger c
-let clear : type value raw_value. (value, raw_value) t -> unit = function Component ((module C), c) -> C.clear c
-let signal : type value raw_value. (value, raw_value) t -> (value, string) result S.t = function Component ((module C), c) -> C.signal c
-let raw_signal : type value raw_value. (value, raw_value) t -> raw_value S.t = function Component ((module C), c) -> C.raw_signal c
-let set : type value raw_value. (value, raw_value) t -> raw_value -> unit = function Component ((module C), c) -> C.set c
-let inner_html : type value raw_value. (value, raw_value) t -> Html_types.div_content_fun elt = function Component ((module C), c) -> C.inner_html c
-let actions : type value raw_value. (value, raw_value) t -> Html_types.div_content_fun elt list S.t = function Component ((module C), c) -> C.actions c
+let focus : type value state. (value, state) t -> unit = function Component ((module C), c) -> C.focus c
+let trigger : type value state. (value, state) t -> unit = function Component ((module C), c) -> C.trigger c
+let clear : type value state. (value, state) t -> unit = function Component ((module C), c) -> C.clear c
+let signal : type value state. (value, state) t -> (value, string) result S.t = function Component ((module C), c) -> C.signal c
+let state : type value state. (value, state) t -> state S.t = function Component ((module C), c) -> C.state c
+let set : type value state. (value, state) t -> state -> unit = function Component ((module C), c) -> C.set c
+let inner_html : type value state. (value, state) t -> Html_types.div_content_fun elt = function Component ((module C), c) -> C.inner_html c
+let actions : type value state. (value, state) t -> Html_types.div_content_fun elt list S.t = function Component ((module C), c) -> C.actions c
 
 let case_errored ~no ~yes signal =
   flip S.map signal @@ function
@@ -58,7 +58,7 @@ let case_errored ~no ~yes signal =
     | _ -> no
 
 let html'
-  : type a value raw_value. (module S with type t = a and type value = value and type raw_value = raw_value) ->
+  : type a value state. (module S with type t = a and type value = value and type state = state) ->
   a ->
   [> Html_types.div] elt
 = fun (module C) c ->
@@ -79,7 +79,7 @@ let html'
         (case_errored ~no: [txt " "] ~yes: (List.singleton % txt) (C.signal c));
     ]
 
-let html : type value raw_value. (value, raw_value) t -> [> Html_types.div] elt = function
+let html : type value state. (value, state) t -> [> Html_types.div] elt = function
   | Component ((module C), c) -> html' (module C) c
 
 let html_fake ~label: label_ content =

--- a/src/client/components/component.ml
+++ b/src/client/components/component.ml
@@ -7,7 +7,7 @@ module type S = sig
   val empty : state
   val from_initial_text : string -> state
   type value
-  val serialise : value -> state Lwt.t
+  val value_to_state : value -> state Lwt.t
   type t
   val initialise : state -> t Lwt.t
   val state : t -> state S.t

--- a/src/client/components/component.mli
+++ b/src/client/components/component.mli
@@ -44,30 +44,41 @@ val html_fake : label: string -> Html_types.div_content_fun elt -> [> Html_types
 module type S = sig
   val label : string
 
-  type value
-  type state
+  type state [@@deriving yojson]
+  (** The type of internal states of the component. They can represent all that
+      the component can. For instance, for an input, this would be a string. *)
 
   val empty : state
+  (** The empty state of the component. *)
+
   val from_initial_text : string -> state
-  val state_to_yojson : state -> Yojson.Safe.t
-  val state_of_yojson : Yojson.Safe.t -> (state, string) result
+
+  type value
+
   val serialise : value -> state Lwt.t
 
   type t
 
   val initialise : state -> t Lwt.t
 
-  val signal : t -> (value, string) result S.t
   val state : t -> state S.t
-  val focus : t -> unit
+  val signal : t -> (value, string) result S.t
+
   val set : t -> value -> unit Lwt.t
+  (** Set the value of the component. *)
+
+  val clear : t -> unit
+  (** Clear the component, bringing the state back to {!empty}. *)
+
+  val focus : t -> unit
+  (** Focus the component. For instance, for an input, the cursor will be put in
+      the input. See also {!trigger}. *)
 
   val trigger : t -> unit
   (** Trigger the component. For simple components, this is akin to {!focus}.
       For components with a button triggering an action, though, {!focus} will
       only focus the button, while {!trigger} will trigger the action. *)
 
-  val clear : t -> unit
   val inner_html : t -> Html_types.div_content_fun elt
   val actions : t -> Html_types.div_content_fun elt list S.t
 end

--- a/src/client/components/component.mli
+++ b/src/client/components/component.mli
@@ -20,7 +20,8 @@ val state : ('value, 'state) t -> 'state S.t
 (** Expose the internal state of the component. This function should be avoided
     as much as possible. *)
 
-val set : ('value, 'state) t -> 'state -> unit
+val set : ('value, 'state) t -> 'value -> unit Lwt.t
+(** Set the component to hold the specific value. *)
 
 val inner_html : ('value, 'state) t -> Html_types.div_content_fun elt
 val actions : ('value, 'state) t -> Html_types.div_content_fun elt list S.t
@@ -59,7 +60,7 @@ module type S = sig
   val signal : t -> (value, string) result S.t
   val state : t -> state S.t
   val focus : t -> unit
-  val set : t -> state -> unit
+  val set : t -> value -> unit Lwt.t
 
   val trigger : t -> unit
   (** Trigger the component. For simple components, this is akin to {!focus}.
@@ -79,7 +80,9 @@ val initialise :
   ('value, 'state) s ->
   'state ->
   ('value, 'state) t Lwt.t
-(** Initialise a prepared component. *)
+(** Initialise a prepared component into a wrapped component of type {!t}.
+    Depending on your use case, you might prefer calling {!S.initialise}
+    directly and store the value of type {!S.t}. *)
 
 (** {2 Utilities} *)
 

--- a/src/client/components/component.mli
+++ b/src/client/components/component.mli
@@ -74,6 +74,12 @@ val initialise :
 
 (** {2 Utilities} *)
 
+val html' :
+  (module S with type t = 'a and type value = 'value and type raw_value = 'raw_value) ->
+  'a ->
+  [> Html_types.div] elt
+(** Render the component as HTML, just like {!html} would. *)
+
 val case_errored :
   no: 'b ->
   yes: ('e -> 'b) ->

--- a/src/client/components/component.mli
+++ b/src/client/components/component.mli
@@ -55,7 +55,7 @@ module type S = sig
 
   type value
 
-  val serialise : value -> state Lwt.t
+  val value_to_state : value -> state Lwt.t
 
   type t
 

--- a/src/client/components/editor.ml
+++ b/src/client/components/editor.ml
@@ -36,7 +36,7 @@ let nil : (unit, unit) bundle =
     let signal Nil = S.const (Ok ())
     let state Nil = S.const ()
     let focus Nil = ()
-    let set Nil () = ()
+    let set Nil () = lwt_unit
     let trigger Nil = ()
     let clear Nil = ()
     let inner_html Nil = div []
@@ -109,7 +109,7 @@ type ('result, 'previewed_value, 'value, 'state) t = {
 [@@deriving fields]
 
 let state e = Component.state e.editor
-let set_state e = Component.set e.editor
+let set e r = Component.set e.editor =<< e.s.break_down r
 let clear e = Component.clear e.editor
 
 let signal e =

--- a/src/client/components/editor.ml
+++ b/src/client/components/editor.ml
@@ -4,12 +4,12 @@ open Html
 
 (* Bundles *)
 
-type ('value, 'raw_value) bundle = Bundle of ('value, 'raw_value) Component.s
+type ('value, 'state) bundle = Bundle of ('value, 'state) Component.s
 
-let cons (type value1)(type raw_value1)(type value2)(type raw_value2)
-    (component : (value1, raw_value1) Component.s)
-    (Bundle bundle: (value2, raw_value2) bundle)
-    : (value1 * value2, raw_value1 * raw_value2) bundle
+let cons (type value1)(type state1)(type value2)(type state2)
+    (component : (value1, state1) Component.s)
+    (Bundle bundle: (value2, state2) bundle)
+    : (value1 * value2, state1 * state2) bundle
   =
   Bundle (module struct
     include (val Pair.prepare component bundle)
@@ -27,14 +27,14 @@ let nil : (unit, unit) bundle =
   Bundle (module struct
     let label = "Nil bundle"
     type value = unit
-    type raw_value = unit [@@deriving yojson]
+    type state = unit [@@deriving yojson]
     let serialise () = lwt_unit
-    let empty_value = ()
-    let raw_value_from_initial_text _ = ()
+    let empty = ()
+    let from_initial_text _ = ()
     type t = Nil
     let initialise () = lwt Nil
     let signal Nil = S.const (Ok ())
-    let raw_signal Nil = S.const ()
+    let state Nil = S.const ()
     let focus Nil = ()
     let set Nil () = ()
     let trigger Nil = ()
@@ -49,19 +49,19 @@ exception NonConvertible
 
 let local_storage_key ~key = key ^ "-editor"
 
-let read_local_storage (type value)(type raw_value) ~key (editor : (value, raw_value) Component.s) =
+let read_local_storage (type value)(type state) ~key (editor : (value, state) Component.s) =
   let module Editor = (val editor) in
-  Option.value ~default: Editor.empty_value @@
+  Option.value ~default: Editor.empty @@
   Js.Optdef.case Dom_html.window##.localStorage (fun () -> None) @@ fun local_storage ->
   Js.Opt.case (local_storage##getItem (Js.string (local_storage_key ~key))) (fun () -> None) @@ fun value ->
-  Result.to_option @@ Editor.raw_value_of_yojson @@ Yojson.Safe.from_string @@ Js.to_string value
+  Result.to_option @@ Editor.state_of_yojson @@ Yojson.Safe.from_string @@ Js.to_string value
 
-let write_local_storage (type value)(type raw_value) ~key (editor : (value, raw_value) Component.s) value =
+let write_local_storage (type value)(type state) ~key (editor : (value, state) Component.s) value =
   let module Editor = (val editor) in
   Js.Optdef.iter Dom_html.window##.localStorage @@ fun local_storage ->
   local_storage##setItem
     (Js.string (local_storage_key ~key))
-    (Js.string @@ Yojson.Safe.to_string @@ Editor.raw_value_to_yojson value)
+    (Js.string @@ Yojson.Safe.to_string @@ Editor.state_to_yojson value)
 
 let update_local_storage ~key (Bundle editor) f =
   let x = read_local_storage ~key editor in
@@ -70,8 +70,8 @@ let update_local_storage ~key (Bundle editor) f =
 
 (* Mode *)
 
-type ('result, 'raw_value) mode =
-  | QuickEdit of 'raw_value
+type ('result, 'state) mode =
+  | QuickEdit of 'state
   | QuickCreate of string * ('result -> unit)
   | CreateWithLocalStorage
   | Edit of 'result
@@ -79,37 +79,37 @@ type ('result, 'raw_value) mode =
 
 (* Prepared editors *)
 
-type ('result, 'previewed_value, 'value, 'raw_value) s = {
+type ('result, 'previewed_value, 'value, 'state) s = {
   key: string;
   icon: string;
   preview: ('value -> 'previewed_value option Lwt.t);
-  submit: (('result, 'raw_value) mode -> 'previewed_value -> 'result Lwt.t);
+  submit: (('result, 'state) mode -> 'previewed_value -> 'result Lwt.t);
   break_down: ('result -> 'value Lwt.t);
   format: ('result -> Html_types.div_content_fun Html.elt);
   href: ('result -> string);
-  bundle: ('value, 'raw_value) bundle;
+  bundle: ('value, 'state) bundle;
 }
 
-let empty_value (type value)(type raw_value) {bundle = (Bundle(module C): (value, raw_value) bundle); _} : raw_value = C.empty_value
-let raw_value_of_yojson (type value)(type raw_value) {bundle = (Bundle(module C): (value, raw_value) bundle); _} = C.raw_value_of_yojson
-let raw_value_to_yojson (type value)(type raw_value) {bundle = (Bundle(module C): (value, raw_value) bundle); _} = C.raw_value_to_yojson
-let serialise (type result)(type value)(type raw_value) : (result, 'previewed_value, value, raw_value) s -> result -> raw_value Lwt.t = fun {bundle = Bundle(module C); break_down; _} value -> break_down value >>= C.serialise
+let empty (type value)(type state) {bundle = (Bundle(module C): (value, state) bundle); _} : state = C.empty
+let state_of_yojson (type value)(type state) {bundle = (Bundle(module C): (value, state) bundle); _} = C.state_of_yojson
+let state_to_yojson (type value)(type state) {bundle = (Bundle(module C): (value, state) bundle); _} = C.state_to_yojson
+let serialise (type result)(type value)(type state) : (result, 'previewed_value, value, state) s -> result -> state Lwt.t = fun {bundle = Bundle(module C); break_down; _} value -> break_down value >>= C.serialise
 
 let prepare ~key ~icon ~preview ~submit ~break_down ~format ~href bundle =
   {key; icon; preview; submit; break_down; format; href; bundle}
 
 (* Initialised editors *)
 
-type ('result, 'previewed_value, 'value, 'raw_value) t = {
-  s: ('result, 'previewed_value, 'value, 'raw_value) s;
-  mode: ('result, 'raw_value) mode;
+type ('result, 'previewed_value, 'value, 'state) t = {
+  s: ('result, 'previewed_value, 'value, 'state) s;
+  mode: ('result, 'state) mode;
   page: (?after_save: (unit -> unit) -> unit -> Page.t Lwt.t);
-  editor: ('value, 'raw_value) Component.t;
+  editor: ('value, 'state) Component.t;
 }
 [@@deriving fields]
 
-let raw_signal e = Component.raw_signal e.editor
-let set_raw_value e = Component.set e.editor
+let state e = Component.state e.editor
+let set_state e = Component.set e.editor
 let clear e = Component.clear e.editor
 
 let signal e =
@@ -132,10 +132,10 @@ let result e =
 
 let page ?after_save e = e.page ?after_save ()
 
-let initialise (type result)(type value)(type previewed_value)(type raw_value)
-    (editor_s : (result, previewed_value, value, raw_value) s)
-    (mode : (result, raw_value) mode)
-    : (result, previewed_value, value, raw_value) t Lwt.t
+let initialise (type result)(type value)(type previewed_value)(type state)
+    (editor_s : (result, previewed_value, value, state) s)
+    (mode : (result, state) mode)
+    : (result, previewed_value, value, state) t Lwt.t
   =
   let {key; icon; preview; submit; break_down; format; href; bundle} = editor_s in
   let Bundle bundle = bundle in
@@ -146,8 +146,8 @@ let initialise (type result)(type value)(type previewed_value)(type raw_value)
      from the local storage. *)
   let%lwt initial_value =
     match mode with
-    | QuickCreate (initial_text, _) -> lwt @@ Bundle.raw_value_from_initial_text initial_text
-    | QuickEdit raw_value -> lwt raw_value
+    | QuickCreate (initial_text, _) -> lwt @@ Bundle.from_initial_text initial_text
+    | QuickEdit state -> lwt state
     | CreateWithLocalStorage -> lwt @@ read_local_storage ~key bundle
     | Edit entry -> Bundle.serialise =<< break_down entry
   in
@@ -163,7 +163,7 @@ let initialise (type result)(type value)(type previewed_value)(type raw_value)
     | QuickCreate _ | QuickEdit _ | Edit _ -> ()
     | CreateWithLocalStorage ->
       let store = write_local_storage ~key bundle in
-      let iter = S.map store @@ Component.raw_signal editor in
+      let iter = S.map store @@ Component.state editor in
       (* NOTE: Depending on the promise breaks eventually. Depending on the editor
         seems to live as long as the page lives. *)
       Depart.depends ~on: editor iter

--- a/src/client/components/editor.ml
+++ b/src/client/components/editor.ml
@@ -28,7 +28,7 @@ let nil : (unit, unit) bundle =
     let label = "Nil bundle"
     type value = unit
     type state = unit [@@deriving yojson]
-    let serialise () = lwt_unit
+    let value_to_state () = lwt_unit
     let empty = ()
     let from_initial_text _ = ()
     type t = Nil
@@ -93,7 +93,7 @@ type ('result, 'previewed_value, 'value, 'state) s = {
 let empty (type value)(type state) {bundle = (Bundle(module C): (value, state) bundle); _} : state = C.empty
 let state_of_yojson (type value)(type state) {bundle = (Bundle(module C): (value, state) bundle); _} = C.state_of_yojson
 let state_to_yojson (type value)(type state) {bundle = (Bundle(module C): (value, state) bundle); _} = C.state_to_yojson
-let serialise (type result)(type value)(type state) : (result, 'previewed_value, value, state) s -> result -> state Lwt.t = fun {bundle = Bundle(module C); break_down; _} value -> break_down value >>= C.serialise
+let result_to_state (type result)(type value)(type state) : (result, 'previewed_value, value, state) s -> result -> state Lwt.t = fun {bundle = Bundle(module C); break_down; _} value -> break_down value >>= C.value_to_state
 
 let prepare ~key ~icon ~preview ~submit ~break_down ~format ~href bundle =
   {key; icon; preview; submit; break_down; format; href; bundle}
@@ -149,7 +149,7 @@ let initialise (type result)(type value)(type previewed_value)(type state)
     | QuickCreate (initial_text, _) -> lwt @@ Bundle.from_initial_text initial_text
     | QuickEdit state -> lwt state
     | CreateWithLocalStorage -> lwt @@ read_local_storage ~key bundle
-    | Edit entry -> Bundle.serialise =<< break_down entry
+    | Edit entry -> Bundle.value_to_state =<< break_down entry
   in
 
   (* Now that we have an initial value, we can actually initialise the editor to

--- a/src/client/components/editor.ml
+++ b/src/client/components/editor.ml
@@ -16,8 +16,8 @@ let cons (type value1)(type raw_value1)(type value2)(type raw_value2)
 
     let inner_html p =
       div [
-        Component.html (c1 p);
-        Component.inner_html (c2 p);
+        Component.html' (module C1) (c1 p);
+        C2.inner_html (c2 p);
       ]
   end)
 

--- a/src/client/components/editor.mli
+++ b/src/client/components/editor.mli
@@ -121,7 +121,7 @@ val state_to_yojson :
   'state ->
   Yojson.Safe.t
 
-val serialise :
+val result_to_state :
   ('result, 'previewed_value, 'value, 'state) s ->
   'result ->
   'state Lwt.t

--- a/src/client/components/editor.mli
+++ b/src/client/components/editor.mli
@@ -137,10 +137,10 @@ val signal :
     submission on every change. Use only on degenerated editors where those
     functions trivial. FIXME: we should have a type for this. *)
 
-val set_state :
+val set :
   ('result, 'previewed_value, 'value, 'state) t ->
-  'state ->
-  unit
+  'result ->
+  unit Lwt.t
 
 val clear : ('result, 'previewed_value, 'value, 'state) t -> unit
 
@@ -150,4 +150,4 @@ val result :
 (** Get the current result of the editor, if it is in a state that permits it.
     Note that this trigger previewing and submitting and is therefore usually
     not suitable, except for degenerate editors such as the version parameters
-    editor. *)
+    editor. FIXME: the existence of this and {!signal} is quite confusing. *)

--- a/src/client/components/editor.mli
+++ b/src/client/components/editor.mli
@@ -7,25 +7,25 @@ open Html
     An editor features several components, and therefore we provide here a way
     to bundle components together under a list-like structure. *)
 
-type ('value, 'raw_value) bundle
+type ('value, 'state) bundle
 
 val nil : (unit, unit) bundle
 
 val cons :
-  ('value1, 'raw_value1) Component.s ->
-  ('value2, 'raw_value2) bundle ->
-  ('value1 * 'value2, 'raw_value1 * 'raw_value2) bundle
+  ('value1, 'state1) Component.s ->
+  ('value2, 'state2) bundle ->
+  ('value1 * 'value2, 'state1 * 'state2) bundle
 
 val (^::):
-  ('value1, 'raw_value1) Component.s ->
-  ('value2, 'raw_value2) bundle ->
-  ('value1 * 'value2, 'raw_value1 * 'raw_value2) bundle
+  ('value1, 'state1) Component.s ->
+  ('value2, 'state2) bundle ->
+  ('value1 * 'value2, 'state1 * 'state2) bundle
 (** [c ^:: cs] is an alias for [cons c cs]. It is right associative. *)
 
 (** {2 High-level interface} *)
 
-type ('result, 'raw_value) mode =
-  | QuickEdit of 'raw_value
+type ('result, 'state) mode =
+  | QuickEdit of 'state
   | QuickCreate of string * ('result -> unit)
   | CreateWithLocalStorage
   | Edit of 'result
@@ -35,13 +35,13 @@ val make_page :
   key: string ->
   icon: string ->
   preview: ('value -> 'previewed_value option Lwt.t) ->
-  submit: (('result, 'raw_value) mode -> 'previewed_value -> 'result Lwt.t) ->
+  submit: (('result, 'state) mode -> 'previewed_value -> 'result Lwt.t) ->
   break_down: ('result -> 'value Lwt.t) ->
   format: ('result -> Html_types.div_content_fun Html.elt) ->
   href: ('result -> string) ->
   (* FIXME: URI? *)
-  mode: ('result, 'raw_value) mode ->
-  ('value, 'raw_value) bundle ->
+  mode: ('result, 'state) mode ->
+  ('value, 'state) bundle ->
   Page.t Lwt.t
 (** Make a fully-featured editor that takes a whole page.
 
@@ -59,8 +59,8 @@ val make_page :
 
 val update_local_storage :
   key: string ->
-  ('value, 'raw_value) bundle ->
-  ('raw_value -> 'raw_value) ->
+  ('value, 'state) bundle ->
+  ('state -> 'state) ->
   unit
 
 exception NonConvertible
@@ -74,31 +74,31 @@ exception NonConvertible
     manipulate them. {!make_page} above is the combination of {!prepare},
     {!initialise} and {!page} below *)
 
-type ('result, 'previewed_value, 'value, 'raw_value) s
+type ('result, 'previewed_value, 'value, 'state) s
 (** An un-initialised editor. *)
 
 val prepare :
   key: string ->
   icon: string ->
   preview: ('value -> 'previewed_value option Lwt.t) ->
-  submit: (('result, 'raw_value) mode -> 'previewed_value -> 'result Lwt.t) ->
+  submit: (('result, 'state) mode -> 'previewed_value -> 'result Lwt.t) ->
   break_down: ('result -> 'value Lwt.t) ->
   format: ('result -> Html_types.div_content_fun Html.elt) ->
   href: ('result -> string) ->
-  ('value, 'raw_value) bundle ->
-  ('result, 'previewed_value, 'value, 'raw_value) s
+  ('value, 'state) bundle ->
+  ('result, 'previewed_value, 'value, 'state) s
 
-type ('result, 'previewed_value, 'value, 'raw_value) t
+type ('result, 'previewed_value, 'value, 'state) t
 (** An initialised editor. *)
 
 val initialise :
-  ('result, 'previewed_value, 'value, 'raw_value) s ->
-  ('result, 'raw_value) mode ->
-  ('result, 'previewed_value, 'value, 'raw_value) t Lwt.t
+  ('result, 'previewed_value, 'value, 'state) s ->
+  ('result, 'state) mode ->
+  ('result, 'previewed_value, 'value, 'state) t Lwt.t
 
 val page :
   ?after_save: (unit -> unit) ->
-  ('result, 'previewed_value, 'value, 'raw_value) t ->
+  ('result, 'previewed_value, 'value, 'state) t ->
   Page.t Lwt.t
 (** Render an initialised editor as a full page, ready for use. The additional
     [?after_save] argument can be used to trigger an action from the outside,
@@ -107,45 +107,45 @@ val page :
 
 (** {3 Editor manipulation} *)
 
-val empty_value :
-  ('result, 'previewed_value, 'value, 'raw_value) s ->
-  'raw_value
+val empty :
+  ('result, 'previewed_value, 'value, 'state) s ->
+  'state
 
-val raw_value_of_yojson :
-  ('result, 'previewed_value, 'value, 'raw_value) s ->
+val state_of_yojson :
+  ('result, 'previewed_value, 'value, 'state) s ->
   Yojson.Safe.t ->
-  ('raw_value, string) result
+  ('state, string) result
 
-val raw_value_to_yojson :
-  ('result, 'previewed_value, 'value, 'raw_value) s ->
-  'raw_value ->
+val state_to_yojson :
+  ('result, 'previewed_value, 'value, 'state) s ->
+  'state ->
   Yojson.Safe.t
 
 val serialise :
-  ('result, 'previewed_value, 'value, 'raw_value) s ->
+  ('result, 'previewed_value, 'value, 'state) s ->
   'result ->
-  'raw_value Lwt.t
+  'state Lwt.t
 
-val raw_signal :
-  ('result, 'previewed_value, 'value, 'raw_value) t ->
-  'raw_value S.t
+val state :
+  ('result, 'previewed_value, 'value, 'state) t ->
+  'state S.t
 
 val signal :
-  ('result, 'previewed_value, 'value, 'raw_value) t ->
+  ('result, 'previewed_value, 'value, 'state) t ->
   ('result, string) result S.t
 (** NOTE: Using this signal will keep triggering the previsualisation and
     submission on every change. Use only on degenerated editors where those
     functions trivial. FIXME: we should have a type for this. *)
 
-val set_raw_value :
-  ('result, 'previewed_value, 'value, 'raw_value) t ->
-  'raw_value ->
+val set_state :
+  ('result, 'previewed_value, 'value, 'state) t ->
+  'state ->
   unit
 
-val clear : ('result, 'previewed_value, 'value, 'raw_value) t -> unit
+val clear : ('result, 'previewed_value, 'value, 'state) t -> unit
 
 val result :
-  ('result, 'previewed_value, 'value, 'raw_value) t ->
+  ('result, 'previewed_value, 'value, 'state) t ->
   'result option Lwt.t
 (** Get the current result of the editor, if it is in a state that permits it.
     Note that this trigger previewing and submitting and is therefore usually

--- a/src/client/components/input.ml
+++ b/src/client/components/input.ml
@@ -28,7 +28,7 @@ let prepare (type value)
 
   let empty = ""
   let from_initial_text = Fun.id
-  let serialise = lwt % serialise
+  let value_to_state = lwt % serialise
 
   type t = {
     state: string S.t;
@@ -52,7 +52,7 @@ let prepare (type value)
 
   let trigger = focus
 
-  let set i x = i.set <$> serialise x
+  let set i x = i.set <$> value_to_state x
 
   let clear i = i.set ""
 

--- a/src/client/components/input.ml
+++ b/src/client/components/input.ml
@@ -52,7 +52,7 @@ let prepare (type value)
 
   let trigger = focus
 
-  let set i x = i.set x
+  let set i x = i.set <$> serialise x
 
   let clear i = i.set ""
 

--- a/src/client/components/input.ml
+++ b/src/client/components/input.ml
@@ -24,20 +24,20 @@ let prepare (type value)
   let label = label
 
   type nonrec value = value
-  type raw_value = string [@@deriving yojson]
+  type state = string [@@deriving yojson]
 
-  let empty_value = ""
-  let raw_value_from_initial_text = Fun.id
+  let empty = ""
+  let from_initial_text = Fun.id
   let serialise = lwt % serialise
 
   type t = {
-    raw_signal: string S.t;
+    state: string S.t;
     signal: (value, string) result S.t;
     set: string -> unit;
     html: html;
   }
 
-  let raw_signal i = i.raw_signal
+  let state i = i.state
 
   let signal i = i.signal
 
@@ -57,9 +57,9 @@ let prepare (type value)
   let clear i = i.set ""
 
   let initialise initial_value =
-    let (raw_signal, set_immediately) = S.create initial_value in
+    let (state, set_immediately) = S.create initial_value in
     let set_delayed = S.delayed_setter 0.30 set_immediately in
-    let signal = S.bind raw_signal validate in
+    let signal = S.bind state validate in
     let html : html =
       match type_ with
       | Text | Password ->
@@ -130,7 +130,7 @@ let prepare (type value)
       | Text {input_dom; _} -> input_dom##.value := Js.string x
       | Textarea {textarea_dom; _} -> textarea_dom##.value := Js.string x
     in
-    lwt {raw_signal; signal; set; html}
+    lwt {state; signal; set; html}
 
   let inner_html i =
     match i.html with
@@ -138,7 +138,7 @@ let prepare (type value)
     | Textarea {textarea; _} -> textarea
 
   let actions i =
-    flip S.map i.raw_signal @@ function
+    flip S.map i.state @@ function
       | "" ->
         (
           match template with

--- a/src/client/components/pair.ml
+++ b/src/client/components/pair.ml
@@ -56,9 +56,9 @@ let prepare (type value1)(type state1)(type value2)(type state2)
   let from_initial_text text =
     (C1.from_initial_text text, C2.empty)
 
-  let serialise (v1, v2) =
-    let%lwt v1 = C1.serialise v1 in
-    let%lwt v2 = C2.serialise v2 in
+  let value_to_state (v1, v2) =
+    let%lwt v1 = C1.value_to_state v1 in
+    let%lwt v2 = C2.value_to_state v2 in
     lwt (v1, v2)
 
   type t = {c1: C1.t; c2: C2.t} [@@deriving fields]

--- a/src/client/components/pair.ml
+++ b/src/client/components/pair.ml
@@ -15,26 +15,26 @@ open Html
 module type S = sig
   type value1
   type value2
-  type raw_value1
-  type raw_value2
+  type state1
+  type state2
 
-  include Component.S with type value = value1 * value2 and type raw_value = raw_value1 * raw_value2
+  include Component.S with type value = value1 * value2 and type state = state1 * state2
 
-  module C1 : Component.S with type value = value1 and type raw_value = raw_value1
-  module C2 : Component.S with type value = value2 and type raw_value = raw_value2
+  module C1 : Component.S with type value = value1 and type state = state1
+  module C2 : Component.S with type value = value2 and type state = state2
 
   val c1 : t -> C1.t
   val c2 : t -> C2.t
 end
 
-let prepare (type value1)(type raw_value1)(type value2)(type raw_value2)
-  ((module C1): (value1, raw_value1) Component.s)
-  ((module C2): (value2, raw_value2) Component.s)
+let prepare (type value1)(type state1)(type value2)(type state2)
+  ((module C1): (value1, state1) Component.s)
+  ((module C2): (value2, state2) Component.s)
   : (module S with
   type value1 = value1
   and type value2 = value2
-  and type raw_value1 = raw_value1
-  and type raw_value2 = raw_value2)
+  and type state1 = state1
+  and type state2 = state2)
 = (module struct
   let label = "Pair"
 
@@ -43,18 +43,18 @@ let prepare (type value1)(type raw_value1)(type value2)(type raw_value2)
 
   type value1 = C1.value
   type value2 = C2.value
-  type raw_value1 = C1.raw_value
-  type raw_value2 = C2.raw_value
+  type state1 = C1.state
+  type state2 = C2.state
 
   type value = C1.value * C2.value
-  type raw_value = C1.raw_value * C2.raw_value
+  type state = C1.state * C2.state
   [@@deriving yojson]
 
-  let empty_value =
-    (C1.empty_value, C2.empty_value)
+  let empty =
+    (C1.empty, C2.empty)
 
-  let raw_value_from_initial_text text =
-    (C1.raw_value_from_initial_text text, C2.empty_value)
+  let from_initial_text text =
+    (C1.from_initial_text text, C2.empty)
 
   let serialise (v1, v2) =
     let%lwt v1 = C1.serialise v1 in
@@ -68,9 +68,9 @@ let prepare (type value1)(type raw_value1)(type value2)(type raw_value2)
     RS.bind (C2.signal p.c2) @@ fun v2 ->
     RS.pure (v1, v2)
 
-  let raw_signal p =
-    S.bind (C1.raw_signal p.c1) @@ fun v1 ->
-    S.bind (C2.raw_signal p.c2) @@ fun v2 ->
+  let state p =
+    S.bind (C1.state p.c1) @@ fun v1 ->
+    S.bind (C2.state p.c2) @@ fun v2 ->
     S.const (v1, v2)
 
   let focus p = C1.focus p.c1

--- a/src/client/components/pair.ml
+++ b/src/client/components/pair.ml
@@ -77,7 +77,7 @@ let prepare (type value1)(type state1)(type value2)(type state2)
   let trigger p = C1.trigger p.c1
 
   let set p (v1, v2) =
-    C1.set p.c1 v1;
+    C1.set p.c1 v1;%lwt
     C2.set p.c2 v2
 
   let clear p =

--- a/src/client/components/parameteriser.ml
+++ b/src/client/components/parameteriser.ml
@@ -2,11 +2,10 @@ open Nes
 open Html
 
 let prepare (type comp_value)(type comp_raw_value)(type params)(type params_previewed)(type params_state)(type raw_params)
-  (component : (comp_value, comp_raw_value) Component.s)
+  ((module C): (comp_value, comp_raw_value) Component.s)
   (editor : (params, params_previewed, params_state, raw_params) Editor.s)
   : (comp_value * params, comp_raw_value * raw_params) Component.s
 = (module struct
-  module C = (val component)
 
   type value = C.value * params
 
@@ -26,37 +25,37 @@ let prepare (type comp_value)(type comp_raw_value)(type params)(type params_prev
     lwt (value, params)
 
   type t = {
-    comp: (comp_value, comp_raw_value) Component.t;
+    comp: C.t;
     editor: (params, params_previewed, params_state, raw_params) Editor.t;
   }
 
   let initialise (initial_value, initial_params) =
-    let%lwt comp = Component.initialise component initial_value in
+    let%lwt comp = C.initialise initial_value in
     let%lwt editor = Editor.initialise editor @@ Editor.QuickEdit initial_params in
     lwt {comp; editor}
 
   let signal p =
-    RS.bind (Component.signal p.comp) @@ fun value ->
+    RS.bind (C.signal p.comp) @@ fun value ->
     RS.bind (Editor.signal p.editor) @@ fun params ->
     S.const (Ok (value, params))
 
   let raw_signal p =
-    S.bind (Component.raw_signal p.comp) @@ fun raw_value ->
+    S.bind (C.raw_signal p.comp) @@ fun raw_value ->
     S.bind (Editor.raw_signal p.editor) @@ fun raw_params ->
     S.const (raw_value, raw_params)
 
   let set p (raw_value, raw_params) =
-    Component.set p.comp raw_value;
+    C.set p.comp raw_value;
     Editor.set_raw_value p.editor raw_params
 
   let clear p =
-    Component.clear p.comp;
+    C.clear p.comp;
     Editor.clear p.editor
 
   let label = C.label
-  let inner_html p = Component.inner_html p.comp
-  let focus p = Component.focus p.comp
-  let trigger p = Component.trigger p.comp
+  let inner_html p = C.inner_html p.comp
+  let focus p = C.focus p.comp
+  let trigger p = C.trigger p.comp
 
   let actions p =
     S.l2
@@ -80,5 +79,5 @@ let prepare (type comp_value)(type comp_raw_value)(type params)(type params_prev
             ()
         ]
       )
-      (Component.actions p.comp)
+      (C.actions p.comp)
 end)

--- a/src/client/components/parameteriser.ml
+++ b/src/client/components/parameteriser.ml
@@ -19,9 +19,9 @@ let prepare (type comp_value)(type comp_state)(type params)(type params_previewe
   let from_initial_text (text : string) =
     (C.from_initial_text text, Editor.empty editor)
 
-  let serialise (value, params) =
-    let%lwt value = C.serialise value in
-    let%lwt params = Editor.serialise editor params in
+  let value_to_state (value, params) =
+    let%lwt value = C.value_to_state value in
+    let%lwt params = Editor.result_to_state editor params in
     lwt (value, params)
 
   type t = {

--- a/src/client/components/parameteriser.ml
+++ b/src/client/components/parameteriser.ml
@@ -1,23 +1,23 @@
 open Nes
 open Html
 
-let prepare (type comp_value)(type comp_raw_value)(type params)(type params_previewed)(type params_state)(type raw_params)
-  ((module C): (comp_value, comp_raw_value) Component.s)
-  (editor : (params, params_previewed, params_state, raw_params) Editor.s)
-  : (comp_value * params, comp_raw_value * raw_params) Component.s
+let prepare (type comp_value)(type comp_state)(type params)(type params_previewed)(type params_value)(type params_state)
+  ((module C): (comp_value, comp_state) Component.s)
+  (editor : (params, params_previewed, params_value, params_state) Editor.s)
+  : (comp_value * params, comp_state * params_state) Component.s
 = (module struct
 
   type value = C.value * params
 
-  let raw_params_of_yojson = Editor.raw_value_of_yojson editor
-  let raw_params_to_yojson = Editor.raw_value_to_yojson editor
+  let params_state_of_yojson = Editor.state_of_yojson editor
+  let params_state_to_yojson = Editor.state_to_yojson editor
 
-  type raw_value = C.raw_value * raw_params [@@deriving yojson]
+  type state = C.state * params_state [@@deriving yojson]
 
-  let empty_value = (C.empty_value, Editor.empty_value editor)
+  let empty = (C.empty, Editor.empty editor)
 
-  let raw_value_from_initial_text (text : string) =
-    (C.raw_value_from_initial_text text, Editor.empty_value editor)
+  let from_initial_text (text : string) =
+    (C.from_initial_text text, Editor.empty editor)
 
   let serialise (value, params) =
     let%lwt value = C.serialise value in
@@ -26,7 +26,7 @@ let prepare (type comp_value)(type comp_raw_value)(type params)(type params_prev
 
   type t = {
     comp: C.t;
-    editor: (params, params_previewed, params_state, raw_params) Editor.t;
+    editor: (params, params_previewed, params_value, params_state) Editor.t;
   }
 
   let initialise (initial_value, initial_params) =
@@ -39,14 +39,14 @@ let prepare (type comp_value)(type comp_raw_value)(type params)(type params_prev
     RS.bind (Editor.signal p.editor) @@ fun params ->
     S.const (Ok (value, params))
 
-  let raw_signal p =
-    S.bind (C.raw_signal p.comp) @@ fun raw_value ->
-    S.bind (Editor.raw_signal p.editor) @@ fun raw_params ->
-    S.const (raw_value, raw_params)
+  let state p =
+    S.bind (C.state p.comp) @@ fun state ->
+    S.bind (Editor.state p.editor) @@ fun params_state ->
+    S.const (state, params_state)
 
-  let set p (raw_value, raw_params) =
-    C.set p.comp raw_value;
-    Editor.set_raw_value p.editor raw_params
+  let set p (state, params_state) =
+    C.set p.comp state;
+    Editor.set_state p.editor params_state
 
   let clear p =
     C.clear p.comp;

--- a/src/client/components/parameteriser.ml
+++ b/src/client/components/parameteriser.ml
@@ -44,9 +44,9 @@ let prepare (type comp_value)(type comp_state)(type params)(type params_previewe
     S.bind (Editor.state p.editor) @@ fun params_state ->
     S.const (state, params_state)
 
-  let set p (state, params_state) =
-    C.set p.comp state;
-    Editor.set_state p.editor params_state
+  let set p (value, params) =
+    C.set p.comp value;%lwt
+    Editor.set p.editor params
 
   let clear p =
     C.clear p.comp;

--- a/src/client/components/plus.ml
+++ b/src/client/components/plus.ml
@@ -104,7 +104,7 @@ let prepare (type value)(type component_state)
 
   let focus _ = () (* FIXME *)
   let trigger = focus
-  let set _ _ = () (* FIXME *)
+  let set _ _ = lwt_unit (* FIXME *)
 
   let clear l =
     Component.clear l.choices;
@@ -181,7 +181,7 @@ let wrap (type value1)(type value2)(type state1)(type state2)
   let serialise = wrap_state <%> serialise % Option.value' ~default: (fun () -> partial_because_wrapped "serialise") % unwrap_value
   let signal = S.map (Result.map wrap_value) % signal
   let state = S.map wrap_state % state
-  let set _ _ = () (* FIXME *)
+  let set _ _ = lwt_unit (* FIXME *)
   let initialise initial_value =
     match unwrap_state initial_value with
     | Some initial_value -> initialise initial_value

--- a/src/client/components/plus.mli
+++ b/src/client/components/plus.mli
@@ -1,29 +1,85 @@
 (** {1 Sum of components} *)
 
-val make :
-  label: string ->
-  ('value, 'state) Component.s list ->
-  int option * 'state list ->
-  ('value, int option * 'state list) Component.t Lwt.t
+(** {2 Tuple elements} *)
 
-exception PartialBecauseWrapped of string
-(** The action of wrapping a component is inherently a very partial one.
-    Normally, if this Plus component is implemented correctly, and if one gives
-    to {!make} wrapped components that complete each other, there should not be
-    any issues. Seeing this exception is a bad omen. The string carries some
-    details on where this was raised from. *)
+module TupleElt : sig
+  type _ t =
+    | Zero : 'a -> ('a * 'b) t
+    | Succ : 'b t -> ('a * 'b) t
+  (** A type for elements of a tuple. For the use case of this component, it is
+      not necessary for this type to be as general as it could.
+  
+      For instance, if we consider the tuple [(1, (2., ("3", ())))], of type [int
+      * (float * (string * unit))], its elements would be [Zero 1], [Succ (Zero
+      2.)], and [Succ (Succ (Zero "3"))], all of type [(int * (float * (string *
+      unit))) t]. *)
 
-val wrap :
-  ('value1 -> 'value2) ->
-  ('value2 -> 'value1 option) ->
-  ('state1 -> 'state2) ->
-  ('state2 -> 'state1 option) ->
-  ('value1, 'state1) Component.s ->
-  ('value2, 'state2) Component.s
+  val zero : 'a -> ('a * 'b) t
+  (** [zero x] is [Zero x]. *)
 
-(** {2 Internal use} *)
+  val succ : 'b t -> ('a * 'b) t
+  (** [succ e] is [Succ e]. *)
+
+  val one : 'b -> ('a * ('b * 'c)) t
+  (** [one x] is short for [Succ (Zero x)]. *)
+
+  val two : 'c -> ('a * ('b * ('c * 'd))) t
+  (** [two x] is short for [Succ (Succ (Zero x))]. *)
+
+  val three : 'd -> ('a * ('b * ('c * ('d * 'e)))) t
+  (** [three x] is short for [Succ (Succ (Succ (Zero x)))]. *)
+
+  val four : 'e -> ('a * ('b * ('c * ('d * ('e * 'f))))) t
+  (** [four x] is short for [Succ (Succ (Succ (Succ (Zero x))))]. *)
+
+  val five : 'f -> ('a * ('b * ('c * ('d * ('e * ('f * 'g)))))) t
+  (** [five x] is short for [Succ (Succ (Succ (Succ (Succ (Zero x)))))]. *)
+end
+
+(** {2 Bundles of components} *)
+
+module Bundle : sig
+  type ('value, 'state) t
+  (** A bundle of components. This can be thought of as a list of components,
+      except that the types are heterogeneous. *)
+
+  val cons :
+    ('value1, 'state1) Component.s ->
+    ('value2, 'state2) t ->
+    ('value1 * 'value2, 'state1 * 'state2) t
+  (** Add a component at the front of a bundle of components. *)
+
+  val (^::):
+    ('value1, 'state1) Component.s ->
+    ('value2, 'state2) t ->
+    ('value1 * 'value2, 'state1 * 'state2) t
+  (** Alias for {!cons}. *)
+
+  val nil : (unit, unit) t
+  (** The empty bundle of components. *)
+end
+
+(** {2 Sum of components} *)
 
 val prepare :
   label: string ->
-  ('value, 'state) Component.s list ->
-  ('value, int option * 'state list) Component.s
+  cast: ('bundled_value TupleElt.t -> 'value) ->
+  uncast: ('value -> 'bundled_value TupleElt.t) ->
+  ('bundled_value, 'state) Bundle.t ->
+  ('value, int option * 'state) Component.s
+(** Prepare a sum of components. The components have to be bundled together. The
+    user must provide [cast] and [uncast] functions to go from a {!tuple_elt} to
+    whatever value they care about and vice-versa. In the simplest sum of two
+    elements, using {!Either.t} as ['value], these functions could be:
+
+    {[
+      let cast = function
+        | Zero x -> Left x
+        | Succ Zero x -> Right x
+        | _ -> assert false (* not reachable *)
+
+      let uncast = function
+        | Left x -> zero x
+        | Right x -> one x
+    ]}
+  *)

--- a/src/client/components/plus.mli
+++ b/src/client/components/plus.mli
@@ -2,9 +2,9 @@
 
 val make :
   label: string ->
-  ('value, 'raw_value) Component.s list ->
-  int option * 'raw_value list ->
-  ('value, int option * 'raw_value list) Component.t Lwt.t
+  ('value, 'state) Component.s list ->
+  int option * 'state list ->
+  ('value, int option * 'state list) Component.t Lwt.t
 
 exception PartialBecauseWrapped of string
 (** The action of wrapping a component is inherently a very partial one.
@@ -16,14 +16,14 @@ exception PartialBecauseWrapped of string
 val wrap :
   ('value1 -> 'value2) ->
   ('value2 -> 'value1 option) ->
-  ('raw_value1 -> 'raw_value2) ->
-  ('raw_value2 -> 'raw_value1 option) ->
-  ('value1, 'raw_value1) Component.s ->
-  ('value2, 'raw_value2) Component.s
+  ('state1 -> 'state2) ->
+  ('state2 -> 'state1 option) ->
+  ('value1, 'state1) Component.s ->
+  ('value2, 'state2) Component.s
 
 (** {2 Internal use} *)
 
 val prepare :
   label: string ->
-  ('value, 'raw_value) Component.s list ->
-  ('value, int option * 'raw_value list) Component.s
+  ('value, 'state) Component.s list ->
+  ('value, int option * 'state list) Component.s

--- a/src/client/components/selector.ml
+++ b/src/client/components/selector.ml
@@ -3,8 +3,6 @@ open Nes
 open Common
 open Html
 
-(* TODO: Also store the search text in the raw signal. *)
-
 let prepare_gen (type model)(type model_validated)
   ~label
   ~search
@@ -35,10 +33,10 @@ let prepare_gen (type model)(type model_validated)
   let model_to_yojson _ = assert false
   let model_of_yojson _ = assert false
 
-  type raw_value = model Entry.Id.t option [@@deriving yojson]
+  type state = model Entry.Id.t option [@@deriving yojson]
 
-  let empty_value = None
-  let raw_value_from_initial_text _ = None
+  let empty = None
+  let from_initial_text _ = None
   let serialise = lwt % Option.map Entry.id % unvalidate
 
   type t = {
@@ -49,7 +47,7 @@ let prepare_gen (type model)(type model_validated)
     select_button_dom: Dom_html.buttonElement Js.t;
   }
 
-  let raw_signal s = S.map (flip Option.bind (some % Entry.id)) s.signal (* FIXME: can we simplify? *)
+  let state s = S.map (flip Option.bind (some % Entry.id)) s.signal (* FIXME: can we simplify? *)
 
   let signal i = S.map validate i.signal
 

--- a/src/client/components/selector.ml
+++ b/src/client/components/selector.ml
@@ -37,7 +37,7 @@ let prepare_gen (type model)(type model_validated)
 
   let empty = None
   let from_initial_text _ = None
-  let serialise = lwt % Option.map Entry.id % unvalidate
+  let value_to_state = lwt % Option.map Entry.id % unvalidate
 
   type t = {
     signal: model Entry.t option S.t;

--- a/src/client/components/star.ml
+++ b/src/client/components/star.ml
@@ -16,7 +16,7 @@ let prepare (type value)(type state)
   let empty = []
   let from_initial_text = List.singleton % C.from_initial_text
 
-  let serialise = Lwt_list.map_p C.serialise
+  let value_to_state = Lwt_list.map_p C.value_to_state
 
   type t = {
     components: C.t list S.t;
@@ -145,7 +145,7 @@ let prepare_non_empty (type value)(type state)
 = (module struct
   include (val (prepare ~label ?more_actions (module C)))
   type value = C.value NonEmptyList.t
-  let serialise = serialise % NonEmptyList.to_list
+  let value_to_state = value_to_state % NonEmptyList.to_list
   let set c v = set c @@ NonEmptyList.to_list v
   let signal =
     S.map (fun l ->

--- a/src/client/components/star.ml
+++ b/src/client/components/star.ml
@@ -2,19 +2,19 @@ open Nes
 open Js_of_ocaml
 open Html
 
-let prepare (type value)(type raw_value)
+let prepare (type value)(type state)
   ~label
   ?(more_actions = S.const [])
-  ((module C): (value, raw_value) Component.s)
-  : (value list, raw_value list) Component.s
+  ((module C): (value, state) Component.s)
+  : (value list, state list) Component.s
 = (module struct
   let label = label
 
   type value = C.value list
-  type raw_value = C.raw_value list [@@deriving yojson]
+  type state = C.state list [@@deriving yojson]
 
-  let empty_value = []
-  let raw_value_from_initial_text = List.singleton % C.raw_value_from_initial_text
+  let empty = []
+  let from_initial_text = List.singleton % C.from_initial_text
 
   let serialise = Lwt_list.map_p C.serialise
 
@@ -37,13 +37,13 @@ let prepare (type value)(type raw_value)
       )
       (S.const (Ok []))
 
-  let raw_signal l =
+  let state l =
     S.map List.rev @@
     S.bind l.components @@
     List.fold_left
       (fun values component ->
         S.bind values @@ fun values ->
-        S.bind (C.raw_signal component) @@ fun value ->
+        S.bind (C.state component) @@ fun value ->
         S.const (value :: values)
       )
       (S.const [])
@@ -75,7 +75,7 @@ let prepare (type value)(type raw_value)
         ~icon: "plus-circle"
         ~classes: ["btn-secondary"]
         ~onclick: (fun () ->
-          let%lwt component = C.initialise C.empty_value in
+          let%lwt component = C.initialise C.empty in
           set_components (S.value components @ [component]);
           C.trigger component;
           lwt_unit
@@ -128,20 +128,20 @@ let prepare (type value)(type raw_value)
     lwt {components; set_components; inner_html; button_add_object_dom}
 end)
 
-let make (type value)(type raw_value)
+let make (type value)(type state)
     ~label
     ?more_actions
-    (component : (value, raw_value) Component.s)
-    (initial_values : raw_value list)
-    : (value list, raw_value list) Component.t Lwt.t
+    (component : (value, state) Component.s)
+    (initial_values : state list)
+    : (value list, state list) Component.t Lwt.t
   =
   Component.initialise (prepare ~label ?more_actions component) initial_values
 
-let prepare_non_empty (type value)(type raw_value)
+let prepare_non_empty (type value)(type state)
   ~label
   ?more_actions
-  ((module C): (value, raw_value) Component.s)
-  : (value NonEmptyList.t, raw_value list) Component.s
+  ((module C): (value, state) Component.s)
+  : (value NonEmptyList.t, state list) Component.s
 = (module struct
   include (val (prepare ~label ?more_actions (module C)))
   type value = C.value NonEmptyList.t
@@ -153,11 +153,11 @@ let prepare_non_empty (type value)(type raw_value)
       signal
 end)
 
-let make_non_empty (type value)(type raw_value)
+let make_non_empty (type value)(type state)
     ~label
     ?more_actions
-    (component : (value, raw_value) Component.s)
-    (initial_values : raw_value list)
-    : (value NonEmptyList.t, raw_value list) Component.t Lwt.t
+    (component : (value, state) Component.s)
+    (initial_values : state list)
+    : (value NonEmptyList.t, state list) Component.t Lwt.t
   =
   Component.initialise (prepare_non_empty ~label ?more_actions component) initial_values

--- a/src/client/components/star.ml
+++ b/src/client/components/star.ml
@@ -146,6 +146,7 @@ let prepare_non_empty (type value)(type state)
   include (val (prepare ~label ?more_actions (module C)))
   type value = C.value NonEmptyList.t
   let serialise = serialise % NonEmptyList.to_list
+  let set c v = set c @@ NonEmptyList.to_list v
   let signal =
     S.map (fun l ->
       Result.bind l @@ Option.to_result ~none: ("You must add at least one " ^ String.lowercase_ascii C.label ^ ".") % NonEmptyList.of_list

--- a/src/client/components/star.mli
+++ b/src/client/components/star.mli
@@ -6,9 +6,9 @@ open Html
 val make :
   label: string ->
   ?more_actions: Html_types.div_content_fun elt list S.t ->
-  ('value, 'raw_value) Component.s ->
-  'raw_value list ->
-  ('value list, 'raw_value list) Component.t Lwt.t
+  ('value, 'state) Component.s ->
+  'state list ->
+  ('value list, 'state list) Component.t Lwt.t
 (** Make a list component, that is a component that contains 0, 1, or more
     instances of the same sub-component. It contains as value the list of values
     of the sub-components. Note that it consume the sub-components as
@@ -17,9 +17,9 @@ val make :
 val make_non_empty :
   label: string ->
   ?more_actions: Html_types.div_content_fun elt list S.t ->
-  ('value, 'raw_value) Component.s ->
-  'raw_value list ->
-  ('value NonEmptyList.t, 'raw_value list) Component.t Lwt.t
+  ('value, 'state) Component.s ->
+  'state list ->
+  ('value NonEmptyList.t, 'state list) Component.t Lwt.t
 (** Variant of {!make} for a list component that has to contain at least one
     sub-component. The value type is therefore {!NonEmptyList.t}. *)
 
@@ -28,15 +28,15 @@ val make_non_empty :
 val prepare :
   label: string ->
   ?more_actions: Html_types.div_content_fun elt list S.t ->
-  ('value, 'raw_value) Component.s ->
-  ('value list, 'raw_value list) Component.s
+  ('value, 'state) Component.s ->
+  ('value list, 'state list) Component.s
 (** Variant of {!make} that only prepares the component. It must still be
     {!Component.initialise}d. This is used for composition. *)
 
 val prepare_non_empty :
   label: string ->
   ?more_actions: Html_types.div_content_fun elt list S.t ->
-  ('value, 'raw_value) Component.s ->
-  ('value NonEmptyList.t, 'raw_value list) Component.s
+  ('value, 'state) Component.s ->
+  ('value NonEmptyList.t, 'state list) Component.s
 (** Variant of {!make_non_empty} that only prepares the component. It must still
     be {!Component.initialise}d. *)

--- a/src/client/views/setParametersEditor.ml
+++ b/src/client/views/setParametersEditor.ml
@@ -52,4 +52,4 @@ let e =
     ~format: (fun _ -> assert false)
     ~href: (fun _ -> assert false)
 
-let empty_value () = Editor.serialise e Model.SetParameters.none
+let empty_value () = Editor.result_to_state e Model.SetParameters.none

--- a/src/client/views/userPasswordResetter.ml
+++ b/src/client/views/userPasswordResetter.ml
@@ -23,7 +23,7 @@ let create username token =
       ~placeholder: "1234678"
       ~serialise: Fun.id
       ~validate: (fun password2 ->
-        flip S.map (Component.raw_signal password1_input) @@ fun password1 ->
+        flip S.map (Component.state password1_input) @@ fun password1 ->
         if password1 = password2 then Ok password2 else Error "The passwords do not match."
       )
       ""

--- a/src/client/views/versionParametersEditor.ml
+++ b/src/client/views/versionParametersEditor.ml
@@ -60,4 +60,4 @@ let e =
     ~format: (fun _ -> assert false)
     ~href: (fun _ -> assert false)
 
-let empty_value () = Editor.serialise e Model.VersionParameters.none
+let empty_value () = Editor.result_to_state e Model.VersionParameters.none


### PR DESCRIPTION
The goal was to get rid of the fact that each component happily provides, in its interface, a `raw_value` (now `state`) type, when in fact we don't need it or care about it. These commits are steps towards this goal, but I haven't actually managed my end goal. Still, this PR brings noticeable improvements, so we will keep it as-is for now.

The final goal actually requires a rewrite of the editor to provide a more modular interface. This would probably behave better in the parameteriser, and it would allow using the modular interface everywhere in components (the parameteriser in particular), while still providing the nice user interface that forgets about `state`. Future work.