### PR TITLE
Rename `Common` into `Dancelor_common`

### DIFF
--- a/src/client/client.ml
+++ b/src/client/client.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Js_of_ocaml
 open Html
 open Utils

--- a/src/client/components/context_links.ml
+++ b/src/client/components/context_links.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 open Utils
 open Model

--- a/src/client/components/search.ml
+++ b/src/client/components/search.ml
@@ -48,7 +48,7 @@ module Search = struct
       {pagination; search_bar; min_characters}
 
   let render
-      ~(make_result : ?context: Common.Endpoints.Page.context S.t -> 'result -> Html_types.tr Html.elt)
+      ~(make_result : ?context: Dancelor_common.Endpoints.Page.context S.t -> 'result -> Html_types.tr Html.elt)
       ?(results_when_no_search = [])
       ?(attached_buttons = [])
       ?(show_table_headers = true)
@@ -141,7 +141,7 @@ module Search = struct
                             @@ fun (_, state) ->
                             match state with
                             | Results results ->
-                              let context = S.map Common.Endpoints.Page.in_search @@ Search_bar.text t.search_bar in
+                              let context = S.map Dancelor_common.Endpoints.Page.in_search @@ Search_bar.text t.search_bar in
                               List.map (make_result ~context) results
                             | Start_typing | Continue_typing | No_results | Errors _ ->
                               List.map make_result results_when_no_search

--- a/src/client/components/search.mli
+++ b/src/client/components/search.mli
@@ -20,7 +20,7 @@ val make :
   'result t
 
 val render :
-  make_result: (?context: Common.Endpoints.Page.context S.t -> 'result -> Html_types.tr Html.elt) ->
+  make_result: (?context: Dancelor_common.Endpoints.Page.context S.t -> 'result -> Html_types.tr Html.elt) ->
   ?results_when_no_search: 'result list ->
   ?attached_buttons: [< Html_types.div_content_fun >`I `Input] elt list ->
   ?show_table_headers: bool ->
@@ -44,7 +44,7 @@ module Quick : sig
     return: ('dialog_result option -> unit) ->
     dialog_title: string Lwt.t ->
     ?dialog_buttons: Html_types.div_content_fun elt list ->
-    make_result: (?context: Common.Endpoints.Page.context S.t -> 'result -> Html_types.tr Html.elt) ->
+    make_result: (?context: Dancelor_common.Endpoints.Page.context S.t -> 'result -> Html_types.tr Html.elt) ->
     ?results_when_no_search: 'result list ->
     'result t ->
     Page.t Lwt.t

--- a/src/client/components/selector.ml
+++ b/src/client/components/selector.ml
@@ -1,6 +1,6 @@
 open Js_of_ocaml
 open Nes
-open Common
+open Dancelor_common
 open Utils
 open Html
 

--- a/src/client/components/selector.mli
+++ b/src/client/components/selector.mli
@@ -1,7 +1,7 @@
 (** {1 Selector component} *)
 
 open Nes
-open Common
+open Dancelor_common
 open Html
 
 val make :

--- a/src/client/components/version_snippets.ml
+++ b/src/client/components/version_snippets.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 
 let make_svg_gen ?(show_logs = false) status_signal =

--- a/src/client/environment.ml
+++ b/src/client/environment.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 
 type run_status = Running | Offline | Newer

--- a/src/client/filter.ml
+++ b/src/client/filter.ml
@@ -1,1 +1,1 @@
-include Common.Filter_builder.Build(Model)
+include Dancelor_common.Filter_builder.Build(Model)

--- a/src/client/formatters/book.ml
+++ b/src/client/formatters/book.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 
 let switch_signal_option = function

--- a/src/client/formatters/book.mli
+++ b/src/client/formatters/book.mli
@@ -1,4 +1,4 @@
-open Common
+open Dancelor_common
 open Html
 
 val title' :

--- a/src/client/formatters/dance.ml
+++ b/src/client/formatters/dance.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 
 let switch_signal_option = function

--- a/src/client/formatters/dance.mli
+++ b/src/client/formatters/dance.mli
@@ -6,13 +6,13 @@ val name :
 
 val name' :
   ?link: bool ->
-  ?context: Common.Endpoints.Page.context S.t ->
+  ?context: Dancelor_common.Endpoints.Page.context S.t ->
   Model.Dance.entry ->
   [> Html_types.span] elt
 
 val name_and_disambiguation' :
   ?name_link: bool ->
-  ?context: Common.Endpoints.Page.context S.t ->
+  ?context: Dancelor_common.Endpoints.Page.context S.t ->
   Model.Dance.entry ->
   [> Html_types.span] elt
 (** Variant of {!name_and_disambiguation} taking an {!Entry.t}. Because this is an entry,

--- a/src/client/formatters/person.ml
+++ b/src/client/formatters/person.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 
 let switch_signal_option = function

--- a/src/client/formatters/person.mli
+++ b/src/client/formatters/person.mli
@@ -6,7 +6,7 @@ val name :
 
 val name' :
   ?link: bool ->
-  ?context: Common.Endpoints.Page.context S.t ->
+  ?context: Dancelor_common.Endpoints.Page.context S.t ->
   Model.Person.entry ->
   [> Html_types.span] elt
 (** Variant of {!name} taking an {!Entry.t}. Because this is an entry, we can

--- a/src/client/formatters/set.ml
+++ b/src/client/formatters/set.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 
 let switch_signal_option = function

--- a/src/client/formatters/set.mli
+++ b/src/client/formatters/set.mli
@@ -1,4 +1,4 @@
-open Common
+open Dancelor_common
 open Html
 
 val works' :

--- a/src/client/formatters/source.ml
+++ b/src/client/formatters/source.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 
 let switch_signal_option = function

--- a/src/client/formatters/source.mli
+++ b/src/client/formatters/source.mli
@@ -8,7 +8,7 @@ val name :
 val name' :
   ?short: bool ->
   ?link: bool ->
-  ?context: Common.Endpoints.Page.context S.t ->
+  ?context: Dancelor_common.Endpoints.Page.context S.t ->
   Model.Source.entry ->
   [> Html_types.span] elt
 (** Variant of {!name} taking an {!Entry.t}. Because this is an entry, we can

--- a/src/client/formatters/tune.ml
+++ b/src/client/formatters/tune.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 
 let switch_signal_option = function

--- a/src/client/formatters/tune.mli
+++ b/src/client/formatters/tune.mli
@@ -1,4 +1,4 @@
-open Common
+open Dancelor_common
 open Html
 
 val name : Model.Tune.t -> [> Html_types.span] elt

--- a/src/client/formatters/version.ml
+++ b/src/client/formatters/version.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 
 let switch_signal_option = function

--- a/src/client/formatters/version.mli
+++ b/src/client/formatters/version.mli
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 
 val name :

--- a/src/client/history.ml
+++ b/src/client/history.ml
@@ -1,6 +1,6 @@
 open Js_of_ocaml
 open Nes
-open Common
+open Dancelor_common
 
 module Log = (val Logs.src_log @@ Logs.Src.create "client.history": Logs.LOG)
 

--- a/src/client/job.ml
+++ b/src/client/job.ml
@@ -1,6 +1,6 @@
 open Js_of_ocaml
 open Nes
-open Common
+open Dancelor_common
 open Html
 open Utils
 

--- a/src/client/model.ml
+++ b/src/client/model.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 let madge_call_or_option endpoint id =
   Lwt.flip_map (Madge_client.call (Endpoints.Api.route @@ endpoint) id) @@ function

--- a/src/client/permission.ml
+++ b/src/client/permission.ml
@@ -2,7 +2,7 @@ open Nes
 
 (** {2 Common tests and assertions} *)
 
-include Common.Permission_builder
+include Dancelor_common.Permission_builder
 include Make(Model.User)
 
 (** {3 Tests} *)

--- a/src/client/utils/action.ml
+++ b/src/client/utils/action.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 
 let delete ?label_suffix ~onclick ~model () =
@@ -33,6 +33,6 @@ let scddb type_ id =
   Button.make_a
     ~label: "See on SCDDB"
     ~icon: (Action See_outside)
-    ~href: (S.const @@ Common.SCDDB.entry_uri type_ id)
+    ~href: (S.const @@ Dancelor_common.SCDDB.entry_uri type_ id)
     ~dropdown: true
     ()

--- a/src/client/utils/any_result.ml
+++ b/src/client/utils/any_result.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Model
 open Html
 

--- a/src/client/utils/utils.ml
+++ b/src/client/utils/utils.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Js_of_ocaml
 
 module Any_result = Any_result

--- a/src/client/views/add_to.ml
+++ b/src/client/views/add_to.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 open Utils
 

--- a/src/client/views/book_download_dialog.ml
+++ b/src/client/views/book_download_dialog.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Model
 open Html
 open Utils

--- a/src/client/views/book_editor.ml
+++ b/src/client/views/book_editor.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 open Components
 open Html

--- a/src/client/views/book_viewer.ml
+++ b/src/client/views/book_viewer.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Utils
 open Model
 

--- a/src/client/views/dance_editor.ml
+++ b/src/client/views/dance_editor.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 open Components
 open Html

--- a/src/client/views/dance_viewer.ml
+++ b/src/client/views/dance_viewer.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Model
 open Html
 open Utils

--- a/src/client/views/explorer.ml
+++ b/src/client/views/explorer.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Js_of_ocaml
 open Components
 open Html

--- a/src/client/views/index.ml
+++ b/src/client/views/index.ml
@@ -56,8 +56,8 @@ let create () =
           S.from_lwt (Utils.Tables.placeholder ~rows: length ()) @@
             let filter =
               (* FIXME: There should be a more direct way to do this *)
-              let newest () = Common.Formula_entry.(meta' newest') in
-              Common.Formula.or_l
+              let newest () = Dancelor_common.Formula_entry.(meta' newest') in
+              Dancelor_common.Formula.or_l
                 Filter.Any.[source' (newest ());
                 person' (newest ());
                 dance' (newest ());
@@ -68,7 +68,7 @@ let create () =
                 ]
             in
             let slice = Slice.make ~length () in
-            let%lwt results = snd <$> Madge_client.call_exn Common.Endpoints.Api.(route @@ Any Search) slice filter in
+            let%lwt results = snd <$> Madge_client.call_exn Dancelor_common.Endpoints.Api.(route @@ Any Search) slice filter in
             lwt [Utils.Tables.any results]
         );
       ];
@@ -94,7 +94,7 @@ let create () =
         faq_item ~id: "faq-scddb" ~question: "How is Dancelor different from the SCDDB?" [
           p [
             txt "The SCDDB (";
-            a ~a: [a_href Common.SCDDB.root] [txt "my.strathspey.org"];
+            a ~a: [a_href Dancelor_common.SCDDB.root] [txt "my.strathspey.org"];
             txt ") is the most comprehensive database of metadata for Scottish country ";
             txt "dancing, and we love it! ";
             txt "However, the SCDDB does not host sheet music. ";

--- a/src/client/views/issue_report.ml
+++ b/src/client/views/issue_report.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 open Utils
 open Components

--- a/src/client/views/main_page.ml
+++ b/src/client/views/main_page.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Js_of_ocaml
 open Html
 open Utils

--- a/src/client/views/person_editor.ml
+++ b/src/client/views/person_editor.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Components
 open Html
 

--- a/src/client/views/person_viewer.ml
+++ b/src/client/views/person_viewer.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Model
 open Html
 open Utils

--- a/src/client/views/search_complex_filters_dialog.ml
+++ b/src/client/views/search_complex_filters_dialog.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Model
 open Html
 open Utils

--- a/src/client/views/set_download_dialog.ml
+++ b/src/client/views/set_download_dialog.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 open Utils
 open Model

--- a/src/client/views/set_editor.ml
+++ b/src/client/views/set_editor.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Components
 open Html
 open Utils

--- a/src/client/views/set_viewer.ml
+++ b/src/client/views/set_viewer.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Model
 open Html
 open Utils

--- a/src/client/views/source_editor.ml
+++ b/src/client/views/source_editor.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 open Components
 open Html

--- a/src/client/views/source_viewer.ml
+++ b/src/client/views/source_viewer.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Model
 open Html
 open Utils

--- a/src/client/views/tune_editor.ml
+++ b/src/client/views/tune_editor.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 open Components
 open Html

--- a/src/client/views/user_creator.ml
+++ b/src/client/views/user_creator.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Components
 open Html
 open Utils

--- a/src/client/views/user_header.ml
+++ b/src/client/views/user_header.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Html
 open Utils
 

--- a/src/client/views/user_password_reset_preparer.ml
+++ b/src/client/views/user_password_reset_preparer.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Components
 open Html
 open Utils

--- a/src/client/views/user_password_resetter.ml
+++ b/src/client/views/user_password_resetter.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Components
 open Js_of_ocaml
 open Utils

--- a/src/client/views/version_deduplicator.ml
+++ b/src/client/views/version_deduplicator.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Model
 open Html
 open Utils

--- a/src/client/views/version_download_dialog.ml
+++ b/src/client/views/version_download_dialog.ml
@@ -1,6 +1,6 @@
 open Js_of_ocaml
 open Nes
-open Common
+open Dancelor_common
 open Model
 open Html
 open Utils

--- a/src/client/views/version_editor.ml
+++ b/src/client/views/version_editor.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Components
 open Html
 open Utils

--- a/src/client/views/version_parameters_editor.ml
+++ b/src/client/views/version_parameters_editor.ml
@@ -36,8 +36,8 @@ let editor =
     ~type_: Text
     ~label: "Transposition (number of semitones)"
     ~placeholder: "eg. +2 or -4"
-    ~serialise: (NEString.of_string_exn % string_of_int % Common.Transposition.to_semitones)
-    ~validate: (S.const % Option.to_result ~none: "Not a number of semitones" % Option.map Common.Transposition.from_semitones % int_of_string_opt % NEString.to_string)
+    ~serialise: (NEString.of_string_exn % string_of_int % Dancelor_common.Transposition.to_semitones)
+    ~validate: (S.const % Option.to_result ~none: "Not a number of semitones" % Option.map Dancelor_common.Transposition.from_semitones % int_of_string_opt % NEString.to_string)
     () ^::
   nil
 

--- a/src/client/views/version_viewer.ml
+++ b/src/client/views/version_viewer.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 open Model
 open Html
 open Utils

--- a/src/common/dune
+++ b/src/common/dune
@@ -1,7 +1,7 @@
 (include_subdirs qualified)
 
 (library
- (name common)
+ (name dancelor_common)
  (public_name dancelor.common)
  (libraries
   cohttp

--- a/src/common/kind_base.ml
+++ b/src/common/kind_base.ml
@@ -44,7 +44,7 @@ let of_string s =
   | "p" | "polka" -> Polka
   | "j98" | "jig[9/8]" -> Jig_9_8
   | "o" | "other" -> Other
-  | _ -> invalid_arg "Common.Kind.Base.of_string"
+  | _ -> invalid_arg "Dancelor_common.Kind.Base.of_string"
 
 let of_string_opt s =
   try
@@ -61,9 +61,9 @@ let of_yojson = function
       try
         Ok (of_string s)
       with
-        | _ -> Error "Common.Kind.Base.of_yojson: not a valid base kind"
+        | _ -> Error "Dancelor_common.Kind.Base.of_yojson: not a valid base kind"
     )
-  | _ -> Error "Common.Kind.Base.of_yojson: not a JSON string"
+  | _ -> Error "Dancelor_common.Kind.Base.of_yojson: not a JSON string"
 
 let tempo = function
   | Jig -> ("4.", 104)

--- a/src/common/music/clef.ml
+++ b/src/common/music/clef.ml
@@ -13,7 +13,7 @@ let of_string = function
   | "alto" -> Alto
   | "tenor" -> Tenor
   | "bass" -> Bass
-  | _ -> failwith "Common.Music.Clef.of_string"
+  | _ -> failwith "Dancelor_common.Music.Clef.of_string"
 
 let to_symbol = function
   | Treble -> "𝄞"
@@ -22,4 +22,4 @@ let to_symbol = function
   | Bass -> "𝄢"
 
 let to_yojson = Utils.to_yojson__of__to_string to_string
-let of_yojson = Utils.of_yojson__of__of_string of_string "Common.Music.Clef.of_yojson"
+let of_yojson = Utils.of_yojson__of__of_string of_string "Dancelor_common.Music.Clef.of_yojson"

--- a/src/common/music/key.ml
+++ b/src/common/music/key.ml
@@ -14,7 +14,7 @@ let to_string key = Pitch.to_string key.pitch ^ Mode.to_string key.mode
 let to_pretty_string key = Pitch.to_pretty_string key.pitch ^ Mode.to_string key.mode
 
 let of_string = function
-  | "" -> failwith "Common.Music.Key.of_string"
+  | "" -> failwith "Dancelor_common.Music.Key.of_string"
   | str ->
     (* FIXME: dirty; does not use mode_of_string *)
     let pitch_str, mode =
@@ -32,4 +32,4 @@ let of_string_opt s =
     | Failure _ -> None
 
 let to_yojson = Utils.to_yojson__of__to_string to_string
-let of_yojson = Utils.of_yojson__of__of_string of_string "Common.Music.Key.of_yojson"
+let of_yojson = Utils.of_yojson__of__of_string of_string "Dancelor_common.Music.Key.of_yojson"

--- a/src/common/music/note.ml
+++ b/src/common/music/note.ml
@@ -25,4 +25,4 @@ let of_char c =
   | 'e' -> E
   | 'f' -> F
   | 'g' -> G
-  | _ -> failwith "Common.Music.note_of_char"
+  | _ -> failwith "Dancelor_common.Music.note_of_char"

--- a/src/common/music/pitch.ml
+++ b/src/common/music/pitch.ml
@@ -12,7 +12,7 @@ let alteration_of_string = function
   | "b" -> Flat
   | "#" -> Sharp
   | "" -> Natural
-  | _ -> failwith "Common.Music.alteration_of_string"
+  | _ -> failwith "Dancelor_common.Music.alteration_of_string"
 
 type octave = int
 [@@deriving eq, ord, show {with_path = false}]
@@ -30,11 +30,11 @@ let octave_of_string = function
   | str ->
     let chr = str.[0] in
     if String.exists ((<>) chr) str then
-      failwith "Common.Music.octave_of_string";
+      failwith "Dancelor_common.Music.octave_of_string";
     match chr with
     | '\'' -> String.length str
     | ',' -> -(String.length str)
-    | _ -> failwith "Common.Music.octave_of_string"
+    | _ -> failwith "Dancelor_common.Music.octave_of_string"
 
 type t = {
   note: Note.t;
@@ -65,7 +65,7 @@ let to_lilypond_string pitch =
   octave_to_lilypond_string pitch.octave
 
 let of_string = function
-  | "" -> failwith "Common.Music.Pitch.of_string"
+  | "" -> failwith "Dancelor_common.Music.Pitch.of_string"
   | s ->
     let note_alteration_str, octave_str =
       (* FIXME: Dirty as fuck *)
@@ -88,7 +88,7 @@ let of_string = function
     }
 
 let to_yojson = Utils.to_yojson__of__to_string to_string
-let of_yojson = Utils.of_yojson__of__of_string of_string "Common.Music.Pitch.of_yojson"
+let of_yojson = Utils.of_yojson__of__of_string of_string "Dancelor_common.Music.Pitch.of_yojson"
 
 let to_int pitch =
   (

--- a/src/server/config.ml
+++ b/src/server/config.ml
@@ -5,7 +5,7 @@ module Log = (val Logs.src_log @@ Logs.Src.create "server.config": Logs.LOG)
 type t = {
   database: string;
   init_only: bool;
-  loglevel: Common.Logger.loglevel_map;
+  loglevel: Dancelor_common.Logger.loglevel_map;
   pid_file: string;
   port: int;
   share: string;

--- a/src/server/controller/any.ml
+++ b/src/server/controller/any.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 let get env id =
   match Database.Any.get id with

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -1,5 +1,5 @@
 open NesUnix
-open Common
+open Dancelor_common
 
 let get env id =
   match Database.Book.get id with

--- a/src/server/controller/controller.ml
+++ b/src/server/controller/controller.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 module Source = Source
 module Person = Person

--- a/src/server/controller/dance.ml
+++ b/src/server/controller/dance.ml
@@ -1,5 +1,5 @@
 open NesUnix
-open Common
+open Dancelor_common
 
 module Log = (val Logs.src_log @@ Logs.Src.create "server.controller.dance": Logs.LOG)
 

--- a/src/server/controller/issue_report.ml
+++ b/src/server/controller/issue_report.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 open Endpoints.Issue_report
 open Request

--- a/src/server/controller/job.ml
+++ b/src/server/controller/job.ml
@@ -1,5 +1,5 @@
 open NesUnix
-open Common
+open Dancelor_common
 
 module Log = (val Logs.src_log @@ Logs.Src.create "server.controller.job": Logs.LOG)
 

--- a/src/server/controller/model_to_renderer.ml
+++ b/src/server/controller/model_to_renderer.ml
@@ -1,10 +1,10 @@
 (** {1 Conversion from models to renderer}
 
-    This module contains the logic to convert from {!Common.Model} to
+    This module contains the logic to convert from {!Dancelor_common.Model} to
     {!Renderer}. It is meant to be used in other controllers. *)
 
 open NesUnix
-open Common
+open Dancelor_common
 
 module Log = (val Logs.src_log @@ Logs.Src.create "server.controller.model_to_renderer": Logs.LOG)
 

--- a/src/server/controller/person.ml
+++ b/src/server/controller/person.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 let get env id =
   match Database.Person.get id with

--- a/src/server/controller/set.ml
+++ b/src/server/controller/set.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 let get env id =
   match Database.Set.get id with

--- a/src/server/controller/source.ml
+++ b/src/server/controller/source.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 let get env id =
   match Database.Source.get id with

--- a/src/server/controller/tune.ml
+++ b/src/server/controller/tune.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 let get env id =
   match Database.Tune.get id with

--- a/src/server/controller/user.ml
+++ b/src/server/controller/user.ml
@@ -1,5 +1,5 @@
 open NesUnix
-open Common
+open Dancelor_common
 
 module Log = (val Logs.src_log @@ Logs.Src.create "server.controller.user": Logs.LOG)
 

--- a/src/server/controller/version.ml
+++ b/src/server/controller/version.ml
@@ -1,5 +1,5 @@
 open NesUnix
-open Common
+open Dancelor_common
 
 module Log = (val Logs.src_log @@ Logs.Src.create "server.controller.version": Logs.LOG)
 

--- a/src/server/database/source.ml
+++ b/src/server/database/source.ml
@@ -1,4 +1,4 @@
-open Common
+open Dancelor_common
 
 include Tables.Source
 let delete = make_delete Tables.reverse_dependencies_of

--- a/src/server/database/table.ml
+++ b/src/server/database/table.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 (** {2 Type of a model} *)
 

--- a/src/server/database/tables.ml
+++ b/src/server/database/tables.ml
@@ -1,5 +1,5 @@
 open NesUnix
-open Common
+open Dancelor_common
 
 module Log = (val Logs.src_log @@ Logs.Src.create "server.database.tables": Logs.LOG)
 

--- a/src/server/database/user.ml
+++ b/src/server/database/user.ml
@@ -3,7 +3,7 @@ include Tables.User
 
 let get_from_username username =
   let all = get_all () in
-  let this = Seq.filter ((=) username % Common.Model_builder.Core.User.username % Common.Entry.value) all in
+  let this = Seq.filter ((=) username % Dancelor_common.Model_builder.Core.User.username % Dancelor_common.Entry.value) all in
   match this () with
   | Nil -> lwt_none
   | Cons (this, next) when next () = Nil -> lwt_some this

--- a/src/server/environment.ml
+++ b/src/server/environment.ml
@@ -1,5 +1,5 @@
 open NesUnix
-open Common
+open Dancelor_common
 
 module Log = (val Logs.src_log @@ Logs.Src.create "server.environment": Logs.LOG)
 

--- a/src/server/filter.ml
+++ b/src/server/filter.ml
@@ -1,1 +1,1 @@
-include Common.Filter_builder.Build(Model)
+include Dancelor_common.Filter_builder.Build(Model)

--- a/src/server/model.ml
+++ b/src/server/model.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 include Model_builder.Build(struct
   let get_user = lwt % Database.User.get
   let get_book = lwt % Database.Book.get

--- a/src/server/permission.ml
+++ b/src/server/permission.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 module Log = (val Logs.src_log @@ Logs.Src.create "server.permission": Logs.LOG)
 

--- a/src/server/routine.ml
+++ b/src/server/routine.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 module Log = (val Logs.src_log @@ Logs.Src.create "server.routine": Logs.LOG)
 

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -1,7 +1,7 @@
 open Cohttp_lwt_unix
 
 open Nes
-open Common
+open Dancelor_common
 
 module Log = (val Logs.src_log @@ Logs.Src.create "server": Logs.LOG)
 
@@ -10,7 +10,7 @@ let log_exn ~msg exn =
   let repr =
     match exn with
     | Database.Error.Exn error ->
-      "Common.Error." ^ Database.Error.show error
+      "Dancelor_common.Error." ^ Database.Error.show error
     | exn -> Printexc.to_string exn
   in
   m "%a" (Format.pp_multiline_sensible msg) (repr ^ "\n" ^ (Printexc.get_backtrace ()))

--- a/src/server/static.ml
+++ b/src/server/static.ml
@@ -1,6 +1,6 @@
 open Tyxml.Html
 open Nes
-open Common
+open Dancelor_common
 
 module Log = (val Logs.src_log @@ Logs.Src.create "server.static": Logs.LOG)
 

--- a/tests/unit/QCheck_generators.ml
+++ b/tests/unit/QCheck_generators.ml
@@ -1,7 +1,7 @@
 open QCheck2
 
 module Id = struct
-  type 'any t = [%import: 'any Common.Entry.Id.t]
+  type 'any t = [%import: 'any Dancelor_common.Entry.Id.t]
 
   let gen _ =
     let open Gen in
@@ -18,7 +18,7 @@ module Id = struct
     for i = 10 to 13 do Bytes.set str i (List.nth alphanumerals (i - 2)) done;
     let str = Bytes.unsafe_to_string str in
     (* convert to and id (which will check it), and we're done! *)
-    pure @@ Option.get @@ Common.Entry.Id.of_string str
+    pure @@ Option.get @@ Dancelor_common.Entry.Id.of_string str
 end
 
 module Entry = struct
@@ -29,13 +29,13 @@ module Entry = struct
 
   module User = struct
     (* FIXME: not sure this one is actually fine *)
-    type t = Common.Model_builder.Core.User.t
+    type t = Dancelor_common.Model_builder.Core.User.t
     let gen : t QCheck2.Gen.t = Gen.pure (Obj.magic 0)
   end
 end
 
 module Formula = struct
-  type 'p t = [%import: 'p Common.Formula.t] [@@deriving qcheck2]
+  type 'p t = [%import: 'p Dancelor_common.Formula.t] [@@deriving qcheck2]
 
   (* Formulas can grow very quickly. We therefore limit the size of formulas
      drastically in our generator. *)
@@ -43,53 +43,53 @@ module Formula = struct
 end
 
 module Formula_string = struct
-  type predicate = [%import: Common.Formula_string.predicate]
+  type predicate = [%import: Dancelor_common.Formula_string.predicate]
   [@@deriving qcheck2]
 
-  type t = [%import: Common.Formula_string.t [@with Common.Formula.t := Formula.t;]
+  type t = [%import: Dancelor_common.Formula_string.t [@with Dancelor_common.Formula.t := Formula.t;]
   ]
   [@@deriving qcheck2]
 end
 
 module Formula_list = struct
-  type 'f predicate = [%import: 'f Common.Formula_list.predicate]
+  type 'f predicate = [%import: 'f Dancelor_common.Formula_list.predicate]
   [@@deriving qcheck2]
 
-  type 'f t = [%import: 'f Common.Formula_list.t [@with Common.Formula.t := Formula.t;]
+  type 'f t = [%import: 'f Dancelor_common.Formula_list.t [@with Dancelor_common.Formula.t := Formula.t;]
   ]
   [@@deriving qcheck2]
 end
 
 module Formula_user = struct
-  type predicate = [%import: Common.Formula_user.predicate [@with Common.Entry.Id.t := Id.t;
-    Common.Entry.id := Id.t;
-    Common.Model_builder.Core.User.t := Model.User.t;
-    Common.Formula_string.t := Formula_string.t;
+  type predicate = [%import: Dancelor_common.Formula_user.predicate [@with Dancelor_common.Entry.Id.t := Id.t;
+    Dancelor_common.Entry.id := Id.t;
+    Dancelor_common.Model_builder.Core.User.t := Model.User.t;
+    Dancelor_common.Formula_string.t := Formula_string.t;
     ]
   ]
   [@@deriving qcheck2]
-  type t = [%import: Common.Formula_user.t [@with Common.Formula.t := Formula.t;]
+  type t = [%import: Dancelor_common.Formula_user.t [@with Dancelor_common.Formula.t := Formula.t;]
   ]
   [@@deriving qcheck2]
 end
 
 module Formula_entry = struct
-  type meta_predicate = [%import: Common.Formula_entry.meta_predicate]
+  type meta_predicate = [%import: Dancelor_common.Formula_entry.meta_predicate]
   [@@deriving qcheck2]
 
-  type meta = [%import: Common.Formula_entry.meta [@with Common.Formula.t := Formula.t;]
+  type meta = [%import: Dancelor_common.Formula_entry.meta [@with Dancelor_common.Formula.t := Formula.t;]
   ]
   [@@deriving qcheck2]
 
-  type ('value, 'filter, 'access_filter) predicate_gen = [%import: ('value, 'filter, 'access_filter) Common.Formula_entry.predicate_gen [@with Common.Entry.Id.t := Id.t;]
+  type ('value, 'filter, 'access_filter) predicate_gen = [%import: ('value, 'filter, 'access_filter) Dancelor_common.Formula_entry.predicate_gen [@with Dancelor_common.Entry.Id.t := Id.t;]
   ]
   [@@deriving qcheck2]
 
-  type ('value, 'filter, 'access_filter) gen = [%import: ('value, 'filter, 'access_filter) Common.Formula_entry.gen [@with Common.Formula.t := Formula.t]
+  type ('value, 'filter, 'access_filter) gen = [%import: ('value, 'filter, 'access_filter) Dancelor_common.Formula_entry.gen [@with Dancelor_common.Formula.t := Formula.t]
   ]
   [@@deriving qcheck2]
 
-  type access_public_predicate = [%import: Common.Formula_entry.access_public_predicate [@with Common.Formula.t := Formula.t;
+  type access_public_predicate = [%import: Dancelor_common.Formula_entry.access_public_predicate [@with Dancelor_common.Formula.t := Formula.t;
     Nes.Void.t := Void.t;
     ]
   ]
@@ -98,32 +98,32 @@ module Formula_entry = struct
   type access_public = access_public_predicate Formula.t
   [@@deriving qcheck2]
 
-  type ('value, 'filter) public = [%import: ('value, 'filter) Common.Formula_entry.public [@with Common.Formula.t := Formula.t;]
+  type ('value, 'filter) public = [%import: ('value, 'filter) Dancelor_common.Formula_entry.public [@with Dancelor_common.Formula.t := Formula.t;]
   ]
   [@@deriving qcheck2]
 
-  type access_private_predicate = [%import: Common.Formula_entry.access_private_predicate [@with Common.Formula.t := Formula.t;
+  type access_private_predicate = [%import: Dancelor_common.Formula_entry.access_private_predicate [@with Dancelor_common.Formula.t := Formula.t;
     public := public;
-    Common.Formula_list.t := Formula_list.t;
-    Common.Formula_user.t := Formula_user.t;
-    Common.Entry.User.t := Entry.User.t;
+    Dancelor_common.Formula_list.t := Formula_list.t;
+    Dancelor_common.Formula_user.t := Formula_user.t;
+    Dancelor_common.Entry.User.t := Entry.User.t;
     Nes.Void.t := Void.t;
     ]
   ]
   [@@deriving qcheck2]
 
-  type access_private = [%import: Common.Formula_entry.access_private [@with Common.Formula.t := Formula.t;]
+  type access_private = [%import: Dancelor_common.Formula_entry.access_private [@with Dancelor_common.Formula.t := Formula.t;]
   ]
   [@@deriving qcheck2]
 
-  type ('value, 'filter) private_ = [%import: ('value, 'filter) Common.Formula_entry.private_ [@with Common.Formula.t := Formula.t;]
+  type ('value, 'filter) private_ = [%import: ('value, 'filter) Dancelor_common.Formula_entry.private_ [@with Dancelor_common.Formula.t := Formula.t;]
   ]
   [@@deriving qcheck2]
 end
 
 module Text_formula = struct
-  type predicate = [%import: Common.Text_formula.predicate]
-  and t = [%import: Common.Text_formula.t]
+  type predicate = [%import: Dancelor_common.Text_formula.predicate]
+  and t = [%import: Dancelor_common.Text_formula.t]
 
   let gen_predicate_name =
     let open Gen in
@@ -142,9 +142,9 @@ module Text_formula = struct
     fix
       (fun self () ->
         oneof [
-          (Common.Text_formula.raw <$> string_printable);
-          (Common.Text_formula.nullary <$> gen_predicate_name);
-          (Common.Text_formula.unary <$> gen_predicate_name <*> Formula.gen (self ()));
+          (Dancelor_common.Text_formula.raw <$> string_printable);
+          (Dancelor_common.Text_formula.nullary <$> gen_predicate_name);
+          (Dancelor_common.Text_formula.unary <$> gen_predicate_name <*> Formula.gen (self ()));
         ]
       )
       ()
@@ -154,39 +154,39 @@ end
 
 module Kind = struct
   module Base = struct
-    type t = [%import: Common.Kind.Base.t] [@@deriving qcheck2]
+    type t = [%import: Dancelor_common.Kind.Base.t] [@@deriving qcheck2]
 
     module Filter = struct
-      type predicate = [%import: Common.Kind.Base.Filter.predicate] [@@deriving qcheck2]
+      type predicate = [%import: Dancelor_common.Kind.Base.Filter.predicate] [@@deriving qcheck2]
 
-      type t = [%import: Common.Kind.Base.Filter.t [@with Common.Formula.t := Formula.t;]
+      type t = [%import: Dancelor_common.Kind.Base.Filter.t [@with Dancelor_common.Formula.t := Formula.t;]
       ]
       [@@deriving qcheck2]
     end
   end
 
   module Version = struct
-    type t = [%import: Common.Kind.Version.t]
+    type t = [%import: Dancelor_common.Kind.Version.t]
 
     let gen = Gen.(pair nat Base.gen)
 
     module Filter = struct
-      type predicate = [%import: Common.Kind.Version.Filter.predicate [@with Common.Kind_base.Filter.t := Base.Filter.t;]
+      type predicate = [%import: Dancelor_common.Kind.Version.Filter.predicate [@with Dancelor_common.Kind_base.Filter.t := Base.Filter.t;]
       ]
       [@@deriving qcheck2]
 
-      type t = [%import: Common.Kind.Version.Filter.t [@with Common.Formula.t := Formula.t;]
+      type t = [%import: Dancelor_common.Kind.Version.Filter.t [@with Dancelor_common.Formula.t := Formula.t;]
       ]
       [@@deriving qcheck2]
     end
   end
 
   module Dance = struct
-    type t = [%import: Common.Kind.Dance.t]
+    type t = [%import: Dancelor_common.Kind.Dance.t]
 
     let gen =
       let open Gen in
-      let open Common.Kind.Dance in
+      let open Dancelor_common.Kind.Dance in
       sized @@
       fix @@ fun self ->
       function
@@ -199,11 +199,11 @@ module Kind = struct
             ]
 
     module Filter = struct
-      type predicate = [%import: Common.Kind.Dance.Filter.predicate [@with Common.Kind_version.Filter.t := Version.Filter.t;]
+      type predicate = [%import: Dancelor_common.Kind.Dance.Filter.predicate [@with Dancelor_common.Kind_version.Filter.t := Version.Filter.t;]
       ]
       [@@deriving qcheck2]
 
-      type t = [%import: Common.Kind.Dance.Filter.t [@with Common.Formula.t := Formula.t;]
+      type t = [%import: Dancelor_common.Kind.Dance.Filter.t [@with Dancelor_common.Formula.t := Formula.t;]
       ]
       [@@deriving qcheck2]
     end
@@ -217,43 +217,43 @@ module Model = struct
      first argument. *)
 
   module Source = struct
-    type t = Common.Model_builder.Core.Source.t
+    type t = Dancelor_common.Model_builder.Core.Source.t
     let gen : t QCheck2.Gen.t = Gen.pure (Obj.magic 0)
   end
 
   module Person = struct
-    type t = Common.Model_builder.Core.Person.t
+    type t = Dancelor_common.Model_builder.Core.Person.t
     let gen : t QCheck2.Gen.t = Gen.pure (Obj.magic 0)
   end
 
   module Dance = struct
-    type t = Common.Model_builder.Core.Dance.t
+    type t = Dancelor_common.Model_builder.Core.Dance.t
     let gen : t QCheck2.Gen.t = Gen.pure (Obj.magic 0)
   end
 
   module Tune = struct
-    type t = Common.Model_builder.Core.Tune.t
+    type t = Dancelor_common.Model_builder.Core.Tune.t
     let gen : t QCheck2.Gen.t = Gen.pure (Obj.magic 0)
   end
 
   module Version = struct
-    type t = Common.Model_builder.Core.Version.t
+    type t = Dancelor_common.Model_builder.Core.Version.t
     let gen : t QCheck2.Gen.t = Gen.pure (Obj.magic 0)
   end
 
   module Set = struct
-    type t = Common.Model_builder.Core.Set.t
+    type t = Dancelor_common.Model_builder.Core.Set.t
     let gen : t QCheck2.Gen.t = Gen.pure (Obj.magic 0)
   end
 
   module Book = struct
-    type t = Common.Model_builder.Core.Book.t
+    type t = Dancelor_common.Model_builder.Core.Book.t
     let gen : t QCheck2.Gen.t = Gen.pure (Obj.magic 0)
   end
 
   module Any = struct
     module Type = struct
-      type t = [%import: Common.Model_builder.Core.Any.Type.t [@with Common.Formula.t := Formula.t;]
+      type t = [%import: Dancelor_common.Model_builder.Core.Any.Type.t [@with Dancelor_common.Formula.t := Formula.t;]
       ]
       [@@deriving qcheck2]
     end
@@ -262,210 +262,210 @@ end
 
 module Filter = struct
   module Person = struct
-    type predicate = [%import: Common.Filter_builder.Core.Person.predicate [@with Common.Entry.Id.t := Id.t;
-      Common.Entry.id := Id.t;
-      Common.Model_builder.Core.Person.t := Model.Person.t;
-      Common.Formula_string.t := Formula_string.t;
+    type predicate = [%import: Dancelor_common.Filter_builder.Core.Person.predicate [@with Dancelor_common.Entry.Id.t := Id.t;
+      Dancelor_common.Entry.id := Id.t;
+      Dancelor_common.Model_builder.Core.Person.t := Model.Person.t;
+      Dancelor_common.Formula_string.t := Formula_string.t;
       ]
     ]
     [@@deriving qcheck2]
-    type t = [%import: Common.Filter_builder.Core.Person.t [@with Common.Formula.t := Formula.t;]
+    type t = [%import: Dancelor_common.Filter_builder.Core.Person.t [@with Dancelor_common.Formula.t := Formula.t;]
     ]
     [@@deriving qcheck2]
   end
 
   module Source = struct
-    type predicate = [%import: Common.Filter_builder.Core.Source.predicate [@with Common.Entry.Id.t := Id.t;
-      Common.Entry.id := Id.t;
-      Common.Model_builder.Core.Person.t := Model.Person.t;
-      Common.Model_builder.Core.Source.t := Model.Source.t;
-      Common.Formula_string.t := Formula_string.t;
-      Common.Formula_list.t := Formula_list.t;
-      Common.Formula_entry.t := Formula_entry.t;
-      Common.Formula_entry.public := Formula_entry.public;
-      Common__Filter_builder__Core.Person.t := Person.t;
+    type predicate = [%import: Dancelor_common.Filter_builder.Core.Source.predicate [@with Dancelor_common.Entry.Id.t := Id.t;
+      Dancelor_common.Entry.id := Id.t;
+      Dancelor_common.Model_builder.Core.Person.t := Model.Person.t;
+      Dancelor_common.Model_builder.Core.Source.t := Model.Source.t;
+      Dancelor_common.Formula_string.t := Formula_string.t;
+      Dancelor_common.Formula_list.t := Formula_list.t;
+      Dancelor_common.Formula_entry.t := Formula_entry.t;
+      Dancelor_common.Formula_entry.public := Formula_entry.public;
+      Dancelor_common__Filter_builder__Core.Person.t := Person.t;
       ]
     ]
     [@@deriving qcheck2]
-    type t = [%import: Common.Filter_builder.Core.Source.t [@with Common.Formula.t := Formula.t;]
+    type t = [%import: Dancelor_common.Filter_builder.Core.Source.t [@with Dancelor_common.Formula.t := Formula.t;]
     ]
     [@@deriving qcheck2]
   end
 
   module Dance = struct
-    type predicate = [%import: Common.Filter_builder.Core.Dance.predicate [@with Common.Entry.Id.t := Id.t;
-      Common.Entry.id := Id.t;
-      Common.Model_builder.Core.Person.t := Model.Person.t;
-      Common.Model_builder.Core.Dance.t := Model.Dance.t;
-      Common.Kind.Dance.Filter.t := Kind.Dance.Filter.t;
-      Common.Formula_string.t := Formula_string.t;
-      Common.Formula_list.t := Formula_list.t;
-      Common.Formula_entry.t := Formula_entry.t;
-      Common.Formula_entry.public := Formula_entry.public;
-      Common__Filter_builder__Core.Person.t := Person.t;
+    type predicate = [%import: Dancelor_common.Filter_builder.Core.Dance.predicate [@with Dancelor_common.Entry.Id.t := Id.t;
+      Dancelor_common.Entry.id := Id.t;
+      Dancelor_common.Model_builder.Core.Person.t := Model.Person.t;
+      Dancelor_common.Model_builder.Core.Dance.t := Model.Dance.t;
+      Dancelor_common.Kind.Dance.Filter.t := Kind.Dance.Filter.t;
+      Dancelor_common.Formula_string.t := Formula_string.t;
+      Dancelor_common.Formula_list.t := Formula_list.t;
+      Dancelor_common.Formula_entry.t := Formula_entry.t;
+      Dancelor_common.Formula_entry.public := Formula_entry.public;
+      Dancelor_common__Filter_builder__Core.Person.t := Person.t;
       ]
     ]
     [@@deriving qcheck2]
-    type t = [%import: Common.Filter_builder.Core.Dance.t [@with Common.Formula.t := Formula.t]
+    type t = [%import: Dancelor_common.Filter_builder.Core.Dance.t [@with Dancelor_common.Formula.t := Formula.t]
     ]
     [@@deriving qcheck2]
   end
 
   module Tune = struct
-    type predicate = [%import: Common.Filter_builder.Core.Tune.predicate [@with Common.Entry.Id.t := Id.t;
-      Common.Model_builder.Core.Person.t := Model.Person.t;
-      Common.Model_builder.Core.Tune.t := Model.Tune.t;
-      Common.Model_builder.Core.Dance.t := Model.Dance.t;
-      Common.Kind.Base.Filter.t := Kind.Base.Filter.t;
-      Common.Formula_string.t := Formula_string.t;
-      Common.Formula_list.t := Formula_list.t;
-      Common.Formula_entry.t := Formula_entry.t;
-      Common.Formula_entry.public := Formula_entry.public;
-      Common__Filter_builder__Core.Person.t := Person.t;
-      Common__Filter_builder__Core.Dance.t := Dance.t;
+    type predicate = [%import: Dancelor_common.Filter_builder.Core.Tune.predicate [@with Dancelor_common.Entry.Id.t := Id.t;
+      Dancelor_common.Model_builder.Core.Person.t := Model.Person.t;
+      Dancelor_common.Model_builder.Core.Tune.t := Model.Tune.t;
+      Dancelor_common.Model_builder.Core.Dance.t := Model.Dance.t;
+      Dancelor_common.Kind.Base.Filter.t := Kind.Base.Filter.t;
+      Dancelor_common.Formula_string.t := Formula_string.t;
+      Dancelor_common.Formula_list.t := Formula_list.t;
+      Dancelor_common.Formula_entry.t := Formula_entry.t;
+      Dancelor_common.Formula_entry.public := Formula_entry.public;
+      Dancelor_common__Filter_builder__Core.Person.t := Person.t;
+      Dancelor_common__Filter_builder__Core.Dance.t := Dance.t;
       ]
     ]
     [@@deriving qcheck2]
-    type t = [%import: Common.Filter_builder.Core.Tune.t [@with Common.Formula.t := Formula.t;]
+    type t = [%import: Dancelor_common.Filter_builder.Core.Tune.t [@with Dancelor_common.Formula.t := Formula.t;]
     ]
     [@@deriving qcheck2]
   end
 
   module Version = struct
-    type predicate = [%import: Common.Filter_builder.Core.Version.predicate [@with Common.Entry.Id.t := Id.t;
-      Common.Model_builder.Core.Version.t := Model.Version.t;
-      Common.Model_builder.Core.Tune.t := Model.Tune.t;
-      Common.Model_builder.Core.Source.t := Model.Source.t;
-      Common.Kind.Base.Filter.t := Kind.Base.Filter.t;
-      Common.Kind.Version.Filter.t := Kind.Version.Filter.t;
-      Common.Formula_string.t := Formula_string.t;
-      Common.Formula_list.t := Formula_list.t;
-      Common.Formula_entry.t := Formula_entry.t;
-      Common.Formula_entry.public := Formula_entry.public;
-      Common__Filter_builder__Core.Source.t := Source.t;
-      Common__Filter_builder__Core.Person.t := Person.t;
-      Common__Filter_builder__Core.Dance.t := Dance.t;
-      Common__Filter_builder__Core.Tune.t := Tune.t;
+    type predicate = [%import: Dancelor_common.Filter_builder.Core.Version.predicate [@with Dancelor_common.Entry.Id.t := Id.t;
+      Dancelor_common.Model_builder.Core.Version.t := Model.Version.t;
+      Dancelor_common.Model_builder.Core.Tune.t := Model.Tune.t;
+      Dancelor_common.Model_builder.Core.Source.t := Model.Source.t;
+      Dancelor_common.Kind.Base.Filter.t := Kind.Base.Filter.t;
+      Dancelor_common.Kind.Version.Filter.t := Kind.Version.Filter.t;
+      Dancelor_common.Formula_string.t := Formula_string.t;
+      Dancelor_common.Formula_list.t := Formula_list.t;
+      Dancelor_common.Formula_entry.t := Formula_entry.t;
+      Dancelor_common.Formula_entry.public := Formula_entry.public;
+      Dancelor_common__Filter_builder__Core.Source.t := Source.t;
+      Dancelor_common__Filter_builder__Core.Person.t := Person.t;
+      Dancelor_common__Filter_builder__Core.Dance.t := Dance.t;
+      Dancelor_common__Filter_builder__Core.Tune.t := Tune.t;
       ]
     ]
     [@@deriving qcheck2]
-    type t = [%import: Common.Filter_builder.Core.Version.t [@with Common.Formula.t := Formula.t;]
+    type t = [%import: Dancelor_common.Filter_builder.Core.Version.t [@with Dancelor_common.Formula.t := Formula.t;]
     ]
     [@@deriving qcheck2]
   end
 
   module Set = struct
-    type predicate = [%import: Common.Filter_builder.Core.Set.predicate [@with Common.Entry.Id.t := Id.t;
-      Common.Model_builder.Core.Version.t := Model.Version.t;
-      Common.Model_builder.Core.Person.t := Model.Person.t;
-      Common.Model_builder.Core.Set.t := Model.Set.t;
-      Common.Kind.Base.Filter.t := Kind.Base.Filter.t;
-      Common.Kind.Version.Filter.t := Kind.Version.Filter.t;
-      Common.Kind.Dance.Filter.t := Kind.Dance.Filter.t;
-      Common.Formula_list.t := Formula_list.t;
-      Common.Formula_string.t := Formula_string.t;
-      Common.Formula_entry.t := Formula_entry.t;
-      Common.Formula_entry.public := Formula_entry.public;
-      Common.Formula_user.t := Formula_user.t;
-      Common.Entry.User.t := Entry.User.t;
-      Common__Filter_builder__Core.Person.t := Person.t;
-      Common__Filter_builder__Core.Version.t := Version.t;
-      Common__Filter_builder__Core.User.t := User.t;
+    type predicate = [%import: Dancelor_common.Filter_builder.Core.Set.predicate [@with Dancelor_common.Entry.Id.t := Id.t;
+      Dancelor_common.Model_builder.Core.Version.t := Model.Version.t;
+      Dancelor_common.Model_builder.Core.Person.t := Model.Person.t;
+      Dancelor_common.Model_builder.Core.Set.t := Model.Set.t;
+      Dancelor_common.Kind.Base.Filter.t := Kind.Base.Filter.t;
+      Dancelor_common.Kind.Version.Filter.t := Kind.Version.Filter.t;
+      Dancelor_common.Kind.Dance.Filter.t := Kind.Dance.Filter.t;
+      Dancelor_common.Formula_list.t := Formula_list.t;
+      Dancelor_common.Formula_string.t := Formula_string.t;
+      Dancelor_common.Formula_entry.t := Formula_entry.t;
+      Dancelor_common.Formula_entry.public := Formula_entry.public;
+      Dancelor_common.Formula_user.t := Formula_user.t;
+      Dancelor_common.Entry.User.t := Entry.User.t;
+      Dancelor_common__Filter_builder__Core.Person.t := Person.t;
+      Dancelor_common__Filter_builder__Core.Version.t := Version.t;
+      Dancelor_common__Filter_builder__Core.User.t := User.t;
       ]
     ]
     [@@deriving qcheck2]
-    type t = [%import: Common.Filter_builder.Core.Set.t [@with Common.Formula.t := Formula.t;]
+    type t = [%import: Dancelor_common.Filter_builder.Core.Set.t [@with Dancelor_common.Formula.t := Formula.t;]
     ]
     [@@deriving qcheck2]
   end
 
   module Book = struct
-    type predicate = [%import: Common.Filter_builder.Core.Book.predicate [@with Common.Entry.Id.t := Id.t;
-      Common.Model_builder.Core.Version.t := Model.Version.t;
-      Common.Model_builder.Core.Person.t := Model.Person.t;
-      Common.Model_builder.Core.Book.t := Model.Book.t;
-      Common.Model_builder.Core.Set.t := Model.Set.t;
-      Common.Kind.Base.Filter.t := Kind.Base.Filter.t;
-      Common.Kind.Version.Filter.t := Kind.Version.Filter.t;
-      Common.Kind.Dance.Filter.t := Kind.Dance.Filter.t;
-      Common.Formula_list.t := Formula_list.t;
-      Common.Formula_string.t := Formula_string.t;
-      Common.Formula_entry.t := Formula_entry.t;
-      Common.Formula_entry.public := Formula_entry.public;
-      Common.Formula_entry.private_ := Formula_entry.private_;
-      Common.Entry.User.t := Entry.User.t;
-      Common.Formula_user.t := Formula_user.t;
-      Common__Filter_builder__Core.Person.t := Person.t;
-      Common__Filter_builder__Core.Version.t := Version.t;
-      Common__Filter_builder__Core.Set.t := Set.t;
-      Common__Filter_builder__Core.User.t := User.t;
+    type predicate = [%import: Dancelor_common.Filter_builder.Core.Book.predicate [@with Dancelor_common.Entry.Id.t := Id.t;
+      Dancelor_common.Model_builder.Core.Version.t := Model.Version.t;
+      Dancelor_common.Model_builder.Core.Person.t := Model.Person.t;
+      Dancelor_common.Model_builder.Core.Book.t := Model.Book.t;
+      Dancelor_common.Model_builder.Core.Set.t := Model.Set.t;
+      Dancelor_common.Kind.Base.Filter.t := Kind.Base.Filter.t;
+      Dancelor_common.Kind.Version.Filter.t := Kind.Version.Filter.t;
+      Dancelor_common.Kind.Dance.Filter.t := Kind.Dance.Filter.t;
+      Dancelor_common.Formula_list.t := Formula_list.t;
+      Dancelor_common.Formula_string.t := Formula_string.t;
+      Dancelor_common.Formula_entry.t := Formula_entry.t;
+      Dancelor_common.Formula_entry.public := Formula_entry.public;
+      Dancelor_common.Formula_entry.private_ := Formula_entry.private_;
+      Dancelor_common.Entry.User.t := Entry.User.t;
+      Dancelor_common.Formula_user.t := Formula_user.t;
+      Dancelor_common__Filter_builder__Core.Person.t := Person.t;
+      Dancelor_common__Filter_builder__Core.Version.t := Version.t;
+      Dancelor_common__Filter_builder__Core.Set.t := Set.t;
+      Dancelor_common__Filter_builder__Core.User.t := User.t;
       ]
     ]
     [@@deriving qcheck2]
-    type t = [%import: Common.Filter_builder.Core.Book.t [@with Common.Formula.t := Formula.t;]
+    type t = [%import: Dancelor_common.Filter_builder.Core.Book.t [@with Dancelor_common.Formula.t := Formula.t;]
     ]
     [@@deriving qcheck2]
   end
 
   module User = struct
-    type predicate = [%import: Common.Filter_builder.Core.User.predicate [@with Common.Entry.Id.t := Id.t;
-      Common.Model_builder.Core.Version.t := Model.Version.t;
-      Common.Model_builder.Core.Person.t := Model.Person.t;
-      Common.Model_builder.Core.User.t := Model.User.t;
-      Common.Model_builder.Core.Set.t := Model.Set.t;
-      Common.Kind.Base.Filter.t := Kind.Base.Filter.t;
-      Common.Kind.Version.Filter.t := Kind.Version.Filter.t;
-      Common.Kind.Dance.Filter.t := Kind.Dance.Filter.t;
-      Common.Formula_list.t := Formula_list.t;
-      Common.Formula_string.t := Formula_string.t;
-      Common.Formula_entry.t := Formula_entry.t;
-      Common.Formula_entry.public := Formula_entry.public;
-      Common.Formula_entry.private_ := Formula_entry.private_;
-      Common.Entry.User.t := Entry.User.t;
-      Common.Formula_user.t := Formula_user.t;
-      Common__Filter_builder__Core.Person.t := Person.t;
-      Common__Filter_builder__Core.Version.t := Version.t;
-      Common__Filter_builder__Core.Set.t := Set.t;
-      Common__Filter_builder__Core.User.t := User.t;
+    type predicate = [%import: Dancelor_common.Filter_builder.Core.User.predicate [@with Dancelor_common.Entry.Id.t := Id.t;
+      Dancelor_common.Model_builder.Core.Version.t := Model.Version.t;
+      Dancelor_common.Model_builder.Core.Person.t := Model.Person.t;
+      Dancelor_common.Model_builder.Core.User.t := Model.User.t;
+      Dancelor_common.Model_builder.Core.Set.t := Model.Set.t;
+      Dancelor_common.Kind.Base.Filter.t := Kind.Base.Filter.t;
+      Dancelor_common.Kind.Version.Filter.t := Kind.Version.Filter.t;
+      Dancelor_common.Kind.Dance.Filter.t := Kind.Dance.Filter.t;
+      Dancelor_common.Formula_list.t := Formula_list.t;
+      Dancelor_common.Formula_string.t := Formula_string.t;
+      Dancelor_common.Formula_entry.t := Formula_entry.t;
+      Dancelor_common.Formula_entry.public := Formula_entry.public;
+      Dancelor_common.Formula_entry.private_ := Formula_entry.private_;
+      Dancelor_common.Entry.User.t := Entry.User.t;
+      Dancelor_common.Formula_user.t := Formula_user.t;
+      Dancelor_common__Filter_builder__Core.Person.t := Person.t;
+      Dancelor_common__Filter_builder__Core.Version.t := Version.t;
+      Dancelor_common__Filter_builder__Core.Set.t := Set.t;
+      Dancelor_common__Filter_builder__Core.User.t := User.t;
       ]
     ]
     [@@deriving qcheck2]
-    type t = [%import: Common.Filter_builder.Core.User.t [@with Common.Formula.t := Formula.t;]
+    type t = [%import: Dancelor_common.Filter_builder.Core.User.t [@with Dancelor_common.Formula.t := Formula.t;]
     ]
     [@@deriving qcheck2]
   end
 
   module Any = struct
-    type predicate = [%import: Common.Filter_builder.Core.Any.predicate [@with Common.Entry.Id.t := Id.t;
-      Common.Model_builder.Core.Version.t := Model.Version.t;
-      Common.Model_builder.Core.Person.t := Model.Person.t;
-      Common.Model_builder.Core.Tune.t := Model.Tune.t;
-      Common.Model_builder.Core.Dance.t := Model.Dance.t;
-      Common.Model_builder.Core.Set.t := Model.Set.t;
-      Common.Model_builder.Core.Book.t := Model.Book.t;
-      Common.Model_builder.Core.Source.t := Model.Source.t;
-      Common.Model_builder.Core.User.t := Entry.User.t;
-      Common.Model_builder.Core.Any.Type.t := Model.Any.Type.t;
-      Common.Kind.Base.Filter.t := Kind.Base.Filter.t;
-      Common.Kind.Version.Filter.t := Kind.Version.Filter.t;
-      Common.Kind.Dance.Filter.t := Kind.Dance.Filter.t;
-      Common.Formula.t := Formula.t;
-      Common.Formula_entry.t := Formula_entry.t;
-      Common.Formula_entry.gen := Formula_entry.gen;
-      Common.Formula_entry.public := Formula_entry.public;
-      Common.Formula_entry.private_ := Formula_entry.private_;
-      Common__Filter_builder__Core.Source.t := Source.t;
-      Common__Filter_builder__Core.Person.t := Person.t;
-      Common__Filter_builder__Core.Dance.t := Dance.t;
-      Common__Filter_builder__Core.Book.t := Book.t;
-      Common__Filter_builder__Core.Set.t := Set.t;
-      Common__Filter_builder__Core.Tune.t := Tune.t;
-      Common__Filter_builder__Core.Version.t := Version.t;
-      Common__Filter_builder__Core.User.t := User.t;
+    type predicate = [%import: Dancelor_common.Filter_builder.Core.Any.predicate [@with Dancelor_common.Entry.Id.t := Id.t;
+      Dancelor_common.Model_builder.Core.Version.t := Model.Version.t;
+      Dancelor_common.Model_builder.Core.Person.t := Model.Person.t;
+      Dancelor_common.Model_builder.Core.Tune.t := Model.Tune.t;
+      Dancelor_common.Model_builder.Core.Dance.t := Model.Dance.t;
+      Dancelor_common.Model_builder.Core.Set.t := Model.Set.t;
+      Dancelor_common.Model_builder.Core.Book.t := Model.Book.t;
+      Dancelor_common.Model_builder.Core.Source.t := Model.Source.t;
+      Dancelor_common.Model_builder.Core.User.t := Entry.User.t;
+      Dancelor_common.Model_builder.Core.Any.Type.t := Model.Any.Type.t;
+      Dancelor_common.Kind.Base.Filter.t := Kind.Base.Filter.t;
+      Dancelor_common.Kind.Version.Filter.t := Kind.Version.Filter.t;
+      Dancelor_common.Kind.Dance.Filter.t := Kind.Dance.Filter.t;
+      Dancelor_common.Formula.t := Formula.t;
+      Dancelor_common.Formula_entry.t := Formula_entry.t;
+      Dancelor_common.Formula_entry.gen := Formula_entry.gen;
+      Dancelor_common.Formula_entry.public := Formula_entry.public;
+      Dancelor_common.Formula_entry.private_ := Formula_entry.private_;
+      Dancelor_common__Filter_builder__Core.Source.t := Source.t;
+      Dancelor_common__Filter_builder__Core.Person.t := Person.t;
+      Dancelor_common__Filter_builder__Core.Dance.t := Dance.t;
+      Dancelor_common__Filter_builder__Core.Book.t := Book.t;
+      Dancelor_common__Filter_builder__Core.Set.t := Set.t;
+      Dancelor_common__Filter_builder__Core.Tune.t := Tune.t;
+      Dancelor_common__Filter_builder__Core.Version.t := Version.t;
+      Dancelor_common__Filter_builder__Core.User.t := User.t;
       ]
     ]
     [@@deriving qcheck2]
-    type t = [%import: Common.Filter_builder.Core.Any.t [@with Common.Formula.t := Formula.t;]
+    type t = [%import: Dancelor_common.Filter_builder.Core.Any.t [@with Dancelor_common.Formula.t := Formula.t;]
     ]
     [@@deriving qcheck2]
   end

--- a/tests/unit/formula.ml
+++ b/tests/unit/formula.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 module Gen = QCheck_generators
 

--- a/tests/unit/kind.ml
+++ b/tests/unit/kind.ml
@@ -1,5 +1,5 @@
 open Nes
-open Common
+open Dancelor_common
 
 let rountrip_test ~name ~gen ~show ~to_string ~of_string ~equal =
   QCheck_alcotest.to_alcotest


### PR DESCRIPTION
I find this very annoying, but some dependency of `ocaml-mariadb`
exposes a `Common` module and it clashes.