### PR TITLE
Use a temporary file for passing JSON to Nix code

### DIFF
--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -47,7 +47,7 @@ let build_pdf env id book_params rendering_params =
   in
   let%lwt book = Model_to_renderer.book_to_renderer_book' book book_params in
   let%lwt book_pdf_arg = Model_to_renderer.renderer_book_to_renderer_book_pdf_arg book rendering_params pdf_metadata in
-  lwt @@ uncurry Job.register_job @@ Renderer.make_book_pdf book_pdf_arg
+  uncurry Job.register_job <$> Renderer.make_book_pdf book_pdf_arg
 
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Book.t -> a = fun env endpoint ->
   match endpoint with

--- a/src/server/controller/job.ml
+++ b/src/server/controller/job.ml
@@ -11,9 +11,11 @@ type state =
 
 let is_failed = function Failed _ -> true | _ -> false
 
-(** A type for Nix expressions. *)
-type expr = Expr of string
-let expr_val (Expr s) = s
+(** A type for Nix expressions. It can also contain a list of files that are
+    necessary for the evaluation of the expression. They will be cleaned up afterwards. *)
+type expr = Expr of string * string list
+let expr_val (Expr (s, _)) = s
+let expr_files (Expr (_, fs)) = fs
 
 (** An internal job. This is an actual job, producing potentially several
     artifacts. A {!Job_id.t} corresponds to an {!job_and_file}, which is an
@@ -95,6 +97,7 @@ let run_job job =
     Log.debug (fun m -> m "Status: %a" Process.pp_process_status status);
     Log.debug (fun m -> m "%a" (Format.pp_multiline_sensible "Stdout") stdout);
     Log.debug (fun m -> m "%a" (Format.pp_multiline_sensible "Stderr") (String.concat "\n" stderr));
+    List.iter Sys.remove (expr_files job.expr);
     (
       job.state :=
         match status with

--- a/src/server/controller/set.ml
+++ b/src/server/controller/set.ml
@@ -56,7 +56,7 @@ let build_pdf env id set_params rendering_params =
   in
   let%lwt set = Model_to_renderer.set_to_renderer_set' set set_params in
   let%lwt book_pdf_arg = Model_to_renderer.renderer_set_to_renderer_book_pdf_arg set rendering_params pdf_metadata in
-  lwt @@ uncurry Job.register_job @@ Renderer.make_book_pdf book_pdf_arg
+  uncurry Job.register_job <$> Renderer.make_book_pdf book_pdf_arg
 
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Set.t -> a = fun env endpoint ->
   match endpoint with

--- a/src/server/controller/version.ml
+++ b/src/server/controller/version.ml
@@ -147,17 +147,17 @@ let build_pdf env id version_params rendering_params =
   let version_params = Model.Version_parameters.set_display_name (NEString.of_string_exn " ") version_params in
   let%lwt set = Model_to_renderer.versions_to_renderer_set' (NEList.singleton (version, version_params)) set_params in
   let%lwt book_pdf_arg = Model_to_renderer.renderer_set_to_renderer_book_pdf_arg set rendering_params pdf_metadata in
-  lwt @@ uncurry Job.register_job @@ Renderer.make_book_pdf book_pdf_arg
+  uncurry Job.register_job <$> Renderer.make_book_pdf book_pdf_arg
 
 (** For use in {!Routine}. *)
 let render_snippets ?version_params version =
   let%lwt tune = Model_to_renderer.version_to_renderer_tune ?version_params version in
-  lwt @@ Renderer.make_tune_snippets tune
+  Renderer.make_tune_snippets tune
 
 let register_snippets_job ?version_params version =
   let%lwt tune = Model_to_renderer.version_to_renderer_tune ?version_params version in
-  let svg_job = Renderer.make_tune_svg tune in
-  let ogg_job = Renderer.make_tune_ogg tune in
+  let%lwt svg_job = Renderer.make_tune_svg tune in
+  let%lwt ogg_job = Renderer.make_tune_ogg tune in
   lwt @@
     match (uncurry Job.register_job svg_job, uncurry Job.register_job ogg_job) with
     | Already_succeeded svg_job_id, Already_succeeded ogg_job_id -> Endpoints.Job.Already_succeeded Endpoints.Version.Snippet_ids.{svg_job_id; ogg_job_id}


### PR DESCRIPTION
Without this, the command line can become too long and break things.
Then, calling Nix just returns `WEXITED 127` without any feedback.