### PR TITLE
Shield NixOS module behind `dancelor.enable`

### DIFF
--- a/nix/nixosmodule.nix
+++ b/nix/nixosmodule.nix
@@ -64,7 +64,7 @@
         };
       };
 
-      config =
+      config = lib.mkIf cfg.enable (
         let
           init-dancelor = pkgs.writeShellApplication {
             name = "init-dancelor";
@@ -173,6 +173,7 @@
               Group = "dancelor";
             };
           };
-        };
+        }
+      );
     };
 }


### PR DESCRIPTION
Closes #414