### PR TITLE
Do no make person's `scddb_id` unique

### DIFF
--- a/src/server/database/migrations.sql
+++ b/src/server/database/migrations.sql
@@ -253,7 +253,7 @@ DROP COLUMN "remember_me_tokens";
 -- @m030_2026_05_split_person_json_into_fields__add_columns
 ALTER TABLE "person"
 ADD COLUMN "name" VARCHAR(256),
-ADD COLUMN "scddb_id" INT UNIQUE,
+ADD COLUMN "scddb_id" INT,
 ADD COLUMN "composed_tunes_are_public" BOOLEAN,
 ADD COLUMN "published_tunes_are_public" BOOLEAN,
 ADD COLUMN "created_at" TIMESTAMP,

--- a/src/server/database/schema.sql
+++ b/src/server/database/schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE "dance" (
 CREATE TABLE "person" (
     "id" VARCHAR(14) NOT NULL PRIMARY KEY,
     "name" VARCHAR(256) NOT NULL,
-    "scddb_id" INT NULL UNIQUE,
+    "scddb_id" INT,
     "composed_tunes_are_public" BOOLEAN NOT NULL,
     "published_tunes_are_public" BOOLEAN NOT NULL,
     "created_at" TIMESTAMP NOT NULL,

--- a/tests/database.sql
+++ b/tests/database.sql
@@ -367,14 +367,6 @@ ALTER TABLE ONLY "dancelor"."version"
 
 
 --
--- Name: person person_scddb_id_key; Type: CONSTRAINT; Schema: dancelor; Owner: -
---
-
-ALTER TABLE ONLY "dancelor"."person"
-    ADD CONSTRAINT "person_scddb_id_key" UNIQUE ("scddb_id");
-
-
---
 -- Name: user user_username_key; Type: CONSTRAINT; Schema: dancelor; Owner: -
 --
 


### PR DESCRIPTION
It turns out that it isn't. It would be good to enforce in the future,
but not as part as this already complicated migration.