### PR TITLE
Roll out a new, SQL-based search

### DIFF
--- a/src/client/client.ml
+++ b/src/client/client.ml
@@ -20,6 +20,7 @@ let dispatch uri =
     | Index -> Index.create ()
     | Any -> redirect_any
     | Explore -> Explorer.view
+    | Explore_new -> Explorer.view_new
     | Book -> Book_viewer.view
     | Book_add -> Book_editor.add ()
     | Book_edit -> Book_editor.edit

--- a/src/client/formatters_new.ml
+++ b/src/client/formatters_new.ml
@@ -99,6 +99,14 @@ module Tune = struct
 end
 
 module Version = struct
+  let name ?(link = true) ?context (version : Version_name.t) =
+    if link then
+      a
+        ~a: [R.a_href @@ S.map (fun context -> Endpoints.Page.href_version ?context version.id) (switch_signal_option context)]
+        [txt version.name]
+    else
+      txt version.name
+
   let name_row ?(link = true) ?context (version : Version_row.t) =
     if link then
       a
@@ -183,7 +191,7 @@ module Set = struct
 
   let tunes ?links (set : Set_row.t) =
     set.tunes
-    |> List.map (Tune.name ?link: links)
+    |> List.map (Version.name ?link: links)
     |> List.interspersei (fun _ -> txt " - ")
     |> List.cons (txt "Tunes: ")
 end

--- a/src/client/views/book_editor.ml
+++ b/src/client/views/book_editor.ml
@@ -79,9 +79,8 @@ let versions_and_parameters ?(label = "Versions") () =
             ~label
             ~model_name: "version"
             ~create_dialog_content: Version_editor.create_row
-            ~search: (fun slice input ->
-              let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_public Filter.Version.converter) input in
-              ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Version Search) slice filter
+            ~search: (fun slice filter ->
+              ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Version Search_new) slice filter
             )
             ~id_to_yojson: Entry.Id.to_yojson'
             ~id_of_yojson: Entry.Id.of_yojson'
@@ -106,9 +105,8 @@ let set_and_parameters ?(label = "Set") () =
         ~label
         ~model_name: "set"
         ~create_dialog_content: Set_editor.create_row
-        ~search: (fun slice input ->
-          let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_private Filter.Set.converter) input in
-          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Set Search) slice filter
+        ~search: (fun slice filter ->
+          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Set Search_new) slice filter
         )
         ~id_to_yojson: Entry.Id.to_yojson'
         ~id_of_yojson: Entry.Id.of_yojson'
@@ -141,9 +139,8 @@ let dance_and_dance_page =
         ~label: "Dance"
         ~model_name: "dance"
         ~create_dialog_content: Dance_editor.create_row
-        ~search: (fun slice input ->
-          let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_public Filter.Dance.converter) input in
-          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Dance Search) slice filter
+        ~search: (fun slice filter ->
+          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Dance Search_new) slice filter
         )
         ~id_to_yojson: Entry.Id.to_yojson'
         ~id_of_yojson: Entry.Id.of_yojson'
@@ -187,9 +184,8 @@ let editor user =
     (
       Selector.prepare
         ~label: "Editor"
-        ~search: (fun slice input ->
-          let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_public Filter.Person.converter) input in
-          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Person Search) slice filter
+        ~search: (fun slice filter ->
+          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Person Search_new) slice filter
         )
         ~id_to_yojson: Entry.Id.to_yojson'
         ~id_of_yojson: Entry.Id.of_yojson'
@@ -279,9 +275,8 @@ let editor user =
         ~label: "Source"
         ~model_name: "source"
         ~create_dialog_content: Source_editor.create_row
-        ~search: (fun slice input ->
-          let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_public Filter.Source.converter) input in
-          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Source Search) slice filter
+        ~search: (fun slice filter ->
+          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Source Search_new) slice filter
         )
         ~id_to_yojson: Entry.Id.to_yojson'
         ~id_of_yojson: Entry.Id.of_yojson'

--- a/src/client/views/dance_editor.ml
+++ b/src/client/views/dance_editor.ml
@@ -33,9 +33,8 @@ let editor =
     (
       Selector.prepare
         ~label: "Deviser"
-        ~search: (fun slice input ->
-          let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_public Filter.Person.converter) input in
-          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Person Search) slice filter
+        ~search: (fun slice filter ->
+          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Person Search_new) slice filter
         )
         ~id_to_yojson: Entry.Id.to_yojson'
         ~id_of_yojson: Entry.Id.of_yojson'

--- a/src/client/views/explorer.ml
+++ b/src/client/views/explorer.ml
@@ -12,13 +12,10 @@ let update_uri input =
     (Js.string "")
     (Js.some (Js.string (Uri.to_string uri)))
 
-let view query =
+let view_gen ~search query =
   let search =
     Search.make
-      ~search: (fun slice filter ->
-        (* let%rlwt filter = lwt @@ Text_formula.string_to_formula Filter.Any.converter input in *)
-        ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Any Search_new) slice filter
-      )
+      ~search
       ?initial_input: query
       ~pagination_mode: (Pagination ())
       ~on_input: update_uri
@@ -54,3 +51,16 @@ let view query =
             ();
         ]
     ]
+
+let view =
+  view_gen
+    ~search: (fun slice input ->
+      let%rlwt filter = lwt @@ Text_formula.string_to_formula Filter.Any.converter input in
+      ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Any Search) slice filter
+    )
+
+let view_new =
+  view_gen
+    ~search: (fun slice filter ->
+      ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Any Search_new) slice filter
+    )

--- a/src/client/views/explorer.ml
+++ b/src/client/views/explorer.ml
@@ -17,7 +17,7 @@ let view query =
     Search.make
       ~search: (fun slice filter ->
         (* let%rlwt filter = lwt @@ Text_formula.string_to_formula Filter.Any.converter input in *)
-        ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Any Search_new) slice @@ NEString.of_string filter
+        ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Any Search_new) slice filter
       )
       ?initial_input: query
       ~pagination_mode: (Pagination ())

--- a/src/client/views/explorer.ml
+++ b/src/client/views/explorer.ml
@@ -15,9 +15,9 @@ let update_uri input =
 let view query =
   let search =
     Search.make
-      ~search: (fun slice input ->
-        let%rlwt filter = lwt @@ Text_formula.string_to_formula Filter.Any.converter input in
-        ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Any Search) slice filter
+      ~search: (fun slice filter ->
+        (* let%rlwt filter = lwt @@ Text_formula.string_to_formula Filter.Any.converter input in *)
+        ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Any Search_new) slice @@ NEString.of_string filter
       )
       ?initial_input: query
       ~pagination_mode: (Pagination ())

--- a/src/client/views/main_page.ml
+++ b/src/client/views/main_page.ml
@@ -14,15 +14,14 @@ let set_title title =
 let get_uri () = Uri.of_string (Js.to_string Dom_html.window##.location##.href)
 
 let quick_search_to_explorer value =
-  let href = Endpoints.Page.(href Explore) (Some value) in
+  let href = Endpoints.Page.(href Explore_new) (Some value) in
   Dom_html.window##.location##.href := Js.string (Uri.to_string href);
   Js_of_ocaml_lwt.Lwt_js.sleep 10.
 
 let quick_search =
   Components.Search.Quick.make
-    ~search: (fun slice input ->
-      let%rlwt filter = lwt @@ Text_formula.string_to_formula Filter.Any.converter input in
-      ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Any Search) slice filter
+    ~search: (fun slice filter ->
+      ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Any Search_new) slice filter
     )
     ~on_enter: (fun value -> Lwt.async (fun () -> quick_search_to_explorer value))
     ()
@@ -58,6 +57,7 @@ let nav_item_explore =
         ~a: [a_class ["dropdown-menu"]]
         (
           [li [Button.make_a ~label: "All" ~href: (S.const @@ Endpoints.Page.(href Explore) None) ~dropdown: true ()];
+          li [Button.make_a ~label: "All (new)" ~href: (S.const @@ Endpoints.Page.(href Explore_new) None) ~dropdown: true ()];
           li [hr ~a: [a_class ["dropdown-divider"]] ()];
           ] @
             List.map

--- a/src/client/views/set_editor.ml
+++ b/src/client/views/set_editor.ml
@@ -233,10 +233,10 @@ let create mode =
     ~href: (Endpoints.Page.href_set % Entry.id)
     ~check_product: (fun (set1, access1) (set2, access2) -> Model.Set.equal set1 set2 && Entry.Access.Private.equal access1 access2)
 
-let version_to_name (version : Model.Version.entry) : Tune_name.t Lwt.t =
+let version_to_name (version : Model.Version.entry) : Version_name.t Lwt.t =
   let%lwt tune = Model.Version.tune' version in
   lwt {
-    Tune_name.id = Entry.id tune;
+    Version_name.id = Entry.id version;
     name = NEString.to_string @@ NEList.hd @@ Model.Tune.names' tune;
   }
 

--- a/src/client/views/set_editor.ml
+++ b/src/client/views/set_editor.ml
@@ -53,9 +53,8 @@ let editor user =
         ~label: "Conceptor"
         ~model_name: "person"
         ~create_dialog_content: Person_editor.create_row
-        ~search: (fun slice input ->
-          let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_public Filter.Person.converter) input in
-          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Person Search) slice filter
+        ~search: (fun slice filter ->
+          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Person Search_new) slice filter
         )
         ~id_to_yojson: Entry.Id.to_yojson'
         ~id_of_yojson: Entry.Id.of_yojson'
@@ -79,9 +78,8 @@ let editor user =
             ~label: "Version"
             ~model_name: "version"
             ~create_dialog_content: Version_editor.create_row
-            ~search: (fun slice input ->
-              let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_public Filter.Version.converter) input in
-              ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Version Search) slice filter
+            ~search: (fun slice filter ->
+              ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Version Search_new) slice filter
             )
             ~id_to_yojson: Entry.Id.to_yojson'
             ~id_of_yojson: Entry.Id.of_yojson'

--- a/src/client/views/source_editor.ml
+++ b/src/client/views/source_editor.ml
@@ -25,9 +25,8 @@ let editor =
     (
       Selector.prepare
         ~label: "Editor"
-        ~search: (fun slice input ->
-          let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_public Filter.Person.converter) input in
-          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Person Search) slice filter
+        ~search: (fun slice filter ->
+          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Person Search_new) slice filter
         )
         ~id_to_yojson: Entry.Id.to_yojson'
         ~id_of_yojson: Entry.Id.of_yojson'

--- a/src/client/views/tune_editor.ml
+++ b/src/client/views/tune_editor.ml
@@ -39,9 +39,8 @@ let editor =
             ~label: "Composer"
             ~model_name: "person"
             ~create_dialog_content: Person_editor.create_row
-            ~search: (fun slice input ->
-              let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_public Filter.Person.converter) input in
-              ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Person Search) slice filter
+            ~search: (fun slice filter ->
+              ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Person Search_new) slice filter
             )
             ~id_to_yojson: Entry.Id.to_yojson'
             ~id_of_yojson: Entry.Id.of_yojson'
@@ -76,9 +75,8 @@ let editor =
     ~label: "Dances"
     (
       Selector.prepare
-        ~search: (fun slice input ->
-          let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_public Filter.Dance.converter) input in
-          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Dance Search) slice filter
+        ~search: (fun slice filter ->
+          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Dance Search_new) slice filter
         )
         ~id_to_yojson: Entry.Id.to_yojson'
         ~id_of_yojson: Entry.Id.of_yojson'

--- a/src/client/views/version_editor.ml
+++ b/src/client/views/version_editor.ml
@@ -191,9 +191,8 @@ let editor =
     ~label: "Tune"
     ~model_name: "tune"
     ~create_dialog_content: Tune_editor.create_row
-    ~search: (fun slice input ->
-      let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_public Filter.Tune.converter) input in
-      ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Tune Search) slice filter
+    ~search: (fun slice filter ->
+      ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Tune Search_new) slice filter
     )
     ~id_to_yojson: Entry.Id.to_yojson'
     ~id_of_yojson: Entry.Id.of_yojson'
@@ -221,9 +220,8 @@ let editor =
         ~label: "Arranger"
         ~model_name: "person"
         ~create_dialog_content: Person_editor.create_row
-        ~search: (fun slice input ->
-          let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_public Filter.Person.converter) input in
-          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Person Search) slice filter
+        ~search: (fun slice filter ->
+          ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Person Search_new) slice filter
         )
         ~id_to_yojson: Entry.Id.to_yojson'
         ~id_of_yojson: Entry.Id.of_yojson'
@@ -250,9 +248,8 @@ let editor =
             ~label: "Source"
             ~model_name: "source"
             ~create_dialog_content: Source_editor.create_row
-            ~search: (fun slice input ->
-              let%rlwt filter = lwt @@ Text_formula.string_to_formula (Formula_entry.converter_public Filter.Source.converter) input in
-              ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Source Search) slice filter
+            ~search: (fun slice filter ->
+              ok <$> Madge_client.call_exn Endpoints.Api.(route @@ Source Search_new) slice filter
             )
             ~id_to_yojson: Entry.Id.to_yojson'
             ~id_of_yojson: Entry.Id.of_yojson'

--- a/src/common/endpoints/any.ml
+++ b/src/common/endpoints/any.ml
@@ -9,7 +9,7 @@ type (_, _, _) t =
   | Get_rows : (Any_id.t list -> 'w, 'w, Any_row.t list) t
   | Search : ((Slice.t -> Filter.Any.t -> 'w), 'w, Any_row.t search_result) t
   | Search_context : ((Filter.Any.t -> Any_id.t -> 'w), 'w, Any_id.t search_context_result) t
-  | Search_new : (Slice.t -> NEString.t option -> 'w, 'w, Any_row.t search_result) t
+  | Search_new : (Slice.t -> string -> 'w, 'w, Any_row.t search_result) t
 [@@deriving madge_wrapped_endpoints]
 
 let route : type a w r. (a, w, r) t -> (a, w, r) route =
@@ -19,4 +19,4 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
     | Get_rows -> literal "get-rows" @@ body "ids" (module JList(Any_id)) @@ post (module JList(Any_row))
     | Search -> query "slice" (module Slice) @@ query "filter" (module Filter.Any) @@ get (module Utils.Search_result(Any_row))
     | Search_context -> literal "context" @@ query "filter" (module Filter.Any) @@ query "element" (module Any_id) @@ get (module Utils.Search_context_result(Any_id))
-    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JOption(JNEString)) @@ get (module Utils.Search_result(Any_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JString) @@ get (module Utils.Search_result(Any_row))

--- a/src/common/endpoints/any.ml
+++ b/src/common/endpoints/any.ml
@@ -9,6 +9,7 @@ type (_, _, _) t =
   | Get_rows : (Any_id.t list -> 'w, 'w, Any_row.t list) t
   | Search : ((Slice.t -> Filter.Any.t -> 'w), 'w, Any_row.t search_result) t
   | Search_context : ((Filter.Any.t -> Any_id.t -> 'w), 'w, Any_id.t search_context_result) t
+  | Search_new : (Slice.t -> string -> 'w, 'w, Any_row.t search_result) t
 [@@deriving madge_wrapped_endpoints]
 
 let route : type a w r. (a, w, r) t -> (a, w, r) route =
@@ -18,3 +19,4 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
     | Get_rows -> literal "get-rows" @@ body "ids" (module JList(Any_id)) @@ post (module JList(Any_row))
     | Search -> query "slice" (module Slice) @@ query "filter" (module Filter.Any) @@ get (module Utils.Search_result(Any_row))
     | Search_context -> literal "context" @@ query "filter" (module Filter.Any) @@ query "element" (module Any_id) @@ get (module Utils.Search_context_result(Any_id))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JString) @@ get (module Utils.Search_result(Any_row))

--- a/src/common/endpoints/any.ml
+++ b/src/common/endpoints/any.ml
@@ -9,7 +9,7 @@ type (_, _, _) t =
   | Get_rows : (Any_id.t list -> 'w, 'w, Any_row.t list) t
   | Search : ((Slice.t -> Filter.Any.t -> 'w), 'w, Any_row.t search_result) t
   | Search_context : ((Filter.Any.t -> Any_id.t -> 'w), 'w, Any_id.t search_context_result) t
-  | Search_new : (Slice.t -> string -> 'w, 'w, Any_row.t search_result) t
+  | Search_new : (Slice.t -> NEString.t option -> 'w, 'w, Any_row.t search_result) t
 [@@deriving madge_wrapped_endpoints]
 
 let route : type a w r. (a, w, r) t -> (a, w, r) route =
@@ -19,4 +19,4 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
     | Get_rows -> literal "get-rows" @@ body "ids" (module JList(Any_id)) @@ post (module JList(Any_row))
     | Search -> query "slice" (module Slice) @@ query "filter" (module Filter.Any) @@ get (module Utils.Search_result(Any_row))
     | Search_context -> literal "context" @@ query "filter" (module Filter.Any) @@ query "element" (module Any_id) @@ get (module Utils.Search_context_result(Any_id))
-    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JString) @@ get (module Utils.Search_result(Any_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JOption(JNEString)) @@ get (module Utils.Search_result(Any_row))

--- a/src/common/endpoints/book.ml
+++ b/src/common/endpoints/book.ml
@@ -7,6 +7,7 @@ module Filter = Filter_builder.Core
 type (_, _, _) t =
   | Create : (Book.t -> Entry.Access.Private.t -> 'w, 'w, Book_id.t) t
   | Search : (Slice.t -> (Book.t, Filter.Book.t) Formula_entry.private_ -> 'w, 'w, Book_row.t search_result) t
+  | Search_new : (Slice.t -> string -> 'w, 'w, Book_row.t search_result) t
   | Get : (Book_id.t -> 'w, 'w, Book.entry) t
   | Get_row : (Book_id.t -> 'w, 'w, Book_row.t) t
   | Get_view : (Book_id.t -> 'w, 'w, Book_view.t) t
@@ -21,6 +22,7 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
   function
     | Create -> body "book" (module Book) @@ body "access" (module Entry.Access.Private) @@ post (module Book_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPrivate(Book)(Filter.Book)) @@ get (module Utils.Search_result(Book_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JString) @@ get (module Utils.Search_result(Book_row))
     | Get -> variable (module Book_id) @@ get (module Entry.JPrivate(Book))
     | Get_row -> variable (module Book_id) @@ literal "row" @@ get (module Book_row)
     | Get_view -> variable (module Book_id) @@ literal "view" @@ get (module Book_view)

--- a/src/common/endpoints/dance.ml
+++ b/src/common/endpoints/dance.ml
@@ -18,11 +18,9 @@ type (_, _, _) t =
 let route : type a w r. (a, w, r) t -> (a, w, r) route =
   let open Route in
   function
-    (* Actions without a specific dance *)
     | Create -> body "dance" (module Dance) @@ post (module Dance_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPublic(Dance)(Filter.Dance)) @@ get (module Utils.Search_result(Dance_row))
     | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JOption(JNEString)) @@ get (module Utils.Search_result(Dance_row))
-    (* Actions on a specific dance *)
     | Get -> variable (module Dance_id) @@ get (module Entry.JPublic(Dance))
     | Get_row -> variable (module Dance_id) @@ literal "row" @@ get (module Dance_row)
     | Get_view -> variable (module Dance_id) @@ literal "view" @@ get (module Dance_view)

--- a/src/common/endpoints/dance.ml
+++ b/src/common/endpoints/dance.ml
@@ -7,6 +7,7 @@ module Filter = Filter_builder.Core
 type (_, _, _) t =
   | Create : (Dance.t -> 'w, 'w, Dance_id.t) t
   | Search : (Slice.t -> (Dance.t, Filter.Dance.t) Formula_entry.public -> 'w, 'w, Dance_row.t search_result) t
+  | Search_new : (Slice.t -> NEString.t option -> 'w, 'w, Dance_row.t search_result) t
   | Get : (Dance_id.t -> 'w, 'w, Dance.entry) t
   | Get_row : (Dance_id.t -> 'w, 'w, Dance_row.t) t
   | Get_view : (Dance_id.t -> 'w, 'w, Dance_view.t) t
@@ -20,6 +21,7 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
     (* Actions without a specific dance *)
     | Create -> body "dance" (module Dance) @@ post (module Dance_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPublic(Dance)(Filter.Dance)) @@ get (module Utils.Search_result(Dance_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JOption(JNEString)) @@ get (module Utils.Search_result(Dance_row))
     (* Actions on a specific dance *)
     | Get -> variable (module Dance_id) @@ get (module Entry.JPublic(Dance))
     | Get_row -> variable (module Dance_id) @@ literal "row" @@ get (module Dance_row)

--- a/src/common/endpoints/dance.ml
+++ b/src/common/endpoints/dance.ml
@@ -7,7 +7,7 @@ module Filter = Filter_builder.Core
 type (_, _, _) t =
   | Create : (Dance.t -> 'w, 'w, Dance_id.t) t
   | Search : (Slice.t -> (Dance.t, Filter.Dance.t) Formula_entry.public -> 'w, 'w, Dance_row.t search_result) t
-  | Search_new : (Slice.t -> NEString.t option -> 'w, 'w, Dance_row.t search_result) t
+  | Search_new : (Slice.t -> string -> 'w, 'w, Dance_row.t search_result) t
   | Get : (Dance_id.t -> 'w, 'w, Dance.entry) t
   | Get_row : (Dance_id.t -> 'w, 'w, Dance_row.t) t
   | Get_view : (Dance_id.t -> 'w, 'w, Dance_view.t) t
@@ -20,7 +20,7 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
   function
     | Create -> body "dance" (module Dance) @@ post (module Dance_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPublic(Dance)(Filter.Dance)) @@ get (module Utils.Search_result(Dance_row))
-    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JOption(JNEString)) @@ get (module Utils.Search_result(Dance_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JString) @@ get (module Utils.Search_result(Dance_row))
     | Get -> variable (module Dance_id) @@ get (module Entry.JPublic(Dance))
     | Get_row -> variable (module Dance_id) @@ literal "row" @@ get (module Dance_row)
     | Get_view -> variable (module Dance_id) @@ literal "view" @@ get (module Dance_view)

--- a/src/common/endpoints/page.ml
+++ b/src/common/endpoints/page.ml
@@ -49,6 +49,7 @@ type (_, _, _) t =
   | Version : ((Context.t option -> Core.Version.t Entry.Id.t -> 'w), 'w, Void.t) t
   | Index : ('w, 'w, Void.t) t
   | Explore : ((string option -> 'w), 'w, Void.t) t
+  | Explore_new : ((string option -> 'w), 'w, Void.t) t
   | User_create : ('w, 'w, Void.t) t
   | User_prepare_reset_password : ('w, 'w, Void.t) t
   | User_password_reset : ((Username.t -> Core.User.Password_reset_token_clear.t -> 'w), 'w, Void.t) t
@@ -84,6 +85,7 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
     | Version_edit -> literal "version" @@ literal "edit" @@ variable (module Entry.Id.S(Core.Version)) @@ void ()
     | Index -> void ()
     | Explore -> literal "explore" @@ query_opt "q" (module JString) @@ void ()
+    | Explore_new -> literal "explore_new" @@ query_opt "q" (module JString) @@ void ()
     | User_create -> literal "user" @@ literal "create" @@ void ()
     | User_prepare_reset_password -> literal "user" @@ literal "prepare-reset-password" @@ void ()
     | User_password_reset -> literal "user" @@ literal "reset-password" @@ query "username" (module Username) @@ query "token" (module Core.User.Password_reset_token_clear) @@ void ()
@@ -151,6 +153,7 @@ let consume : type a w r. return: w -> (a, w, r) t -> a = fun ~return: value end
   | Version_add -> const value
   | Version_edit -> const value
   | Explore -> const value
+  | Explore_new -> const value
   | User_create -> value
   | User_prepare_reset_password -> value
   | User_password_reset -> const2 value

--- a/src/common/endpoints/person.ml
+++ b/src/common/endpoints/person.ml
@@ -8,7 +8,7 @@ type (_, _, _) t =
   | For_user_row : (User_id.t -> 'w, 'w, Person_row.t option) t (* FIXME: move to user endpoints *)
   | Create : (Person.t -> 'w, 'w, Person_id.t) t
   | Search : (Slice.t -> (Person.t, Filter.Person.t) Formula_entry.public -> 'w, 'w, Person_row.t search_result) t
-  | Search_new : (Slice.t -> NEString.t option -> 'w, 'w, Person_row.t search_result) t
+  | Search_new : (Slice.t -> string -> 'w, 'w, Person_row.t search_result) t
   | Get : (Person_id.t -> 'w, 'w, Person.entry) t (* FIXME: remove *)
   | Get_row : (Person_id.t -> 'w, 'w, Person_row.t) t
   | Get_view : (Person_id.t -> 'w, 'w, Person_view.t) t
@@ -22,7 +22,7 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
     | For_user_row -> literal "for-user" @@ variable (module User_id) @@ literal "row" @@ get (module JOption(Person_row))
     | Create -> body "person" (module Person) @@ post (module Person_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPublic(Person)(Filter.Person)) @@ get (module Utils.Search_result(Person_row))
-    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JOption(JNEString)) @@ get (module Utils.Search_result(Person_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JString) @@ get (module Utils.Search_result(Person_row))
     | Get -> variable (module Person_id) @@ get (module Entry.JPublic(Person))
     | Get_row -> variable (module Person_id) @@ literal "row" @@ get (module Person_row)
     | Get_view -> variable (module Person_id) @@ literal "view" @@ get (module Person_view)

--- a/src/common/endpoints/person.ml
+++ b/src/common/endpoints/person.ml
@@ -8,6 +8,7 @@ type (_, _, _) t =
   | For_user_row : (User_id.t -> 'w, 'w, Person_row.t option) t (* FIXME: move to user endpoints *)
   | Create : (Person.t -> 'w, 'w, Person_id.t) t
   | Search : (Slice.t -> (Person.t, Filter.Person.t) Formula_entry.public -> 'w, 'w, Person_row.t search_result) t
+  | Search_new : (Slice.t -> string -> 'w, 'w, Person_row.t search_result) t
   | Get : (Person_id.t -> 'w, 'w, Person.entry) t (* FIXME: remove *)
   | Get_row : (Person_id.t -> 'w, 'w, Person_row.t) t
   | Get_view : (Person_id.t -> 'w, 'w, Person_view.t) t
@@ -21,6 +22,7 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
     | For_user_row -> literal "for-user" @@ variable (module User_id) @@ literal "row" @@ get (module JOption(Person_row))
     | Create -> body "person" (module Person) @@ post (module Person_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPublic(Person)(Filter.Person)) @@ get (module Utils.Search_result(Person_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JString) @@ get (module Utils.Search_result(Person_row))
     | Get -> variable (module Person_id) @@ get (module Entry.JPublic(Person))
     | Get_row -> variable (module Person_id) @@ literal "row" @@ get (module Person_row)
     | Get_view -> variable (module Person_id) @@ literal "view" @@ get (module Person_view)

--- a/src/common/endpoints/person.ml
+++ b/src/common/endpoints/person.ml
@@ -8,7 +8,7 @@ type (_, _, _) t =
   | For_user_row : (User_id.t -> 'w, 'w, Person_row.t option) t (* FIXME: move to user endpoints *)
   | Create : (Person.t -> 'w, 'w, Person_id.t) t
   | Search : (Slice.t -> (Person.t, Filter.Person.t) Formula_entry.public -> 'w, 'w, Person_row.t search_result) t
-  | Search_new : (Slice.t -> string -> 'w, 'w, Person_row.t search_result) t
+  | Search_new : (Slice.t -> NEString.t option -> 'w, 'w, Person_row.t search_result) t
   | Get : (Person_id.t -> 'w, 'w, Person.entry) t (* FIXME: remove *)
   | Get_row : (Person_id.t -> 'w, 'w, Person_row.t) t
   | Get_view : (Person_id.t -> 'w, 'w, Person_view.t) t
@@ -22,7 +22,7 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
     | For_user_row -> literal "for-user" @@ variable (module User_id) @@ literal "row" @@ get (module JOption(Person_row))
     | Create -> body "person" (module Person) @@ post (module Person_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPublic(Person)(Filter.Person)) @@ get (module Utils.Search_result(Person_row))
-    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JString) @@ get (module Utils.Search_result(Person_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JOption(JNEString)) @@ get (module Utils.Search_result(Person_row))
     | Get -> variable (module Person_id) @@ get (module Entry.JPublic(Person))
     | Get_row -> variable (module Person_id) @@ literal "row" @@ get (module Person_row)
     | Get_view -> variable (module Person_id) @@ literal "view" @@ get (module Person_view)

--- a/src/common/endpoints/set.ml
+++ b/src/common/endpoints/set.ml
@@ -7,6 +7,7 @@ module Filter = Filter_builder.Core
 type (_, _, _) t =
   | Create : (Set.t -> Entry.Access.Private.t -> 'w, 'w, Set_id.t) t
   | Search : (Slice.t -> (Set.t, Filter.Set.t) Formula_entry.private_ -> 'w, 'w, Set_row.t search_result) t
+  | Search_new : (Slice.t -> string -> 'w, 'w, Set_row.t search_result) t
   | Get : (Set_id.t -> 'w, 'w, Set.entry) t
   | Get_row : (Set_id.t -> 'w, 'w, Set_row.t) t
   | Get_view : (Set_id.t -> 'w, 'w, Set_view.t) t
@@ -19,15 +20,13 @@ type (_, _, _) t =
 let route : type a w r. (a, w, r) t -> (a, w, r) route =
   let open Route in
   function
-    (* Actions without specific set *)
     | Create -> body "set" (module Set) @@ body "access" (module Entry.Access.Private) @@ post (module Set_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPrivate(Set)(Filter.Set)) @@ get (module Utils.Search_result(Set_row))
-    (* Actions on a specific set *)
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JString) @@ get (module Utils.Search_result(Set_row))
     | Get -> variable (module Set_id) @@ get (module Entry.JPrivate(Set))
     | Get_row -> variable (module Set_id) @@ literal "row" @@ get (module Set_row)
     | Get_view -> variable (module Set_id) @@ literal "view" @@ get (module Set_view)
     | Get_rows -> literal "rows" @@ body "ids" (module JList(Set_id)) @@ post (module JList(Set_row))
     | Update -> variable (module Set_id) @@ body "set" (module Set) @@ body "access" (module Entry.Access.Private) @@ put (module JUnit)
     | Delete -> variable (module Set_id) @@ delete (module JUnit)
-    (* Files related to a set *)
     | Build_pdf -> literal "build-pdf" @@ variable (module Set_id) @@ query "parameters" (module Set_parameters) @@ query "rendering-parameters" (module Rendering_parameters) @@ post (module Job.Registration_response(Job_id))

--- a/src/common/endpoints/source.ml
+++ b/src/common/endpoints/source.ml
@@ -7,6 +7,7 @@ module Filter = Filter_builder.Core
 type (_, _, _) t =
   | Create : (Source.t -> 'w, 'w, Source_id.t) t
   | Search : (Slice.t -> (Source.t, Filter.Source.t) Formula_entry.public -> 'w, 'w, Source_row.t search_result) t
+  | Search_new : (Slice.t -> NEString.t option -> 'w, 'w, Source_row.t search_result) t
   | Get : (Source_id.t -> 'w, 'w, Source.entry) t
   | Get_row : (Source_id.t -> 'w, 'w, Source_row.t) t
   | Get_view : (Source_id.t -> 'w, 'w, Source_view.t) t
@@ -20,6 +21,7 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
   function
     | Create -> body "source" (module Source) @@ post (module Source_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPublic(Source)(Filter.Source)) @@ get (module Utils.Search_result(Source_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JOption(JNEString)) @@ get (module Utils.Search_result(Source_row))
     | Get -> variable (module Source_id) @@ get (module Entry.JPublic(Source))
     | Get_row -> variable (module Source_id) @@ literal "row" @@ get (module Source_row)
     | Get_view -> variable (module Source_id) @@ literal "view" @@ get (module Source_view)

--- a/src/common/endpoints/source.ml
+++ b/src/common/endpoints/source.ml
@@ -7,7 +7,7 @@ module Filter = Filter_builder.Core
 type (_, _, _) t =
   | Create : (Source.t -> 'w, 'w, Source_id.t) t
   | Search : (Slice.t -> (Source.t, Filter.Source.t) Formula_entry.public -> 'w, 'w, Source_row.t search_result) t
-  | Search_new : (Slice.t -> NEString.t option -> 'w, 'w, Source_row.t search_result) t
+  | Search_new : (Slice.t -> string -> 'w, 'w, Source_row.t search_result) t
   | Get : (Source_id.t -> 'w, 'w, Source.entry) t
   | Get_row : (Source_id.t -> 'w, 'w, Source_row.t) t
   | Get_view : (Source_id.t -> 'w, 'w, Source_view.t) t
@@ -21,7 +21,7 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
   function
     | Create -> body "source" (module Source) @@ post (module Source_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPublic(Source)(Filter.Source)) @@ get (module Utils.Search_result(Source_row))
-    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JOption(JNEString)) @@ get (module Utils.Search_result(Source_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JString) @@ get (module Utils.Search_result(Source_row))
     | Get -> variable (module Source_id) @@ get (module Entry.JPublic(Source))
     | Get_row -> variable (module Source_id) @@ literal "row" @@ get (module Source_row)
     | Get_view -> variable (module Source_id) @@ literal "view" @@ get (module Source_view)

--- a/src/common/endpoints/tune.ml
+++ b/src/common/endpoints/tune.ml
@@ -7,7 +7,7 @@ module Filter = Filter_builder.Core
 type (_, _, _) t =
   | Create : (Tune.t -> 'w, 'w, Tune_id.t) t
   | Search : (Slice.t -> (Tune.t, Filter.Tune.t) Formula_entry.public -> 'w, 'w, Tune_row.t search_result) t
-  | Search_new : (Slice.t -> NEString.t option -> 'w, 'w, Tune_row.t search_result) t
+  | Search_new : (Slice.t -> string -> 'w, 'w, Tune_row.t search_result) t
   | Get : (Tune_id.t -> 'w, 'w, Tune.entry) t
   | Get_row : (Tune_id.t -> 'w, 'w, Tune_row.t) t
   | Get_view : (Tune_id.t -> 'w, 'w, Tune_view.t) t
@@ -20,7 +20,7 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
   function
     | Create -> body "tune" (module Tune) @@ post (module Tune_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPublic(Tune)(Filter.Tune)) @@ get (module Utils.Search_result(Tune_row))
-    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JOption(JNEString)) @@ get (module Utils.Search_result(Tune_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JString) @@ get (module Utils.Search_result(Tune_row))
     | Get -> variable (module Tune_id) @@ get (module Entry.JPublic(Tune))
     | Get_row -> variable (module Tune_id) @@ literal "row" @@ get (module Tune_row)
     | Get_view -> variable (module Tune_id) @@ literal "view" @@ get (module Tune_view)

--- a/src/common/endpoints/tune.ml
+++ b/src/common/endpoints/tune.ml
@@ -7,6 +7,7 @@ module Filter = Filter_builder.Core
 type (_, _, _) t =
   | Create : (Tune.t -> 'w, 'w, Tune_id.t) t
   | Search : (Slice.t -> (Tune.t, Filter.Tune.t) Formula_entry.public -> 'w, 'w, Tune_row.t search_result) t
+  | Search_new : (Slice.t -> NEString.t option -> 'w, 'w, Tune_row.t search_result) t
   | Get : (Tune_id.t -> 'w, 'w, Tune.entry) t
   | Get_row : (Tune_id.t -> 'w, 'w, Tune_row.t) t
   | Get_view : (Tune_id.t -> 'w, 'w, Tune_view.t) t
@@ -19,6 +20,7 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
   function
     | Create -> body "tune" (module Tune) @@ post (module Tune_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPublic(Tune)(Filter.Tune)) @@ get (module Utils.Search_result(Tune_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JOption(JNEString)) @@ get (module Utils.Search_result(Tune_row))
     | Get -> variable (module Tune_id) @@ get (module Entry.JPublic(Tune))
     | Get_row -> variable (module Tune_id) @@ literal "row" @@ get (module Tune_row)
     | Get_view -> variable (module Tune_id) @@ literal "view" @@ get (module Tune_view)

--- a/src/common/endpoints/version.ml
+++ b/src/common/endpoints/version.ml
@@ -37,7 +37,7 @@ end
 type (_, _, _) t =
   | Create : (Version.t -> 'w, 'w, Version_id.t) t
   | Search : (Slice.t -> (Version.t, Filter.Version.t) Formula_entry.public -> 'w, 'w, Version_row.t search_result) t
-  | Search_new : (Slice.t -> NEString.t option -> 'w, 'w, Version_row.t search_result) t
+  | Search_new : (Slice.t -> string -> 'w, 'w, Version_row.t search_result) t
   | Get : (Version_id.t -> 'w, 'w, Version.entry) t
   | Get_row : (Version_id.t -> 'w, 'w, Version_row.t) t
   | Get_view : (Version_id.t -> 'w, 'w, Version_view.t) t
@@ -73,7 +73,7 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
   function
     | Create -> body "version" (module Version) @@ post (module Version_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPublic(Version)(Filter.Version)) @@ get (module Utils.Search_result(Version_row))
-    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JOption(JNEString)) @@ get (module Utils.Search_result(Version_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JString) @@ get (module Utils.Search_result(Version_row))
     | Get -> variable (module Version_id) @@ get (module Entry.JPublic(Version_no_lilypond))
     | Get_row -> variable (module Version_id) @@ literal "row" @@ get (module Version_row)
     | Get_view -> variable (module Version_id) @@ literal "view" @@ get (module Version_view)

--- a/src/common/endpoints/version.ml
+++ b/src/common/endpoints/version.ml
@@ -37,6 +37,7 @@ end
 type (_, _, _) t =
   | Create : (Version.t -> 'w, 'w, Version_id.t) t
   | Search : (Slice.t -> (Version.t, Filter.Version.t) Formula_entry.public -> 'w, 'w, Version_row.t search_result) t
+  | Search_new : (Slice.t -> NEString.t option -> 'w, 'w, Version_row.t search_result) t
   | Get : (Version_id.t -> 'w, 'w, Version.entry) t
   | Get_row : (Version_id.t -> 'w, 'w, Version_row.t) t
   | Get_view : (Version_id.t -> 'w, 'w, Version_view.t) t
@@ -72,6 +73,7 @@ let route : type a w r. (a, w, r) t -> (a, w, r) route =
   function
     | Create -> body "version" (module Version) @@ post (module Version_id)
     | Search -> query "slice" (module Slice) @@ query "filter" (module Formula_entry.JPublic(Version)(Filter.Version)) @@ get (module Utils.Search_result(Version_row))
+    | Search_new -> literal "search" @@ query "slice" (module Slice) @@ query "filter" (module JOption(JNEString)) @@ get (module Utils.Search_result(Version_row))
     | Get -> variable (module Version_id) @@ get (module Entry.JPublic(Version_no_lilypond))
     | Get_row -> variable (module Version_id) @@ literal "row" @@ get (module Version_row)
     | Get_view -> variable (module Version_id) @@ literal "view" @@ get (module Version_view)

--- a/src/common/model_new.ml
+++ b/src/common/model_new.ml
@@ -318,7 +318,7 @@ module Set_row = struct
     name: string;
     kind: Kind_dance.t;
     conceptors: Person_name.t list; [@default []]
-    tunes: Tune_name.t list; [@default []]
+    tunes: Version_name.t list; [@default []]
     permission: Permission_builder.can_get_private;
   }
   [@@deriving yojson, fields]

--- a/src/common/permission_builder.ml
+++ b/src/common/permission_builder.ml
@@ -48,6 +48,7 @@ module type S = sig
   (** Whether the given user can get public elements. As the name suggests, they
       are public, so anyone, including anonymous users. *)
   val can_get_public : user -> 'value Entry.public -> can_get_public option
+  val can_get_public_new : user -> 'value -> can_get_public option
 
   (** Whether the given user can create public elements. This is any connected
       user. *)
@@ -88,6 +89,7 @@ module Make (User : Model_builder.Signature.User) : S = struct
   let is_connected user = user <> None
 
   let can_get_public _user _entry : can_get_public option = Some Everyone
+  let can_get_public_new _user _entry : can_get_public option = Some Everyone
 
   let can_create_public user : can_create_public option = if is_connected user then Some Connected else None
 

--- a/src/madge/serialisation.ml
+++ b/src/madge/serialisation.ml
@@ -42,6 +42,10 @@ module JString : JSONABLE with type t = string = struct
   type t = string [@@deriving yojson]
 end
 
+module JNEString : JSONABLE with type t = NEString.t = struct
+  type t = NEString.t [@@deriving yojson]
+end
+
 module JUri : JSONABLE with type t = Uri.t = struct
   type t = Uri.t
   let to_yojson = JString.to_yojson % Uri.to_string

--- a/src/nes/nesSlice.ml
+++ b/src/nes/nesSlice.ml
@@ -7,6 +7,7 @@ type t = {
 let start s = s.start
 let end_incl s = s.end_incl
 let end_excl s = s.end_incl + 1
+let length s = s.end_incl - s.start + 1
 
 let make
     ?(start = 0)

--- a/src/nes/nesSlice.mli
+++ b/src/nes/nesSlice.mli
@@ -26,6 +26,7 @@ val everything : t
 val start : t -> int
 val end_incl : t -> int
 val end_excl : t -> int
+val length : t -> int
 (** Getters from a slice. [end_excl] may return [min_int] to represent an
     inclusive bound up to [max_int]. *)
 

--- a/src/server/controller/any.ml
+++ b/src/server/controller/any.ml
@@ -157,13 +157,21 @@ let search_new env slice filter =
   let%lwt dances_result = Dance.search'_new env filter in
   let%lwt sources_result = Source.search'_new env filter in
   let%lwt tunes_result = Tune.search'_new env filter in
-  let total = persons_result.total + dances_result.total + sources_result.total + tunes_result.total in
+  let%lwt versions_result = Version.search'_new env filter in
+  let total =
+    persons_result.total +
+      dances_result.total +
+      sources_result.total +
+      tunes_result.total +
+      versions_result.total
+  in
   let items =
     list_merge_sorted_l_on (fun (_, s1) (_, s2) -> Float.compare s2 s1) [
       List.map (Pair.map_fst Any_row.person) persons_result.items;
       List.map (Pair.map_fst Any_row.dance) dances_result.items;
       List.map (Pair.map_fst Any_row.source) sources_result.items;
       List.map (Pair.map_fst Any_row.tune) tunes_result.items;
+      List.map (Pair.map_fst Any_row.version) versions_result.items;
     ]
   in
   let items = List.map fst @@ Slice.list ~strict: false slice items in

--- a/src/server/controller/any.ml
+++ b/src/server/controller/any.ml
@@ -156,12 +156,14 @@ let search_new env slice filter =
   let%lwt persons_result = Person.search'_new env filter in
   let%lwt dances_result = Dance.search'_new env filter in
   let%lwt sources_result = Source.search'_new env filter in
-  let total = persons_result.total + dances_result.total + sources_result.total in
+  let%lwt tunes_result = Tune.search'_new env filter in
+  let total = persons_result.total + dances_result.total + sources_result.total + tunes_result.total in
   let items =
     list_merge_sorted_l_on (fun (_, s1) (_, s2) -> Float.compare s2 s1) [
       List.map (Pair.map_fst Any_row.person) persons_result.items;
       List.map (Pair.map_fst Any_row.dance) dances_result.items;
       List.map (Pair.map_fst Any_row.source) sources_result.items;
+      List.map (Pair.map_fst Any_row.tune) tunes_result.items;
     ]
   in
   let items = List.map fst @@ Slice.list ~strict: false slice items in

--- a/src/server/controller/any.ml
+++ b/src/server/controller/any.ml
@@ -60,9 +60,9 @@ let lwt_stream_merge_sorted cmp xs ys =
   match x, y with
   | Some x, Some y when cmp x y <= 0 -> Lwt_stream.junk xs;%lwt lwt_some x
   | Some _, Some y -> Lwt_stream.junk ys;%lwt lwt_some y
-  | Some x, _ -> Lwt_stream.junk xs;%lwt lwt_some x
-  | _, Some y -> Lwt_stream.junk ys;%lwt lwt_some y
-  | _ -> lwt_none
+  | Some x, None -> Lwt_stream.junk xs;%lwt lwt_some x
+  | None, Some y -> Lwt_stream.junk ys;%lwt lwt_some y
+  | None, None -> lwt_none
 
 (** Given a list of streams sorted according to the comparison function, produce
     one sorted stream of all the values. In case of equality, a stream appearing
@@ -70,6 +70,26 @@ let lwt_stream_merge_sorted cmp xs ys =
 let lwt_stream_merge_sorted_l cmp = function
   | [] -> Lwt_stream.of_list []
   | s :: ss -> List.fold_left (lwt_stream_merge_sorted cmp) s ss
+
+(** Given two lists sorted according to the comparison function,
+    produce one sorted list of all the values. In case of equality,
+    the left list wins. *)
+let list_merge_sorted_on cmp xs ys =
+  let rec aux = function
+    | [], [] -> []
+    | xs, [] -> xs
+    | [], ys -> ys
+    | x :: xs, ((y :: _) as ys) when cmp x y <= 0 -> x :: aux (xs, ys)
+    | xs, y :: ys -> y :: aux (xs, ys)
+  in
+  aux (xs, ys)
+
+(** Given a list of lists sorted according to the comparison function,
+    produce one sorted list of all the values. In case of equality, a
+    list appearing earlier wins. *)
+let list_merge_sorted_l_on cmp = function
+  | [] -> []
+  | l :: ls -> List.fold_left (list_merge_sorted_on cmp) l ls
 
 (** Slice a stream. Raises {!Invalid_argument} if [start] is strictly bigger
     than the length of the stream. If [strict] is set (the default), also raises
@@ -132,9 +152,21 @@ let search_context env filter element =
   | None -> Madge_server.shortcut_not_found "Could not find the given element in the search results."
   | Some List.{total; previous; index; next; _} -> lwt {Model_new.index; total; previous_item = previous; next_item = next}
 
+let search_new env slice filter =
+  let%lwt persons_result = Person.search'_new env filter in
+  let total = persons_result.total in
+  let items =
+    list_merge_sorted_l_on (fun (_, s1) (_, s2) -> Float.compare s2 s1) [
+      List.map (Pair.map_fst Any_row.person) persons_result.items;
+    ]
+  in
+  let items = List.map fst @@ Slice.list ~strict: false slice items in
+  lwt {Model_new.total; items}
+
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Any.t -> a = fun env endpoint ->
   match endpoint with
   | Get -> get env
   | Get_rows -> get_rows env
   | Search -> search env
   | Search_context -> search_context env
+  | Search_new -> search_new env

--- a/src/server/controller/any.ml
+++ b/src/server/controller/any.ml
@@ -158,12 +158,14 @@ let search_new env slice filter =
   let%lwt sources_result = Source.search'_new env filter in
   let%lwt tunes_result = Tune.search'_new env filter in
   let%lwt versions_result = Version.search'_new env filter in
+  let%lwt sets_result = Set.search'_new env filter in
   let total =
     persons_result.total +
       dances_result.total +
       sources_result.total +
       tunes_result.total +
-      versions_result.total
+      versions_result.total +
+      sets_result.total
   in
   let items =
     list_merge_sorted_l_on (fun (_, s1) (_, s2) -> Float.compare s2 s1) [
@@ -172,6 +174,7 @@ let search_new env slice filter =
       List.map (Pair.map_fst Any_row.source) sources_result.items;
       List.map (Pair.map_fst Any_row.tune) tunes_result.items;
       List.map (Pair.map_fst Any_row.version) versions_result.items;
+      List.map (Pair.map_fst Any_row.set) sets_result.items;
     ]
   in
   let items = List.map fst @@ Slice.list ~strict: false slice items in

--- a/src/server/controller/any.ml
+++ b/src/server/controller/any.ml
@@ -159,13 +159,15 @@ let search_new env slice filter =
   let%lwt tunes_result = Tune.search'_new env filter in
   let%lwt versions_result = Version.search'_new env filter in
   let%lwt sets_result = Set.search'_new env filter in
+  let%lwt books_result = Book.search'_new env filter in
   let total =
     persons_result.total +
       dances_result.total +
       sources_result.total +
       tunes_result.total +
       versions_result.total +
-      sets_result.total
+      sets_result.total +
+      books_result.total
   in
   let items =
     list_merge_sorted_l_on (fun (_, s1) (_, s2) -> Float.compare s2 s1) [
@@ -175,6 +177,7 @@ let search_new env slice filter =
       List.map (Pair.map_fst Any_row.tune) tunes_result.items;
       List.map (Pair.map_fst Any_row.version) versions_result.items;
       List.map (Pair.map_fst Any_row.set) sets_result.items;
+      List.map (Pair.map_fst Any_row.book) books_result.items;
     ]
   in
   let items = List.map fst @@ Slice.list ~strict: false slice items in

--- a/src/server/controller/any.ml
+++ b/src/server/controller/any.ml
@@ -154,10 +154,12 @@ let search_context env filter element =
 
 let search_new env slice filter =
   let%lwt persons_result = Person.search'_new env filter in
-  let total = persons_result.total in
+  let%lwt sources_result = Source.search'_new env filter in
+  let total = persons_result.total + sources_result.total in
   let items =
     list_merge_sorted_l_on (fun (_, s1) (_, s2) -> Float.compare s2 s1) [
       List.map (Pair.map_fst Any_row.person) persons_result.items;
+      List.map (Pair.map_fst Any_row.source) sources_result.items;
     ]
   in
   let items = List.map fst @@ Slice.list ~strict: false slice items in

--- a/src/server/controller/any.ml
+++ b/src/server/controller/any.ml
@@ -154,11 +154,13 @@ let search_context env filter element =
 
 let search_new env slice filter =
   let%lwt persons_result = Person.search'_new env filter in
+  let%lwt dances_result = Dance.search'_new env filter in
   let%lwt sources_result = Source.search'_new env filter in
-  let total = persons_result.total + sources_result.total in
+  let total = persons_result.total + dances_result.total + sources_result.total in
   let items =
     list_merge_sorted_l_on (fun (_, s1) (_, s2) -> Float.compare s2 s1) [
       List.map (Pair.map_fst Any_row.person) persons_result.items;
+      List.map (Pair.map_fst Any_row.dance) dances_result.items;
       List.map (Pair.map_fst Any_row.source) sources_result.items;
     ]
   in

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -121,6 +121,16 @@ let search env slice filter =
   let%lwt items = Lwt_list.map_s (to_row env) result.items in
   lwt {result with items}
 
+let search'_new env filter =
+  let user = Environment.user env in
+  let%lwt items = Database.Book.search ~user: (Option.map Entry.id user) filter in
+  lwt {total = List.length items; items}
+
+let search_new env slice filter =
+  let%lwt {total; items} = search'_new env filter in
+  let items = List.map fst @@ Slice.list slice items in
+  lwt {total; items}
+
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Book.t -> a = fun env endpoint ->
   match endpoint with
   | Get -> get env
@@ -128,6 +138,7 @@ let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Book.t -> a 
   | Get_view -> get_view env
   | Get_rows -> get_rows env
   | Search -> search env
+  | Search_new -> search_new env
   | Create -> create env
   | Update -> update env
   | Delete -> delete env

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -128,7 +128,7 @@ let search'_new env filter =
 
 let search_new env slice filter =
   let%lwt {total; items} = search'_new env filter in
-  let items = List.map fst @@ Slice.list slice items in
+  let items = List.map fst @@ Slice.list ~strict: false slice items in
   lwt {total; items}
 
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Book.t -> a = fun env endpoint ->

--- a/src/server/controller/dance.ml
+++ b/src/server/controller/dance.ml
@@ -112,7 +112,7 @@ let search'_new env filter =
 
 let search_new env slice filter =
   let%lwt {total; items} = search'_new env filter in
-  let items = List.map fst @@ Slice.list slice items in
+  let items = List.map fst @@ Slice.list ~strict: false slice items in
   lwt {total; items}
 
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Dance.t -> a = fun env endpoint ->

--- a/src/server/controller/dance.ml
+++ b/src/server/controller/dance.ml
@@ -105,12 +105,23 @@ let search env slice filter =
   let%lwt items = Lwt_list.map_s to_row result.items in
   lwt {result with items}
 
+let search'_new env filter =
+  let%lwt items = Database.Dance.search filter in
+  let%lwt items = Lwt_list.filter_s (Permission.can_get_public_new env % fst) items in
+  lwt {total = List.length items; items}
+
+let search_new env slice filter =
+  let%lwt {total; items} = search'_new env filter in
+  let items = List.map fst @@ Slice.list slice items in
+  lwt {total; items}
+
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Dance.t -> a = fun env endpoint ->
   match endpoint with
   | Get -> get env
   | Get_row -> get_row env
   | Get_view -> get_view env
   | Search -> search env
+  | Search_new -> search_new env
   | Create -> create env
   | Update -> update env
   | Delete -> delete env

--- a/src/server/controller/person.ml
+++ b/src/server/controller/person.ml
@@ -110,10 +110,15 @@ let search env slice filter =
   let%lwt result = search env slice filter in
   lwt {result with items = List.map to_row result.items}
 
+let search'_new env filter =
+  let%lwt items = Database.Person.search filter in
+  let%lwt items = Lwt_list.filter_s (Permission.can_get_public_new env % fst) items in
+  lwt {total = List.length items; items}
+
 let search_new env slice filter =
-  let%lwt all = Database.Person.search filter in
-  let%lwt all = Lwt_list.filter_s (Permission.can_get_public_new env) all in
-  lwt {total = List.length all; items = Slice.list slice all}
+  let%lwt {total; items} = search'_new env filter in
+  let items = List.map fst @@ Slice.list slice items in
+  lwt {total; items}
 
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Person.t -> a = fun env endpoint ->
   match endpoint with

--- a/src/server/controller/person.ml
+++ b/src/server/controller/person.ml
@@ -110,12 +110,18 @@ let search env slice filter =
   let%lwt result = search env slice filter in
   lwt {result with items = List.map to_row result.items}
 
+let search_new env slice filter =
+  let%lwt all = Database.Person.search filter in
+  let%lwt all = Lwt_list.filter_s (Permission.can_get_public_new env) all in
+  lwt {total = List.length all; items = Slice.list slice all}
+
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Person.t -> a = fun env endpoint ->
   match endpoint with
   | Get -> get env
   | Get_row -> get_row env
   | Get_view -> get_view env
   | Search -> search env
+  | Search_new -> search_new env
   | For_user_row -> for_user_row env
   | Create -> create env
   | Update -> update env

--- a/src/server/controller/person.ml
+++ b/src/server/controller/person.ml
@@ -117,7 +117,7 @@ let search'_new env filter =
 
 let search_new env slice filter =
   let%lwt {total; items} = search'_new env filter in
-  let items = List.map fst @@ Slice.list slice items in
+  let items = List.map fst @@ Slice.list ~strict: false slice items in
   lwt {total; items}
 
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Person.t -> a = fun env endpoint ->

--- a/src/server/controller/set.ml
+++ b/src/server/controller/set.ml
@@ -148,7 +148,6 @@ let search env slice filter =
 let search'_new env filter =
   let user = Environment.user env in
   let%lwt items = Database.Set.search ~user: (Option.map Entry.id user) filter in
-  let%lwt items = Lwt_list.filter_s (Permission.can_get_public_new env % fst) items in
   lwt {total = List.length items; items}
 
 let search_new env slice filter =
@@ -163,6 +162,7 @@ let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Set.t -> a =
   | Get_view -> get_view env
   | Get_rows -> get_rows env
   | Search -> search env
+  | Search_new -> search_new env
   | Create -> create env
   | Update -> update env
   | Delete -> delete env

--- a/src/server/controller/set.ml
+++ b/src/server/controller/set.ml
@@ -7,10 +7,10 @@ open Model_new
    should be pushed into individual controllers in a first place, and
    then even all the way to the respective databases. *)
 
-let version_to_name (version : Model.Version.entry) : Tune_name.t Lwt.t =
+let version_to_name (version : Model.Version.entry) : Version_name.t Lwt.t =
   let%lwt tune = Model.Version.tune' version in
   lwt {
-    Tune_name.id = Entry.id tune;
+    Version_name.id = Entry.id version;
     name = NEString.to_string @@ NEList.hd @@ Model.Tune.names' tune;
   }
 
@@ -144,6 +144,17 @@ let search env slice filter =
   let%lwt result = search env slice filter in
   let%lwt items = Lwt_list.map_s (to_row env) result.items in
   lwt {result with items}
+
+let search'_new env filter =
+  let user = Environment.user env in
+  let%lwt items = Database.Set.search ~user: (Option.map Entry.id user) filter in
+  let%lwt items = Lwt_list.filter_s (Permission.can_get_public_new env % fst) items in
+  lwt {total = List.length items; items}
+
+let search_new env slice filter =
+  let%lwt {total; items} = search'_new env filter in
+  let items = List.map fst @@ Slice.list slice items in
+  lwt {total; items}
 
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Set.t -> a = fun env endpoint ->
   match endpoint with

--- a/src/server/controller/set.ml
+++ b/src/server/controller/set.ml
@@ -152,7 +152,7 @@ let search'_new env filter =
 
 let search_new env slice filter =
   let%lwt {total; items} = search'_new env filter in
-  let items = List.map fst @@ Slice.list slice items in
+  let items = List.map fst @@ Slice.list ~strict: false slice items in
   lwt {total; items}
 
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Set.t -> a = fun env endpoint ->

--- a/src/server/controller/source.ml
+++ b/src/server/controller/source.ml
@@ -128,7 +128,7 @@ let search'_new env filter =
 
 let search_new env slice filter =
   let%lwt {total; items} = search'_new env filter in
-  let items = List.map fst @@ Slice.list slice items in
+  let items = List.map fst @@ Slice.list ~strict: false slice items in
   lwt {total; items}
 
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Source.t -> a = fun env endpoint ->

--- a/src/server/controller/source.ml
+++ b/src/server/controller/source.ml
@@ -121,12 +121,23 @@ let get_cover env id =
   let fname = Option.value fname ~default: (Filename.concat (Config.get ()).share "no-cover.webp") in
   Madge_server.respond_file ~fname
 
+let search'_new env filter =
+  let%lwt items = Database.Source.search filter in
+  let%lwt items = Lwt_list.filter_s (Permission.can_get_public_new env % fst) items in
+  lwt {total = List.length items; items}
+
+let search_new env slice filter =
+  let%lwt {total; items} = search'_new env filter in
+  let items = List.map fst @@ Slice.list slice items in
+  lwt {total; items}
+
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Source.t -> a = fun env endpoint ->
   match endpoint with
   | Get -> get env
   | Get_row -> get_row env
   | Get_view -> get_view env
   | Search -> search env
+  | Search_new -> search_new env
   | Create -> create env
   | Update -> update env
   | Delete -> delete env

--- a/src/server/controller/tune.ml
+++ b/src/server/controller/tune.ml
@@ -145,7 +145,7 @@ let search'_new env filter =
 
 let search_new env slice filter =
   let%lwt {total; items} = search'_new env filter in
-  let items = List.map fst @@ Slice.list slice items in
+  let items = List.map fst @@ Slice.list ~strict: false slice items in
   lwt {total; items}
 
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Tune.t -> a = fun env endpoint ->

--- a/src/server/controller/tune.ml
+++ b/src/server/controller/tune.ml
@@ -138,12 +138,23 @@ let search env slice filter =
   let%lwt items = Lwt_list.map_s to_row result.items in
   lwt {result with items}
 
+let search'_new env filter =
+  let%lwt items = Database.Tune.search filter in
+  let%lwt items = Lwt_list.filter_s (Permission.can_get_public_new env % fst) items in
+  lwt {total = List.length items; items}
+
+let search_new env slice filter =
+  let%lwt {total; items} = search'_new env filter in
+  let items = List.map fst @@ Slice.list slice items in
+  lwt {total; items}
+
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Tune.t -> a = fun env endpoint ->
   match endpoint with
   | Get -> get env
   | Get_row -> get_row env
   | Get_view -> get_view env
   | Search -> search env
+  | Search_new -> search_new env
   | Create -> create env
   | Update -> update env
   | Delete -> delete env

--- a/src/server/controller/version.ml
+++ b/src/server/controller/version.ml
@@ -288,7 +288,7 @@ let search'_new env filter =
 
 let search_new env slice filter =
   let%lwt {total; items} = search'_new env filter in
-  let items = List.map fst @@ Slice.list slice items in
+  let items = List.map fst @@ Slice.list ~strict: false slice items in
   lwt {total; items}
 
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Version.t -> a = fun env endpoint ->

--- a/src/server/controller/version.ml
+++ b/src/server/controller/version.ml
@@ -281,6 +281,16 @@ let search env slice filter =
   let%lwt items = Lwt_list.map_s to_row result.items in
   lwt {result with items}
 
+let search'_new env filter =
+  let%lwt items = Database.Version.search filter in
+  let%lwt items = Lwt_list.filter_s (Permission.can_get_public_new env % fst) items in
+  lwt {total = List.length items; items}
+
+let search_new env slice filter =
+  let%lwt {total; items} = search'_new env filter in
+  let items = List.map fst @@ Slice.list slice items in
+  lwt {total; items}
+
 let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Version.t -> a = fun env endpoint ->
   match endpoint with
   | Get -> get env
@@ -289,6 +299,7 @@ let dispatch : type a r. Environment.t -> (a, r Lwt.t, r) Endpoints.Version.t ->
   | Get_view_for_tune -> get_view_for_tune env
   | Content -> content env
   | Search -> search env
+  | Search_new -> search_new env
   | Create -> create env
   | Update -> update env
   | Delete -> delete env

--- a/src/server/database/book.ml
+++ b/src/server/database/book.ml
@@ -1,12 +1,37 @@
 open Nes
 open Dancelor_common
+open Model_new
 
 module Book_sql = Book_sql.Sqlgg(Sqlgg_postgresql)
 
 type t = Model_builder.Core.Book.t
 type entry = Model_builder.Core.Book.entry
 
-let row_to_book
+let sql_to_row ~id ~name ~date ~authors ~permission ~(k : Book_row.t -> 'w) : 'w =
+  k {
+    id = Entry.Id.of_string_exn id;
+    name;
+    date = Option.map (Option.get % PartialDate.from_string) date;
+    authors;
+    permission = (match permission with `Everyone -> Everyone | `Owner -> Owner | `Viewer -> Viewer | `Omniscient_administrator -> Omniscient_administrator);
+  }
+
+let search ~user ?(threshold = 0.3) needle : (Book_row.t * float) list Lwt.t =
+  Connection.with_ @@ fun db ->
+  let%lwt authors = Utils.fold_to_hashtbl Book_sql.Fold.get_all_authors_new db (fun k ~book_id -> Person.sql_to_name ~k: (k book_id)) in
+  Book_sql.List.search
+    db
+    ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "")
+    ~needle
+    ~threshold
+    (fun ~score ~id ->
+      sql_to_row
+        ~id
+        ~authors: (Hashtbl.find_all authors id)
+        ~k: (Pair.snoc score)
+    )
+
+let sql_to_book
     ~id
     ~name
     ~date
@@ -49,7 +74,7 @@ let row_to_book
         ()
     )
 
-let book_to_row ~create_or_update db id book access =
+let book_to_sql ~create_or_update db id book access =
   let (visibility, viewers) =
     match Entry.Access.Private.visibility access with
     | Owners_only -> (0L, [])
@@ -161,7 +186,7 @@ let book_to_row ~create_or_update db id book access =
     )
     (NEList.to_list @@ Entry.Access.Private.owners access)
 
-let row_to_content_version ~k = fun
+let sql_to_content_version ~k = fun
     ~version_id
     ~version_parameter_transposition_semitones
     ~version_parameter_first_bar
@@ -185,7 +210,7 @@ let row_to_content_version ~k = fun
         ()
     )
 
-let row_to_content_item ~versions_and_params ~k = fun
+let sql_to_content_item ~versions_and_params ~k = fun
     ~page_type
     ~part_title
     ~dance_id
@@ -237,9 +262,9 @@ let get id : Model_builder.Core.Book.entry option Lwt.t =
   let%lwt owners = Book_sql.List.get_owners db ~book_id: id (fun ~owner_id -> Entry.Id.of_string_exn owner_id) in
   let%lwt viewers = Book_sql.List.get_viewers db ~book_id: id (fun ~viewer_id -> Entry.Id.of_string_exn viewer_id) in
   let content_versions = Hashtbl.create 8 in
-  Book_sql.Fold.get_content_versions db ~book_id: id (fun ~content_index -> row_to_content_version ~k: (fun v () -> Hashtbl.add content_versions content_index v)) ();%lwt
-  let%lwt content = Book_sql.List.get_content db ~book_id: id (fun ~index -> row_to_content_item ~versions_and_params: (List.rev @@ Hashtbl.find_all content_versions index) ~k: Fun.id) in
-  Book_sql.Single.get db ~id (row_to_book ~id ~authors ~sources ~viewers ~owners ~content)
+  Book_sql.Fold.get_content_versions db ~book_id: id (fun ~content_index -> sql_to_content_version ~k: (fun v () -> Hashtbl.add content_versions content_index v)) ();%lwt
+  let%lwt content = Book_sql.List.get_content db ~book_id: id (fun ~index -> sql_to_content_item ~versions_and_params: (List.rev @@ Hashtbl.find_all content_versions index) ~k: Fun.id) in
+  Book_sql.Single.get db ~id (sql_to_book ~id ~authors ~sources ~viewers ~owners ~content)
 
 let get_all () =
   Connection.with_ @@ fun db ->
@@ -253,10 +278,10 @@ let get_all () =
   Book_sql.Fold.get_all_sources db (fun ~book_id ~source_id () -> Hashtbl.add sources book_id @@ Entry.Id.of_string_exn source_id) ();%lwt
   Book_sql.Fold.get_all_owners db (fun ~book_id ~owner_id () -> Hashtbl.add owners book_id @@ Entry.Id.of_string_exn owner_id) ();%lwt
   Book_sql.Fold.get_all_viewers db (fun ~book_id ~viewer_id () -> Hashtbl.add viewers book_id @@ Entry.Id.of_string_exn viewer_id) ();%lwt
-  Book_sql.Fold.get_all_content_versions db (fun ~book_id ~content_index -> row_to_content_version ~k: (fun v () -> Hashtbl.add content_versions (book_id, content_index) v)) ();%lwt
-  Book_sql.Fold.get_all_content db (fun ~book_id ~index -> row_to_content_item ~versions_and_params: (List.rev @@ Hashtbl.find_all content_versions (book_id, index)) ~k: (fun v () -> Hashtbl.add content book_id v)) ();%lwt
+  Book_sql.Fold.get_all_content_versions db (fun ~book_id ~content_index -> sql_to_content_version ~k: (fun v () -> Hashtbl.add content_versions (book_id, content_index) v)) ();%lwt
+  Book_sql.Fold.get_all_content db (fun ~book_id ~index -> sql_to_content_item ~versions_and_params: (List.rev @@ Hashtbl.find_all content_versions (book_id, index)) ~k: (fun v () -> Hashtbl.add content book_id v)) ();%lwt
   Book_sql.List.get_all db (fun ~id ->
-    row_to_book
+    sql_to_book
       ~id
       ~authors: (List.rev @@ Hashtbl.find_all authors id)
       ~sources: (List.rev @@ Hashtbl.find_all sources id)
@@ -268,12 +293,12 @@ let get_all () =
 let create book access =
   Connection.with_ @@ fun db ->
   let%lwt id = Globally_unique_id.make db Book in
-  book_to_row ~create_or_update: Book_sql.create db id book access;%lwt
+  book_to_sql ~create_or_update: Book_sql.create db id book access;%lwt
   lwt id
 
 let update id book access =
   Connection.with_ @@ fun db ->
-  book_to_row ~create_or_update: (fun db ~id -> Book_sql.update db ~id) db id book access
+  book_to_sql ~create_or_update: (fun db ~id -> Book_sql.update db ~id) db id book access
 
 let delete id =
   Connection.with_ @@ fun db ->

--- a/src/server/database/book.mli
+++ b/src/server/database/book.mli
@@ -1,15 +1,18 @@
 open Dancelor_common
+open Model_new
 
 type t = Model_builder.Core.Book.t
 type entry = Model_builder.Core.Book.entry
 
-val get : t Entry.id -> entry option Lwt.t
+val get : Book_id.t -> entry option Lwt.t
 
 (* FIXME: we should really rather provide a fold function, or directly an Lwt_stream or something *)
 val get_all : unit -> entry list Lwt.t
 
-val create : t -> Entry.Access.Private.t -> t Entry.id Lwt.t
+val create : t -> Entry.Access.Private.t -> Book_id.t Lwt.t
 
-val update : t Entry.id -> t -> Entry.Access.Private.t -> unit Lwt.t
+val update : Book_id.t -> t -> Entry.Access.Private.t -> unit Lwt.t
 
-val delete : t Entry.id -> unit Lwt.t
+val delete : Book_id.t -> unit Lwt.t
+
+val search : user: User_id.t option -> ?threshold: float -> string -> (Book_row.t * float) list Lwt.t

--- a/src/server/database/book.sql
+++ b/src/server/database/book.sql
@@ -299,19 +299,12 @@ INSERT INTO "book_content_versions" (
 );
 
 -- @search
-SELECT
-    "search"."score",
-    "book"."id",
-    "name",
-    "date",
-    "permission"
-FROM (
+SELECT * FROM (
     SELECT
+        CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END AS "score",
         "book"."id",
-        CASE
-            WHEN @needle = '' THEN 1.0
-            ELSE word_similarity(@needle, "name")
-        END AS "score",
+        "name",
+        "date",
         CASE
             WHEN "book"."visibility" = 1 THEN 'Everyone'
             WHEN "book_owners"."owner_id" IS NOT NULL THEN 'Owner'
@@ -323,12 +316,10 @@ FROM (
     LEFT JOIN "book_owners" ON "book_owners"."book_id" = "book"."id" AND "book_owners"."owner_id" = @user_id
     LEFT JOIN "book_viewers" ON "book_viewers"."book_id" = "book"."id" AND "book_viewers"."viewer_id" = @user_id
     LEFT JOIN "user" ON "user"."id" = @user_id
-) AS "search"
-JOIN "book" ON "book"."id" = "search"."id"
-WHERE "search"."score" >= @threshold
-  AND "search"."permission" IS NOT NULL
+    WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
+) AS "book+"
+WHERE "book+"."permission" IS NOT NULL
 ORDER BY "score" DESC, "name" ASC;
-
 
 -- @get_all_authors_new
 SELECT

--- a/src/server/database/book.sql
+++ b/src/server/database/book.sql
@@ -309,23 +309,26 @@ FROM (
     SELECT
         "book"."id",
         CASE
-	    WHEN @needle = '' THEN 1.0
+            WHEN @needle = '' THEN 1.0
             ELSE word_similarity(@needle, "name")
         END AS "score",
-	CASE
-	    WHEN "book"."visibility" = 1 THEN 'Everyone'
-	    WHEN EXISTS (SELECT 1 FROM "book_owners" WHERE "book_owners"."book_id" = "book"."id" AND "book_owners"."owner_id" = @user_id) THEN 'Owner'
-	    WHEN "book"."visibility" = 2 AND EXISTS (SELECT 1 FROM "book_viewers" WHERE "book_viewers"."book_id" = "book"."id" AND "book_viewers"."viewer_id" = @user_id) THEN 'Viewer'
-	    WHEN "user"."role" = 2 AND "user"."omniscience" THEN 'Omniscient_administrator'
-	    ELSE NULL
-	END AS "permission"
+        CASE
+            WHEN "book"."visibility" = 1 THEN 'Everyone'
+            WHEN "book_owners"."owner_id" IS NOT NULL THEN 'Owner'
+            WHEN "book"."visibility" = 2 AND "book_viewers"."viewer_id" IS NOT NULL THEN 'Viewer'
+            WHEN "user"."role" = 2 AND "user"."omniscience" THEN 'Omniscient_administrator'
+            ELSE NULL
+        END AS "permission"
     FROM "book"
+    LEFT JOIN "book_owners" ON "book_owners"."book_id" = "book"."id" AND "book_owners"."owner_id" = @user_id
+    LEFT JOIN "book_viewers" ON "book_viewers"."book_id" = "book"."id" AND "book_viewers"."viewer_id" = @user_id
     LEFT JOIN "user" ON "user"."id" = @user_id
 ) AS "search"
 JOIN "book" ON "book"."id" = "search"."id"
 WHERE "search"."score" >= @threshold
   AND "search"."permission" IS NOT NULL
 ORDER BY "score" DESC, "name" ASC;
+
 
 -- @get_all_authors_new
 SELECT

--- a/src/server/database/book.sql
+++ b/src/server/database/book.sql
@@ -297,3 +297,40 @@ INSERT INTO "book_content_versions" (
     @version_parameter_display_name,
     @version_parameter_display_composer
 );
+
+-- @search
+SELECT
+    "search"."score",
+    "book"."id",
+    "name",
+    "date",
+    "permission"
+FROM (
+    SELECT
+        "book"."id",
+        CASE
+	    WHEN @needle = '' THEN 1.0
+            ELSE word_similarity(@needle, "name")
+        END AS "score",
+	CASE
+	    WHEN "book"."visibility" = 1 THEN 'Everyone'
+	    WHEN EXISTS (SELECT 1 FROM "book_owners" WHERE "book_owners"."book_id" = "book"."id" AND "book_owners"."owner_id" = @user_id) THEN 'Owner'
+	    WHEN "book"."visibility" = 2 AND EXISTS (SELECT 1 FROM "book_viewers" WHERE "book_viewers"."book_id" = "book"."id" AND "book_viewers"."viewer_id" = @user_id) THEN 'Viewer'
+	    WHEN "user"."role" = 2 AND "user"."omniscience" THEN 'Omniscient_administrator'
+	    ELSE NULL
+	END AS "permission"
+    FROM "book"
+    LEFT JOIN "user" ON "user"."id" = @user_id
+) AS "search"
+JOIN "book" ON "book"."id" = "search"."id"
+WHERE "search"."score" >= @threshold
+  AND "search"."permission" IS NOT NULL
+ORDER BY "score" DESC, "name" ASC;
+
+-- @get_all_authors_new
+SELECT
+    "book_id",
+    "person"."id",
+    "person"."name"
+FROM "book_authors"
+JOIN "person" ON "book_authors"."author_id" = "person"."id";

--- a/src/server/database/dance.ml
+++ b/src/server/database/dance.ml
@@ -37,7 +37,7 @@ let sql_to_row ~id ~name ~kind ~devisers ~disambiguation ~(k : Dance_row.t -> 'w
 
 let search ?(threshold = 0.3) needle : (Dance_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
-  let%lwt devisers = Utils.fold_to_hashtbl Dance_sql.Fold.get_all_devisers_new db (fun k ~dance_id -> Utils.sql_to_person_name ~k: (k dance_id)) in
+  let%lwt devisers = Utils.fold_to_hashtbl Dance_sql.Fold.get_all_devisers_new db (fun k ~dance_id -> Person.sql_to_name ~k: (k dance_id)) in
   Dance_sql.List.search
     db
     ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))

--- a/src/server/database/dance.ml
+++ b/src/server/database/dance.ml
@@ -40,9 +40,9 @@ let search ?(threshold = 0.3) needle : (Dance_row.t * float) list Lwt.t =
   let%lwt devisers = Utils.fold_to_hashtbl Dance_sql.Fold.get_all_devisers_new db (fun k ~dance_id -> Person.sql_to_name ~k: (k dance_id)) in
   Dance_sql.List.search
     db
-    ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))
-    ~threshold: (string_of_float threshold)
-    (fun ~score ~id -> sql_to_row ~id ~devisers: (Hashtbl.find_all devisers id) ~k: (Pair.snoc @@ float_of_string score))
+    ~needle
+    ~threshold
+    (fun ~score ~id -> sql_to_row ~id ~devisers: (Hashtbl.find_all devisers id) ~k: (Pair.snoc score))
 
 let sql_to_dance
     ~id

--- a/src/server/database/dance.ml
+++ b/src/server/database/dance.ml
@@ -1,5 +1,6 @@
 open Nes
 open Dancelor_common
+open Model_new
 
 module Dance_sql = Dance_sql.Sqlgg(Sqlgg_postgresql)
 
@@ -25,7 +26,25 @@ let two_chords_of_common : Model_builder.Core.Dance.two_chords -> two_chords = f
   | One_chord -> One_chord
   | Two_chords -> Two_chords
 
-let row_to_dance
+let sql_to_row ~id ~name ~kind ~devisers ~disambiguation ~(k : Dance_row.t -> 'w) : 'w =
+  k {
+    id = Entry.Id.of_string_exn id;
+    name;
+    kind = Kind_dance.of_string kind;
+    devisers;
+    disambiguation;
+  }
+
+let search ?(threshold = 0.3) needle : (Dance_row.t * float) list Lwt.t =
+  Connection.with_ @@ fun db ->
+  let%lwt devisers = Utils.fold_to_hashtbl Dance_sql.Fold.get_all_devisers_new db (fun k ~dance_id -> Utils.sql_to_person_name ~k: (k dance_id)) in
+  Dance_sql.List.search
+    db
+    ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))
+    ~threshold: (string_of_float threshold)
+    (fun ~score ~id -> sql_to_row ~id ~devisers: (Hashtbl.find_all devisers id) ~k: (Pair.snoc @@ float_of_string score))
+
+let sql_to_dance
     ~id
     ~name
     ~extra_names
@@ -54,7 +73,7 @@ let row_to_dance
         ()
     )
 
-let dance_to_row ~create_or_update db id dance =
+let dance_to_sql ~create_or_update db id dance =
   (* FIXME: transaction, maybe [Connection.with_transaction] *)
   let id = Entry.Id.to_string id in
   ignore
@@ -90,7 +109,7 @@ let get id : Model_builder.Core.Dance.entry option Lwt.t =
   Connection.with_ @@ fun db ->
   let%lwt extra_names = Dance_sql.List.get_extra_names db ~dance_id: id (fun ~extra_name -> NEString.of_string_exn extra_name) in
   let%lwt devisers = Dance_sql.List.get_devisers db ~dance_id: id (fun ~deviser_id -> Entry.Id.of_string_exn deviser_id) in
-  Dance_sql.Single.get db ~id (row_to_dance ~id ~extra_names ~devisers)
+  Dance_sql.Single.get db ~id (sql_to_dance ~id ~extra_names ~devisers)
 
 let get_all () =
   Connection.with_ @@ fun db ->
@@ -109,7 +128,7 @@ let get_all () =
     )
     ();%lwt
   Dance_sql.List.get_all db (fun ~id ->
-    row_to_dance
+    sql_to_dance
       ~id
       ~extra_names: (List.rev @@ Hashtbl.find_all extra_names id)
       ~devisers: (List.rev @@ Hashtbl.find_all devisers id)
@@ -118,12 +137,12 @@ let get_all () =
 let create dance =
   Connection.with_ @@ fun db ->
   let%lwt id = Globally_unique_id.make db Dance in
-  dance_to_row ~create_or_update: Dance_sql.create db id dance;%lwt
+  dance_to_sql ~create_or_update: Dance_sql.create db id dance;%lwt
   lwt id
 
 let update id dance =
   Connection.with_ @@ fun db ->
-  dance_to_row ~create_or_update: (fun db ~id -> Dance_sql.update db ~id) db id dance
+  dance_to_sql ~create_or_update: (fun db ~id -> Dance_sql.update db ~id) db id dance
 
 let delete id =
   Connection.with_ @@ fun db ->

--- a/src/server/database/dance.mli
+++ b/src/server/database/dance.mli
@@ -1,4 +1,6 @@
+open Nes
 open Dancelor_common
+open Model_new
 
 type t = Model_builder.Core.Dance.t
 type entry = Model_builder.Core.Dance.entry
@@ -13,3 +15,5 @@ val create : t -> t Entry.id Lwt.t
 val update : t Entry.id -> t -> unit Lwt.t
 
 val delete : t Entry.id -> unit Lwt.t
+
+val search : ?threshold: float -> NEString.t option -> (Dance_row.t * float) list Lwt.t

--- a/src/server/database/dance.mli
+++ b/src/server/database/dance.mli
@@ -16,4 +16,4 @@ val update : t Entry.id -> t -> unit Lwt.t
 
 val delete : t Entry.id -> unit Lwt.t
 
-val search : ?threshold: float -> NEString.t option -> (Dance_row.t * float) list Lwt.t
+val search : ?threshold: float -> string -> (Dance_row.t * float) list Lwt.t

--- a/src/server/database/dance.sql
+++ b/src/server/database/dance.sql
@@ -118,3 +118,31 @@ INSERT INTO "dance_devisers" (
     @index,
     @deviser_id
 );
+
+-- @search
+SELECT
+    "search"."score",
+    "dance"."id",
+    "name",
+    "kind",
+    "disambiguation"
+FROM (
+    SELECT
+        "id",
+	@needle {Some { word_similarity(@needle, "name") } | None { '1' } } AS "score"
+    FROM "dance"
+) AS "search"
+JOIN "dance"
+ON "dance"."id" = "search"."id"
+WHERE "search"."score" >= @threshold
+ORDER BY "score" DESC, "name" ASC;
+
+-- @get_all_devisers_new
+SELECT
+    "dance_id",
+    "person"."id",
+    "person"."name"
+FROM "dance_devisers"
+JOIN "person"
+ON "dance_devisers"."deviser_id" = "person"."id"
+ORDER BY "index";

--- a/src/server/database/dance.sql
+++ b/src/server/database/dance.sql
@@ -129,7 +129,9 @@ SELECT
 FROM (
     SELECT
         "id",
-	@needle {Some { word_similarity(@needle, "name") } | None { '1' } } AS "score"
+        CASE WHEN @needle = '' THEN 1.0
+             ELSE word_similarity(@needle, "name")
+        END AS "score"
     FROM "dance"
 ) AS "search"
 JOIN "dance"

--- a/src/server/database/dance.sql
+++ b/src/server/database/dance.sql
@@ -121,22 +121,13 @@ INSERT INTO "dance_devisers" (
 
 -- @search
 SELECT
-    "search"."score",
+    CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END AS "score",
     "dance"."id",
     "name",
     "kind",
     "disambiguation"
-FROM (
-    SELECT
-        "id",
-        CASE WHEN @needle = '' THEN 1.0
-             ELSE word_similarity(@needle, "name")
-        END AS "score"
-    FROM "dance"
-) AS "search"
-JOIN "dance"
-ON "dance"."id" = "search"."id"
-WHERE "search"."score" >= @threshold
+FROM "dance"
+WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
 ORDER BY "score" DESC, "name" ASC;
 
 -- @get_all_devisers_new

--- a/src/server/database/migrations.ml
+++ b/src/server/database/migrations.ml
@@ -867,6 +867,10 @@ let migrations : migration list = [
     Migrations_sql.m059_2026_05_string_to_nestring_option__make_book_remarks_nullable;
     Migrations_sql.m059_2026_05_string_to_nestring_option__convert_book_remarks;
   ];
+  make_custom "m060_2026_06_create_extension_pg_trgm" (fun db ->
+    Connection.bypass_exec db "CREATE EXTENSION IF NOT EXISTS pg_trgm";
+    lwt_unit
+  );
 ]
 
 exception Migration_failed of string * exn

--- a/src/server/database/migrations.sql
+++ b/src/server/database/migrations.sql
@@ -1177,3 +1177,6 @@ ALTER COLUMN "remark" DROP NOT NULL;
 UPDATE "book"
 SET "remark" = NULL
 WHERE "remark" = '';
+
+-- -- @m060_2026_06_create_extension_pg_trgm
+-- CREATE EXTENSION IF NOT EXISTS pg_trgm;

--- a/src/server/database/person.ml
+++ b/src/server/database/person.ml
@@ -14,7 +14,7 @@ let search ?(threshold = 0.3) needle : (Person_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
   Person_sql.List.search
     db
-    ~needle
+    ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))
     ~threshold: (string_of_float threshold)
     (fun ~score -> sql_to_row_k @@ Pair.snoc @@ float_of_string score)
 

--- a/src/server/database/person.ml
+++ b/src/server/database/person.ml
@@ -17,9 +17,9 @@ let search ?(threshold = 0.3) needle : (Person_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
   Person_sql.List.search
     db
-    ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))
-    ~threshold: (string_of_float threshold)
-    (fun ~score -> sql_to_row (Pair.snoc @@ float_of_string score))
+    ~needle
+    ~threshold
+    (fun ~score -> sql_to_row (Pair.snoc score))
 
 let sql_to_person
     ~id

--- a/src/server/database/person.ml
+++ b/src/server/database/person.ml
@@ -1,12 +1,24 @@
 open Nes
 open Dancelor_common
+open Model_new
 
 module Person_sql = Person_sql.Sqlgg(Sqlgg_postgresql)
 
 type t = Model_builder.Core.Person.t
 type entry = Model_builder.Core.Person.entry
 
-let row_to_person
+let sql_to_row ~id ~name : Person_row.t =
+  {id = Entry.Id.of_string_exn id; name}
+
+let search ?(threshold = 0.3) needle : Person_row.t list Lwt.t =
+  Connection.with_ @@ fun db ->
+  Person_sql.List.search
+    db
+    ~needle
+    ~threshold: (string_of_float threshold)
+    sql_to_row
+
+let sql_to_person
     ~id
     ~name
     ~scddb_id
@@ -28,7 +40,7 @@ let row_to_person
         ()
     )
 
-let person_to_row ~create_or_update id person =
+let person_to_sql ~create_or_update id person =
   create_or_update
     ~id: (Entry.Id.to_string id)
     ~name: (NEString.to_string @@ Model_builder.Core.Person.name person)
@@ -39,21 +51,21 @@ let person_to_row ~create_or_update id person =
 let get id : Model_builder.Core.Person.entry option Lwt.t =
   let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
-  Person_sql.Single.get db ~id (row_to_person ~id)
+  Person_sql.Single.get db ~id (sql_to_person ~id)
 
 let get_all () =
   Connection.with_ @@ fun db ->
-  Person_sql.List.get_all db row_to_person
+  Person_sql.List.get_all db sql_to_person
 
 let create person =
   Connection.with_ @@ fun db ->
   let%lwt id = Globally_unique_id.make db Person in
-  let%lwt _ = person_to_row ~create_or_update: (Person_sql.create db) id person in
+  let%lwt _ = person_to_sql ~create_or_update: (Person_sql.create db) id person in
   lwt id
 
 let update id person =
   Connection.with_ @@ fun db ->
-  ignore <$> person_to_row ~create_or_update: (fun ~id -> Person_sql.update db ~id) id person
+  ignore <$> person_to_sql ~create_or_update: (fun ~id -> Person_sql.update db ~id) id person
 
 let delete id =
   let%lwt _ =

--- a/src/server/database/person.ml
+++ b/src/server/database/person.ml
@@ -7,7 +7,7 @@ module Person_sql = Person_sql.Sqlgg(Sqlgg_postgresql)
 type t = Model_builder.Core.Person.t
 type entry = Model_builder.Core.Person.entry
 
-let sql_to_row_k ~id ~name (k : Person_row.t -> 'w) : 'w =
+let sql_to_row ~id ~name (k : Person_row.t -> 'w) : 'w =
   k {id = Entry.Id.of_string_exn id; name}
 
 let search ?(threshold = 0.3) needle : (Person_row.t * float) list Lwt.t =
@@ -16,7 +16,7 @@ let search ?(threshold = 0.3) needle : (Person_row.t * float) list Lwt.t =
     db
     ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))
     ~threshold: (string_of_float threshold)
-    (fun ~score -> sql_to_row_k @@ Pair.snoc @@ float_of_string score)
+    (fun ~score -> sql_to_row (Pair.snoc @@ float_of_string score))
 
 let sql_to_person
     ~id

--- a/src/server/database/person.ml
+++ b/src/server/database/person.ml
@@ -7,6 +7,9 @@ module Person_sql = Person_sql.Sqlgg(Sqlgg_postgresql)
 type t = Model_builder.Core.Person.t
 type entry = Model_builder.Core.Person.entry
 
+let sql_to_name ~id ~name ~(k : Person_name.t -> 'w) : 'w =
+  k {id = Entry.Id.of_string_exn id; name}
+
 let sql_to_row ~id ~name (k : Person_row.t -> 'w) : 'w =
   k {id = Entry.Id.of_string_exn id; name}
 

--- a/src/server/database/person.ml
+++ b/src/server/database/person.ml
@@ -7,16 +7,16 @@ module Person_sql = Person_sql.Sqlgg(Sqlgg_postgresql)
 type t = Model_builder.Core.Person.t
 type entry = Model_builder.Core.Person.entry
 
-let sql_to_row ~id ~name : Person_row.t =
-  {id = Entry.Id.of_string_exn id; name}
+let sql_to_row_k ~id ~name (k : Person_row.t -> 'w) : 'w =
+  k {id = Entry.Id.of_string_exn id; name}
 
-let search ?(threshold = 0.3) needle : Person_row.t list Lwt.t =
+let search ?(threshold = 0.3) needle : (Person_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
   Person_sql.List.search
     db
     ~needle
     ~threshold: (string_of_float threshold)
-    sql_to_row
+    (fun ~score -> sql_to_row_k @@ Pair.snoc @@ float_of_string score)
 
 let sql_to_person
     ~id

--- a/src/server/database/person.mli
+++ b/src/server/database/person.mli
@@ -16,4 +16,4 @@ val update : Person_id.t -> t -> unit Lwt.t
 
 val delete : Person_id.t -> unit Lwt.t
 
-val search : ?threshold: float -> string -> (Person_row.t * float) list Lwt.t
+val search : ?threshold: float -> NEString.t option -> (Person_row.t * float) list Lwt.t

--- a/src/server/database/person.mli
+++ b/src/server/database/person.mli
@@ -16,7 +16,7 @@ val update : Person_id.t -> t -> unit Lwt.t
 
 val delete : Person_id.t -> unit Lwt.t
 
-val search : ?threshold: float -> NEString.t option -> (Person_row.t * float) list Lwt.t
+val search : ?threshold: float -> string -> (Person_row.t * float) list Lwt.t
 
 (** {2 Utilities for other models} *)
 

--- a/src/server/database/person.mli
+++ b/src/server/database/person.mli
@@ -17,3 +17,11 @@ val update : Person_id.t -> t -> unit Lwt.t
 val delete : Person_id.t -> unit Lwt.t
 
 val search : ?threshold: float -> NEString.t option -> (Person_row.t * float) list Lwt.t
+
+(** {2 Utilities for other models} *)
+
+val sql_to_name :
+  id: string ->
+  name: string ->
+  k: (Person_name.t -> 'w) ->
+  'w

--- a/src/server/database/person.mli
+++ b/src/server/database/person.mli
@@ -1,15 +1,19 @@
+open Nes
 open Dancelor_common
+open Model_new
 
 type t = Model_builder.Core.Person.t
 type entry = Model_builder.Core.Person.entry
 
-val get : t Entry.id -> entry option Lwt.t
+val get : Person_id.t -> entry option Lwt.t
 
 (* FIXME: we should really rather provide a fold function, or directly an Lwt_stream or something *)
 val get_all : unit -> entry list Lwt.t
 
-val create : t -> t Entry.id Lwt.t
+val create : t -> Person_id.t Lwt.t
 
-val update : t Entry.id -> t -> unit Lwt.t
+val update : Person_id.t -> t -> unit Lwt.t
 
-val delete : t Entry.id -> unit Lwt.t
+val delete : Person_id.t -> unit Lwt.t
+
+val search : ?threshold: float -> string -> Person_row.t list Lwt.t

--- a/src/server/database/person.mli
+++ b/src/server/database/person.mli
@@ -16,4 +16,4 @@ val update : Person_id.t -> t -> unit Lwt.t
 
 val delete : Person_id.t -> unit Lwt.t
 
-val search : ?threshold: float -> string -> Person_row.t list Lwt.t
+val search : ?threshold: float -> string -> (Person_row.t * float) list Lwt.t

--- a/src/server/database/person.sql
+++ b/src/server/database/person.sql
@@ -62,7 +62,9 @@ SELECT
 FROM (
     SELECT
         "id",
-	@needle {Some { word_similarity(@needle, "name") } | None { '1' } } AS "score"
+        CASE WHEN @needle = '' THEN 1.0
+             ELSE word_similarity(@needle, "name")
+        END AS "score"
     FROM "person"
 ) AS "search"
 JOIN "person"

--- a/src/server/database/person.sql
+++ b/src/server/database/person.sql
@@ -56,6 +56,7 @@ WHERE "id" = @id;
 
 -- @search
 SELECT
+    "search"."score",
     "person"."id",
     "name"
 FROM (

--- a/src/server/database/person.sql
+++ b/src/server/database/person.sql
@@ -53,3 +53,16 @@ WHERE "id" = @id;
 -- @delete
 DELETE FROM "person"
 WHERE "id" = @id;
+
+-- @search
+SELECT
+    "person"."id",
+    "name"
+FROM (
+    SELECT "id", word_similarity(@needle, "name") AS "score"
+    FROM "person"
+) AS "search"
+JOIN "person"
+ON "person"."id" = "search"."id"
+WHERE "search"."score" >= @threshold
+ORDER BY "score" DESC;

--- a/src/server/database/person.sql
+++ b/src/server/database/person.sql
@@ -56,18 +56,9 @@ WHERE "id" = @id;
 
 -- @search
 SELECT
-    "search"."score",
-    "person"."id",
+    CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END AS "score",
+    "id",
     "name"
-FROM (
-    SELECT
-        "id",
-        CASE WHEN @needle = '' THEN 1.0
-             ELSE word_similarity(@needle, "name")
-        END AS "score"
-    FROM "person"
-) AS "search"
-JOIN "person"
-ON "person"."id" = "search"."id"
-WHERE "search"."score" >= @threshold
+FROM "person"
+WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
 ORDER BY "score" DESC, "name" ASC;

--- a/src/server/database/person.sql
+++ b/src/server/database/person.sql
@@ -60,10 +60,12 @@ SELECT
     "person"."id",
     "name"
 FROM (
-    SELECT "id", word_similarity(@needle, "name") AS "score"
+    SELECT
+        "id",
+	@needle {Some { word_similarity(@needle, "name") } | None { '1' } } AS "score"
     FROM "person"
 ) AS "search"
 JOIN "person"
 ON "person"."id" = "search"."id"
 WHERE "search"."score" >= @threshold
-ORDER BY "score" DESC;
+ORDER BY "score" DESC, "name" ASC;

--- a/src/server/database/schema-extra-before.sql
+++ b/src/server/database/schema-extra-before.sql
@@ -1,0 +1,5 @@
+-- NOTE: For schema elements that sqlgg cannot parse. This file will
+-- be included before `schema.sql` in tests only.
+
+-- FIXME: Upstream to sqlgg.
+CREATE EXTENSION pg_trgm;

--- a/src/server/database/set.ml
+++ b/src/server/database/set.ml
@@ -7,12 +7,6 @@ module Set_sql = Set_sql.Sqlgg(Sqlgg_postgresql)
 type t = Model_builder.Core.Set.t
 type entry = Model_builder.Core.Set.entry
 
-(* type can_get_private = *)
-(*   | Everyone (\** everyone can see this entry *\) *)
-(*   | Owner (\** you can see this entry because you are its owner *\) *)
-(*   | Viewer (\** you can see this entry because its owner marked you as a viewer *\) *)
-(*   | Omniscient_administrator (\** you can see this entry because you are an administrator with omniscience enabled *\) *)
-
 let sql_to_row ~id ~name ~kind ~conceptors ~tunes ~permission ~(k : Set_row.t -> 'w) : 'w =
   k {
     id = Entry.Id.of_string_exn id;

--- a/src/server/database/set.ml
+++ b/src/server/database/set.ml
@@ -1,12 +1,46 @@
 open Nes
 open Dancelor_common
+open Model_new
 
 module Set_sql = Set_sql.Sqlgg(Sqlgg_postgresql)
 
 type t = Model_builder.Core.Set.t
 type entry = Model_builder.Core.Set.entry
 
-let row_to_set
+(* type can_get_private = *)
+(*   | Everyone (\** everyone can see this entry *\) *)
+(*   | Owner (\** you can see this entry because you are its owner *\) *)
+(*   | Viewer (\** you can see this entry because its owner marked you as a viewer *\) *)
+(*   | Omniscient_administrator (\** you can see this entry because you are an administrator with omniscience enabled *\) *)
+
+let sql_to_row ~id ~name ~kind ~conceptors ~tunes ~permission ~(k : Set_row.t -> 'w) : 'w =
+  k {
+    id = Entry.Id.of_string_exn id;
+    name;
+    kind = Kind_dance.of_string kind;
+    conceptors;
+    tunes;
+    permission = (match permission with `Everyone -> Everyone | `Owner -> Owner | `Viewer -> Viewer | `Omniscient_administrator -> Omniscient_administrator);
+  }
+
+let search ~user ?(threshold = 0.3) needle : (Set_row.t * float) list Lwt.t =
+  Connection.with_ @@ fun db ->
+  let%lwt tunes = Utils.fold_to_hashtbl Set_sql.Fold.get_all_tunes_new db (fun k ~set_id -> Version.sql_to_name ~k: (k set_id)) in
+  let%lwt conceptors = Utils.fold_to_hashtbl Set_sql.Fold.get_all_conceptors_new db (fun k ~set_id -> Person.sql_to_name ~k: (k set_id)) in
+  Set_sql.List.search
+    db
+    ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "")
+    ~needle
+    ~threshold
+    (fun ~score ~id ->
+      sql_to_row
+        ~id
+        ~tunes: (Hashtbl.find_all tunes id)
+        ~conceptors: (Hashtbl.find_all conceptors id)
+        ~k: (Pair.snoc score)
+    )
+
+let sql_to_set
     ~id
     ~name
     ~kind
@@ -47,7 +81,7 @@ let row_to_set
         ()
     )
 
-let set_to_row ~create_or_update db id set access =
+let set_to_sql ~create_or_update db id set access =
   let (visibility, viewers) =
     match Entry.Access.Private.visibility access with
     | Owners_only -> (0L, [])
@@ -145,7 +179,7 @@ let get id : Model_builder.Core.Set.entry option Lwt.t =
       )
     )
   in
-  Set_sql.Single.get db ~id (row_to_set ~id ~conceptors ~viewers ~owners ~content)
+  Set_sql.Single.get db ~id (sql_to_set ~id ~conceptors ~viewers ~owners ~content)
 
 let get_all () =
   Connection.with_ @@ fun db ->
@@ -185,7 +219,7 @@ let get_all () =
     )
     ();%lwt
   Set_sql.List.get_all db (fun ~id ->
-    row_to_set
+    sql_to_set
       ~id
       ~conceptors: (List.rev @@ Hashtbl.find_all conceptors id)
       ~viewers: (List.rev @@ Hashtbl.find_all viewers id)
@@ -196,12 +230,12 @@ let get_all () =
 let create set access =
   Connection.with_ @@ fun db ->
   let%lwt id = Globally_unique_id.make db Set in
-  set_to_row ~create_or_update: Set_sql.create db id set access;%lwt
+  set_to_sql ~create_or_update: Set_sql.create db id set access;%lwt
   lwt id
 
 let update id set access =
   Connection.with_ @@ fun db ->
-  set_to_row ~create_or_update: (fun db ~id -> Set_sql.update db ~id) db id set access
+  set_to_sql ~create_or_update: (fun db ~id -> Set_sql.update db ~id) db id set access
 
 let delete id =
   Connection.with_ @@ fun db ->

--- a/src/server/database/set.mli
+++ b/src/server/database/set.mli
@@ -1,15 +1,18 @@
 open Dancelor_common
+open Model_new
 
 type t = Model_builder.Core.Set.t
 type entry = Model_builder.Core.Set.entry
 
-val get : t Entry.id -> entry option Lwt.t
+val get : Set_id.t -> entry option Lwt.t
 
 (* FIXME: we should really rather provide a fold function, or directly an Lwt_stream or something *)
 val get_all : unit -> entry list Lwt.t
 
-val create : t -> Entry.Access.Private.t -> t Entry.id Lwt.t
+val create : t -> Entry.Access.Private.t -> Set_id.t Lwt.t
 
-val update : t Entry.id -> t -> Entry.Access.Private.t -> unit Lwt.t
+val update : Set_id.t -> t -> Entry.Access.Private.t -> unit Lwt.t
 
-val delete : t Entry.id -> unit Lwt.t
+val delete : Set_id.t -> unit Lwt.t
+
+val search : user: User_id.t option -> ?threshold: float -> string -> (Set_row.t * float) list Lwt.t

--- a/src/server/database/set.sql
+++ b/src/server/database/set.sql
@@ -186,3 +186,50 @@ INSERT INTO "set_content" (
     @version_parameter_display_name,
     @version_parameter_display_composer
 );
+
+-- @search
+SELECT
+    "search"."score",
+    "set"."id",
+    "name",
+    "kind",
+    "permission"
+FROM (
+    SELECT
+        "set"."id",
+        CASE
+	    WHEN @needle = '' THEN 1.0
+            ELSE word_similarity(@needle, "name")
+        END AS "score",
+	CASE
+	    WHEN "set"."visibility" = 1 THEN 'Everyone'
+	    WHEN EXISTS (SELECT 1 FROM "set_owners" WHERE "set_owners"."set_id" = "set"."id" AND "set_owners"."owner_id" = @user_id) THEN 'Owner'
+	    WHEN "set"."visibility" = 2 AND EXISTS (SELECT 1 FROM "set_viewers" WHERE "set_viewers"."set_id" = "set"."id" AND "set_viewers"."viewer_id" = @user_id) THEN 'Viewer'
+	    WHEN "user"."role" = 2 AND "user"."omniscience" THEN 'Omniscient_administrator'
+	    ELSE NULL
+	END AS "permission"
+    FROM "set"
+    LEFT JOIN "user" ON "user"."id" = @user_id
+) AS "search"
+JOIN "set" ON "set"."id" = "search"."id"
+WHERE "search"."score" >= @threshold
+  AND "search"."permission" IS NOT NULL
+ORDER BY "score" DESC, "name" ASC;
+
+-- @get_all_conceptors_new
+SELECT
+    "set_id",
+    "person"."id",
+    "person"."name"
+FROM "set_conceptors"
+JOIN "person" ON "set_conceptors"."conceptor_id" = "person"."id";
+
+-- @get_all_tunes_new
+SELECT
+    "set_id",
+    "version"."id",
+    "tune"."name"
+FROM "set_content"
+JOIN "version" ON "set_content"."version_id" = "version"."id"
+JOIN "tune" ON "version"."tune_id" = "tune"."id"
+ORDER BY "index";

--- a/src/server/database/set.sql
+++ b/src/server/database/set.sql
@@ -188,19 +188,12 @@ INSERT INTO "set_content" (
 );
 
 -- @search
-SELECT
-    "search"."score",
-    "set"."id",
-    "name",
-    "kind",
-    "permission"
-FROM (
+SELECT * FROM (
     SELECT
+        CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END AS "score",
         "set"."id",
-        CASE
-            WHEN @needle = '' THEN 1.0
-            ELSE word_similarity(@needle, "name")
-        END AS "score",
+        "set"."name",
+        "set"."kind",
         CASE
             WHEN "set"."visibility" = 1 THEN 'Everyone'
             WHEN "set_owners"."owner_id" IS NOT NULL THEN 'Owner'
@@ -212,10 +205,9 @@ FROM (
     LEFT JOIN "set_owners" ON "set_owners"."set_id" = "set"."id" AND "set_owners"."owner_id" = @user_id
     LEFT JOIN "set_viewers" ON "set_viewers"."set_id" = "set"."id" AND "set_viewers"."viewer_id" = @user_id
     LEFT JOIN "user" ON "user"."id" = @user_id
-) AS "search"
-JOIN "set" ON "set"."id" = "search"."id"
-WHERE "search"."score" >= @threshold
-  AND "search"."permission" IS NOT NULL
+    WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
+) AS "set+"
+WHERE "set+"."permission" IS NOT NULL
 ORDER BY "score" DESC, "name" ASC;
 
 -- @get_all_conceptors_new

--- a/src/server/database/set.sql
+++ b/src/server/database/set.sql
@@ -198,17 +198,19 @@ FROM (
     SELECT
         "set"."id",
         CASE
-	    WHEN @needle = '' THEN 1.0
+            WHEN @needle = '' THEN 1.0
             ELSE word_similarity(@needle, "name")
         END AS "score",
-	CASE
-	    WHEN "set"."visibility" = 1 THEN 'Everyone'
-	    WHEN EXISTS (SELECT 1 FROM "set_owners" WHERE "set_owners"."set_id" = "set"."id" AND "set_owners"."owner_id" = @user_id) THEN 'Owner'
-	    WHEN "set"."visibility" = 2 AND EXISTS (SELECT 1 FROM "set_viewers" WHERE "set_viewers"."set_id" = "set"."id" AND "set_viewers"."viewer_id" = @user_id) THEN 'Viewer'
-	    WHEN "user"."role" = 2 AND "user"."omniscience" THEN 'Omniscient_administrator'
-	    ELSE NULL
-	END AS "permission"
+        CASE
+            WHEN "set"."visibility" = 1 THEN 'Everyone'
+            WHEN "set_owners"."owner_id" IS NOT NULL THEN 'Owner'
+            WHEN "set"."visibility" = 2 AND "set_viewers"."viewer_id" IS NOT NULL THEN 'Viewer'
+            WHEN "user"."role" = 2 AND "user"."omniscience" THEN 'Omniscient_administrator'
+            ELSE NULL
+        END AS "permission"
     FROM "set"
+    LEFT JOIN "set_owners" ON "set_owners"."set_id" = "set"."id" AND "set_owners"."owner_id" = @user_id
+    LEFT JOIN "set_viewers" ON "set_viewers"."set_id" = "set"."id" AND "set_viewers"."viewer_id" = @user_id
     LEFT JOIN "user" ON "user"."id" = @user_id
 ) AS "search"
 JOIN "set" ON "set"."id" = "search"."id"

--- a/src/server/database/source.ml
+++ b/src/server/database/source.ml
@@ -13,14 +13,9 @@ let sql_to_person_name ~id ~name ~(k : Person_name.t -> 'w) : 'w =
 let sql_to_row ~id ~name ~date ~editors ~(k : Source_row.t -> 'w) : 'w =
   k {id = Entry.Id.of_string_exn id; name; date = Option.map (Option.get % PartialDate.from_string) date; editors}
 
-let fold_to_hashtbl f =
-  let tbl = Hashtbl.create 8 in
-  f (fun k x () -> Hashtbl.add tbl k x);%lwt
-  lwt tbl
-
 let search ?(threshold = 0.3) needle : (Source_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
-  let%lwt editors = fold_to_hashtbl (fun k -> Source_sql.Fold.get_all_editors_new db (fun ~source_id -> sql_to_person_name ~k: (k source_id)) ()) in
+  let%lwt editors = Utils.fold_to_hashtbl Source_sql.Fold.get_all_editors_new db (fun k ~source_id -> sql_to_person_name ~k: (k source_id)) in
   Source_sql.List.search
     db
     ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))

--- a/src/server/database/source.ml
+++ b/src/server/database/source.ml
@@ -19,9 +19,9 @@ let search ?(threshold = 0.3) needle : (Source_row.t * float) list Lwt.t =
   let%lwt editors = Utils.fold_to_hashtbl Source_sql.Fold.get_all_editors_new db (fun k ~source_id -> Person.sql_to_name ~k: (k source_id)) in
   Source_sql.List.search
     db
-    ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))
-    ~threshold: (string_of_float threshold)
-    (fun ~score ~id -> sql_to_row ~id ~editors: (Hashtbl.find_all editors id) ~k: (Pair.snoc @@ float_of_string score))
+    ~needle
+    ~threshold
+    (fun ~score ~id -> sql_to_row ~id ~editors: (Hashtbl.find_all editors id) ~k: (Pair.snoc score))
 
 let sql_to_source
     ~id

--- a/src/server/database/source.ml
+++ b/src/server/database/source.ml
@@ -16,7 +16,7 @@ let sql_to_row ~id ~name ~date ~editors ~(k : Source_row.t -> 'w) : 'w =
 
 let search ?(threshold = 0.3) needle : (Source_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
-  let%lwt editors = Utils.fold_to_hashtbl Source_sql.Fold.get_all_editors_new db (fun k ~source_id -> Utils.sql_to_person_name ~k: (k source_id)) in
+  let%lwt editors = Utils.fold_to_hashtbl Source_sql.Fold.get_all_editors_new db (fun k ~source_id -> Person.sql_to_name ~k: (k source_id)) in
   Source_sql.List.search
     db
     ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))

--- a/src/server/database/source.ml
+++ b/src/server/database/source.ml
@@ -7,15 +7,12 @@ module Source_sql = Source_sql.Sqlgg(Sqlgg_postgresql)
 type t = Model_builder.Core.Source.t
 type entry = Model_builder.Core.Source.entry
 
-let sql_to_person_name ~id ~name ~(k : Person_name.t -> 'w) : 'w =
-  k {id = Entry.Id.of_string_exn id; name}
-
 let sql_to_row ~id ~name ~date ~editors ~(k : Source_row.t -> 'w) : 'w =
   k {id = Entry.Id.of_string_exn id; name; date = Option.map (Option.get % PartialDate.from_string) date; editors}
 
 let search ?(threshold = 0.3) needle : (Source_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
-  let%lwt editors = Utils.fold_to_hashtbl Source_sql.Fold.get_all_editors_new db (fun k ~source_id -> sql_to_person_name ~k: (k source_id)) in
+  let%lwt editors = Utils.fold_to_hashtbl Source_sql.Fold.get_all_editors_new db (fun k ~source_id -> Utils.sql_to_person_name ~k: (k source_id)) in
   Source_sql.List.search
     db
     ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))

--- a/src/server/database/source.ml
+++ b/src/server/database/source.ml
@@ -7,6 +7,10 @@ module Source_sql = Source_sql.Sqlgg(Sqlgg_postgresql)
 type t = Model_builder.Core.Source.t
 type entry = Model_builder.Core.Source.entry
 
+let sql_to_short_name ~id ~name ~short_name ~(k : Source_short_name.t -> 'w) : 'w =
+  let short_name = Option.value short_name ~default: name in
+  k {id = Entry.Id.of_string_exn id; short_name}
+
 let sql_to_row ~id ~name ~date ~editors ~(k : Source_row.t -> 'w) : 'w =
   k {id = Entry.Id.of_string_exn id; name; date = Option.map (Option.get % PartialDate.from_string) date; editors}
 

--- a/src/server/database/source.ml
+++ b/src/server/database/source.ml
@@ -1,12 +1,33 @@
 open Nes
 open Dancelor_common
+open Model_new
 
 module Source_sql = Source_sql.Sqlgg(Sqlgg_postgresql)
 
 type t = Model_builder.Core.Source.t
 type entry = Model_builder.Core.Source.entry
 
-let row_to_source
+let sql_to_person_name ~id ~name ~(k : Person_name.t -> 'w) : 'w =
+  k {id = Entry.Id.of_string_exn id; name}
+
+let sql_to_row ~id ~name ~date ~editors ~(k : Source_row.t -> 'w) : 'w =
+  k {id = Entry.Id.of_string_exn id; name; date = Option.map (Option.get % PartialDate.from_string) date; editors}
+
+let fold_to_hashtbl f =
+  let tbl = Hashtbl.create 8 in
+  f (fun k x () -> Hashtbl.add tbl k x);%lwt
+  lwt tbl
+
+let search ?(threshold = 0.3) needle : (Source_row.t * float) list Lwt.t =
+  Connection.with_ @@ fun db ->
+  let%lwt editors = fold_to_hashtbl (fun k -> Source_sql.Fold.get_all_editors_new db (fun ~source_id -> sql_to_person_name ~k: (k source_id)) ()) in
+  Source_sql.List.search
+    db
+    ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))
+    ~threshold: (string_of_float threshold)
+    (fun ~score ~id -> sql_to_row ~id ~editors: (Hashtbl.find_all editors id) ~k: (Pair.snoc @@ float_of_string score))
+
+let sql_to_source
     ~id
     ~name
     ~short_name
@@ -32,7 +53,7 @@ let row_to_source
         ()
     )
 
-let source_to_row ~create_or_update ~delete_all_editors ~add_one_editor id source =
+let source_to_sql ~create_or_update ~delete_all_editors ~add_one_editor id source =
   (* FIXME: transaction, maybe [Connection.with_transaction] *)
   let id = Entry.Id.to_string id in
   ignore
@@ -54,18 +75,18 @@ let get id : Model_builder.Core.Source.entry option Lwt.t =
   let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   let%lwt editors = Source_sql.List.get_editors db ~source_id: id (fun ~person_id -> Entry.Id.of_string_exn person_id) in
-  Source_sql.Single.get db ~id (row_to_source ~id ~editors)
+  Source_sql.Single.get db ~id (sql_to_source ~id ~editors)
 
 let get_all () =
   Connection.with_ @@ fun db ->
   let editors = Hashtbl.create 8 in
   Source_sql.Fold.get_all_editors db (fun ~source_id ~person_id () -> Hashtbl.add editors source_id (Entry.Id.of_string_exn person_id)) ();%lwt
-  Source_sql.List.get_all db (fun ~id -> row_to_source ~id ~editors: (List.rev @@ Hashtbl.find_all editors id))
+  Source_sql.List.get_all db (fun ~id -> sql_to_source ~id ~editors: (List.rev @@ Hashtbl.find_all editors id))
 
 let create source =
   Connection.with_ @@ fun db ->
   let%lwt id = Globally_unique_id.make db Source in
-  source_to_row
+  source_to_sql
     ~create_or_update: (Source_sql.create db)
     ~delete_all_editors: (fun ~source_id: _ -> lwt_unit)
     ~add_one_editor: (Source_sql.add_one_editor db)
@@ -75,7 +96,7 @@ let create source =
 
 let update id source =
   Connection.with_ @@ fun db ->
-  source_to_row
+  source_to_sql
     ~create_or_update: (fun ~id -> Source_sql.update db ~id)
     ~delete_all_editors: (Source_sql.delete_all_editors db)
     ~add_one_editor: (Source_sql.add_one_editor db)

--- a/src/server/database/source.mli
+++ b/src/server/database/source.mli
@@ -5,19 +5,28 @@ open Model_new
 type t = Model_builder.Core.Source.t
 type entry = Model_builder.Core.Source.entry
 
-val get : t Entry.id -> entry option Lwt.t
+val get : Source_id.t -> entry option Lwt.t
 
 (* FIXME: we should really rather provide a fold function, or directly an Lwt_stream or something *)
 val get_all : unit -> entry list Lwt.t
 
-val create : t -> t Entry.id Lwt.t
+val create : t -> Source_id.t Lwt.t
 
-val update : t Entry.id -> t -> unit Lwt.t
+val update : Source_id.t -> t -> unit Lwt.t
 
-val delete : t Entry.id -> unit Lwt.t
+val delete : Source_id.t -> unit Lwt.t
 
-val with_cover : t Entry.id -> (string option -> 'a Lwt.t) -> 'a Lwt.t
+val with_cover : Source_id.t -> (string option -> 'a Lwt.t) -> 'a Lwt.t
 (** Given a source id, produce a file containing the cover and pass its path to
     the callback. [None] means that there is no cover for this source. *)
 
 val search : ?threshold: float -> NEString.t option -> (Source_row.t * float) list Lwt.t
+
+(** {2 Utilities for other models} *)
+
+val sql_to_short_name :
+  id: string ->
+  name: string ->
+  short_name: string option ->
+  k: (Source_short_name.t -> 'w) ->
+  'w

--- a/src/server/database/source.mli
+++ b/src/server/database/source.mli
@@ -1,4 +1,6 @@
+open Nes
 open Dancelor_common
+open Model_new
 
 type t = Model_builder.Core.Source.t
 type entry = Model_builder.Core.Source.entry
@@ -17,3 +19,5 @@ val delete : t Entry.id -> unit Lwt.t
 val with_cover : t Entry.id -> (string option -> 'a Lwt.t) -> 'a Lwt.t
 (** Given a source id, produce a file containing the cover and pass its path to
     the callback. [None] means that there is no cover for this source. *)
+
+val search : ?threshold: float -> NEString.t option -> (Source_row.t * float) list Lwt.t

--- a/src/server/database/source.mli
+++ b/src/server/database/source.mli
@@ -20,7 +20,7 @@ val with_cover : Source_id.t -> (string option -> 'a Lwt.t) -> 'a Lwt.t
 (** Given a source id, produce a file containing the cover and pass its path to
     the callback. [None] means that there is no cover for this source. *)
 
-val search : ?threshold: float -> NEString.t option -> (Source_row.t * float) list Lwt.t
+val search : ?threshold: float -> string -> (Source_row.t * float) list Lwt.t
 
 (** {2 Utilities for other models} *)
 

--- a/src/server/database/source.sql
+++ b/src/server/database/source.sql
@@ -100,8 +100,7 @@ FROM (
 	@needle {Some { word_similarity(@needle, "name") } | None { '1' } } AS "score"
     FROM "source"
 ) AS "search"
-JOIN "source"
-ON "source"."id" = "search"."id"
+JOIN "source" ON "source"."id" = "search"."id"
 WHERE "search"."score" >= @threshold
 ORDER BY "score" DESC, "name" ASC;
 
@@ -111,5 +110,4 @@ SELECT
     "person"."id",
     "person"."name"
 FROM "source_editors"
-JOIN "person"
-ON "source_editors"."person_id" = "person"."id";
+JOIN "person" ON "source_editors"."person_id" = "person"."id";

--- a/src/server/database/source.sql
+++ b/src/server/database/source.sql
@@ -90,20 +90,12 @@ WHERE "id" = @id;
 
 -- @search
 SELECT
-    "search"."score",
+    CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END AS "score",
     "source"."id",
     "name",
     "date"
-FROM (
-    SELECT
-        "id",
-        CASE WHEN @needle = '' THEN 1.0
-             ELSE word_similarity(@needle, "name")
-        END AS "score"
-    FROM "source"
-) AS "search"
-JOIN "source" ON "source"."id" = "search"."id"
-WHERE "search"."score" >= @threshold
+FROM "source"
+WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
 ORDER BY "score" DESC, "name" ASC;
 
 -- @get_all_editors_new

--- a/src/server/database/source.sql
+++ b/src/server/database/source.sql
@@ -97,7 +97,9 @@ SELECT
 FROM (
     SELECT
         "id",
-	@needle {Some { word_similarity(@needle, "name") } | None { '1' } } AS "score"
+        CASE WHEN @needle = '' THEN 1.0
+             ELSE word_similarity(@needle, "name")
+        END AS "score"
     FROM "source"
 ) AS "search"
 JOIN "source" ON "source"."id" = "search"."id"

--- a/src/server/database/source.sql
+++ b/src/server/database/source.sql
@@ -87,3 +87,29 @@ WHERE "id" = @id;
 SELECT "cover"
 FROM "source"
 WHERE "id" = @id;
+
+-- @search
+SELECT
+    "search"."score",
+    "source"."id",
+    "name",
+    "date"
+FROM (
+    SELECT
+        "id",
+	@needle {Some { word_similarity(@needle, "name") } | None { '1' } } AS "score"
+    FROM "source"
+) AS "search"
+JOIN "source"
+ON "source"."id" = "search"."id"
+WHERE "search"."score" >= @threshold
+ORDER BY "score" DESC, "name" ASC;
+
+-- @get_all_editors_new
+SELECT
+    "source_id",
+    "person"."id",
+    "person"."name"
+FROM "source_editors"
+JOIN "person"
+ON "source_editors"."person_id" = "person"."id";

--- a/src/server/database/tune.ml
+++ b/src/server/database/tune.ml
@@ -1,12 +1,30 @@
 open Nes
 open Dancelor_common
+open Model_new
 
 module Tune_sql = Tune_sql.Sqlgg(Sqlgg_postgresql)
 
 type t = Model_builder.Core.Tune.t
 type entry = Model_builder.Core.Tune.entry
 
-let row_to_tune
+let sql_to_row ~id ~name ~kind ~composers ~(k : Tune_row.t -> 'w) : 'w =
+  k {
+    id = Entry.Id.of_string_exn id;
+    name;
+    kind = Kind_base.of_string kind;
+    composers;
+  }
+
+let search ?(threshold = 0.3) needle : (Tune_row.t * float) list Lwt.t =
+  Connection.with_ @@ fun db ->
+  let%lwt composers = Utils.fold_to_hashtbl Tune_sql.Fold.get_all_composers_new db (fun k ~tune_id -> Utils.sql_to_person_name ~k: (k tune_id)) in
+  Tune_sql.List.search
+    db
+    ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))
+    ~threshold: (string_of_float threshold)
+    (fun ~score ~id -> sql_to_row ~id ~composers: (Hashtbl.find_all composers id) ~k: (Pair.snoc @@ float_of_string score))
+
+let sql_to_tune
     ~id
     ~name
     ~extra_names
@@ -35,7 +53,7 @@ let row_to_tune
         ()
     )
 
-let tune_to_row ~create_or_update db id tune =
+let tune_to_sql ~create_or_update db id tune =
   (* FIXME: transaction, maybe [Connection.with_transaction] *)
   let id = Entry.Id.to_string id in
   ignore
@@ -78,7 +96,7 @@ let get id : Model_builder.Core.Tune.entry option Lwt.t =
   let%lwt extra_names = Tune_sql.List.get_extra_names db ~tune_id: id (fun ~extra_name -> NEString.of_string_exn extra_name) in
   let%lwt composers = Tune_sql.List.get_composers db ~tune_id: id (fun ~composer_id ~details -> (Entry.Id.of_string_exn composer_id, Option.map NEString.of_string_exn details)) in
   let%lwt dances = Tune_sql.List.get_dances db ~tune_id: id (fun ~dance_id -> Entry.Id.of_string_exn dance_id) in
-  Tune_sql.Single.get db ~id (row_to_tune ~id ~extra_names ~composers ~dances)
+  Tune_sql.Single.get db ~id (sql_to_tune ~id ~extra_names ~composers ~dances)
 
 let get_all () =
   Connection.with_ @@ fun db ->
@@ -104,7 +122,7 @@ let get_all () =
     )
     ();%lwt
   Tune_sql.List.get_all db (fun ~id ->
-    row_to_tune
+    sql_to_tune
       ~id
       ~extra_names: (List.rev @@ Hashtbl.find_all extra_names id)
       ~composers: (List.rev @@ Hashtbl.find_all composers id)
@@ -114,12 +132,12 @@ let get_all () =
 let create tune =
   Connection.with_ @@ fun db ->
   let%lwt id = Globally_unique_id.make db Tune in
-  tune_to_row ~create_or_update: Tune_sql.create db id tune;%lwt
+  tune_to_sql ~create_or_update: Tune_sql.create db id tune;%lwt
   lwt id
 
 let update id tune =
   Connection.with_ @@ fun db ->
-  tune_to_row ~create_or_update: (fun db ~id -> Tune_sql.update db ~id) db id tune
+  tune_to_sql ~create_or_update: (fun db ~id -> Tune_sql.update db ~id) db id tune
 
 let delete id =
   Connection.with_ @@ fun db ->

--- a/src/server/database/tune.ml
+++ b/src/server/database/tune.ml
@@ -20,9 +20,9 @@ let search ?(threshold = 0.3) needle : (Tune_row.t * float) list Lwt.t =
   let%lwt composers = Utils.fold_to_hashtbl Tune_sql.Fold.get_all_composers_new db (fun k ~tune_id -> Person.sql_to_name ~k: (k tune_id)) in
   Tune_sql.List.search
     db
-    ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))
-    ~threshold: (string_of_float threshold)
-    (fun ~score ~id -> sql_to_row ~id ~composers: (Hashtbl.find_all composers id) ~k: (Pair.snoc @@ float_of_string score))
+    ~needle
+    ~threshold
+    (fun ~score ~id -> sql_to_row ~id ~composers: (Hashtbl.find_all composers id) ~k: (Pair.snoc score))
 
 let sql_to_tune
     ~id

--- a/src/server/database/tune.ml
+++ b/src/server/database/tune.ml
@@ -17,7 +17,7 @@ let sql_to_row ~id ~name ~kind ~composers ~(k : Tune_row.t -> 'w) : 'w =
 
 let search ?(threshold = 0.3) needle : (Tune_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
-  let%lwt composers = Utils.fold_to_hashtbl Tune_sql.Fold.get_all_composers_new db (fun k ~tune_id -> Utils.sql_to_person_name ~k: (k tune_id)) in
+  let%lwt composers = Utils.fold_to_hashtbl Tune_sql.Fold.get_all_composers_new db (fun k ~tune_id -> Person.sql_to_name ~k: (k tune_id)) in
   Tune_sql.List.search
     db
     ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))

--- a/src/server/database/tune.mli
+++ b/src/server/database/tune.mli
@@ -17,3 +17,13 @@ val update : t Entry.id -> t -> unit Lwt.t
 val delete : t Entry.id -> unit Lwt.t
 
 val search : ?threshold: float -> NEString.t option -> (Tune_row.t * float) list Lwt.t
+
+(** {2 Utilities for other models} *)
+
+val sql_to_row :
+  id: string ->
+  name: string ->
+  kind: string ->
+  composers: Person_name.t list ->
+  k: (Tune_row.t -> 'w) ->
+  'w

--- a/src/server/database/tune.mli
+++ b/src/server/database/tune.mli
@@ -16,7 +16,7 @@ val update : t Entry.id -> t -> unit Lwt.t
 
 val delete : t Entry.id -> unit Lwt.t
 
-val search : ?threshold: float -> NEString.t option -> (Tune_row.t * float) list Lwt.t
+val search : ?threshold: float -> string -> (Tune_row.t * float) list Lwt.t
 
 (** {2 Utilities for other models} *)
 

--- a/src/server/database/tune.mli
+++ b/src/server/database/tune.mli
@@ -1,4 +1,6 @@
+open Nes
 open Dancelor_common
+open Model_new
 
 type t = Model_builder.Core.Tune.t
 type entry = Model_builder.Core.Tune.entry
@@ -13,3 +15,5 @@ val create : t -> t Entry.id Lwt.t
 val update : t Entry.id -> t -> unit Lwt.t
 
 val delete : t Entry.id -> unit Lwt.t
+
+val search : ?threshold: float -> NEString.t option -> (Tune_row.t * float) list Lwt.t

--- a/src/server/database/tune.sql
+++ b/src/server/database/tune.sql
@@ -152,7 +152,9 @@ SELECT
 FROM (
     SELECT
         "id",
-	@needle {Some { word_similarity(@needle, "name") } | None { '1' } } AS "score"
+        CASE WHEN @needle = '' THEN 1.0
+             ELSE word_similarity(@needle, "name")
+        END AS "score"
     FROM "tune"
 ) AS "search"
 JOIN "tune" ON "tune"."id" = "search"."id"

--- a/src/server/database/tune.sql
+++ b/src/server/database/tune.sql
@@ -145,20 +145,12 @@ INSERT INTO "recommended_tunes" (
 
 -- @search
 SELECT
-    "search"."score",
+    CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END AS "score",
     "tune"."id",
     "name",
     "kind"
-FROM (
-    SELECT
-        "id",
-        CASE WHEN @needle = '' THEN 1.0
-             ELSE word_similarity(@needle, "name")
-        END AS "score"
-    FROM "tune"
-) AS "search"
-JOIN "tune" ON "tune"."id" = "search"."id"
-WHERE "search"."score" >= @threshold
+FROM "tune"
+WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
 ORDER BY "score" DESC, "name" ASC;
 
 -- @get_all_composers_new

--- a/src/server/database/tune.sql
+++ b/src/server/database/tune.sql
@@ -155,8 +155,7 @@ FROM (
 	@needle {Some { word_similarity(@needle, "name") } | None { '1' } } AS "score"
     FROM "tune"
 ) AS "search"
-JOIN "tune"
-ON "tune"."id" = "search"."id"
+JOIN "tune" ON "tune"."id" = "search"."id"
 WHERE "search"."score" >= @threshold
 ORDER BY "score" DESC, "name" ASC;
 
@@ -166,6 +165,5 @@ SELECT
     "person"."id",
     "person"."name"
 FROM "tune_composers"
-JOIN "person"
-ON "tune_composers"."composer_id" = "person"."id"
+JOIN "person" ON "tune_composers"."composer_id" = "person"."id"
 ORDER BY "index";

--- a/src/server/database/tune.sql
+++ b/src/server/database/tune.sql
@@ -142,3 +142,30 @@ INSERT INTO "recommended_tunes" (
     @tune_id,
     @dance_id
 );
+
+-- @search
+SELECT
+    "search"."score",
+    "tune"."id",
+    "name",
+    "kind"
+FROM (
+    SELECT
+        "id",
+	@needle {Some { word_similarity(@needle, "name") } | None { '1' } } AS "score"
+    FROM "tune"
+) AS "search"
+JOIN "tune"
+ON "tune"."id" = "search"."id"
+WHERE "search"."score" >= @threshold
+ORDER BY "score" DESC, "name" ASC;
+
+-- @get_all_composers_new
+SELECT
+    "tune_id",
+    "person"."id",
+    "person"."name"
+FROM "tune_composers"
+JOIN "person"
+ON "tune_composers"."composer_id" = "person"."id"
+ORDER BY "index";

--- a/src/server/database/utils.ml
+++ b/src/server/database/utils.ml
@@ -1,0 +1,6 @@
+open Nes
+
+let fold_to_hashtbl fold db k =
+  let tbl = Hashtbl.create 8 in
+  fold db (k (fun key value () -> Hashtbl.add tbl key value)) ();%lwt
+  lwt tbl

--- a/src/server/database/utils.ml
+++ b/src/server/database/utils.ml
@@ -1,11 +1,6 @@
 open Nes
-open Dancelor_common
-open Model_new
 
 let fold_to_hashtbl fold db k =
   let tbl = Hashtbl.create 8 in
   fold db (k (fun key value () -> Hashtbl.add tbl key value)) ();%lwt
   lwt tbl
-
-let sql_to_person_name ~id ~name ~(k : Person_name.t -> 'w) : 'w =
-  k {id = Entry.Id.of_string_exn id; name}

--- a/src/server/database/utils.ml
+++ b/src/server/database/utils.ml
@@ -1,6 +1,11 @@
 open Nes
+open Dancelor_common
+open Model_new
 
 let fold_to_hashtbl fold db k =
   let tbl = Hashtbl.create 8 in
   fold db (k (fun key value () -> Hashtbl.add tbl key value)) ();%lwt
   lwt tbl
+
+let sql_to_person_name ~id ~name ~(k : Person_name.t -> 'w) : 'w =
+  k {id = Entry.Id.of_string_exn id; name}

--- a/src/server/database/version.ml
+++ b/src/server/database/version.ml
@@ -44,9 +44,9 @@ let sql_to_row
 
 let search ?(threshold = 0.3) needle : (Version_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
-  let%lwt tune_composers = Utils.fold_to_hashtbl Tune_sql.Fold.get_all_composers_new db (fun k ~tune_id -> Utils.sql_to_person_name ~k: (k tune_id)) in
+  let%lwt tune_composers = Utils.fold_to_hashtbl Tune_sql.Fold.get_all_composers_new db (fun k ~tune_id -> Person.sql_to_name ~k: (k tune_id)) in
   let%lwt sources = Utils.fold_to_hashtbl Version_sql.Fold.get_all_sources_new db (fun k ~version_id -> Source.sql_to_short_name ~k: (k version_id)) in
-  let%lwt arrangers = Utils.fold_to_hashtbl Version_sql.Fold.get_all_arrangers_new db (fun k ~version_id -> Utils.sql_to_person_name ~k: (k version_id)) in
+  let%lwt arrangers = Utils.fold_to_hashtbl Version_sql.Fold.get_all_arrangers_new db (fun k ~version_id -> Person.sql_to_name ~k: (k version_id)) in
   Version_sql.List.search
     db
     ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))

--- a/src/server/database/version.ml
+++ b/src/server/database/version.ml
@@ -49,8 +49,8 @@ let search ?(threshold = 0.3) needle : (Version_row.t * float) list Lwt.t =
   let%lwt arrangers = Utils.fold_to_hashtbl Version_sql.Fold.get_all_arrangers_new db (fun k ~version_id -> Person.sql_to_name ~k: (k version_id)) in
   Version_sql.List.search
     db
-    ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))
-    ~threshold: (string_of_float threshold)
+    ~needle
+    ~threshold
     (fun ~score ~id ~tune_id ->
       sql_to_row
         ~id
@@ -58,7 +58,7 @@ let search ?(threshold = 0.3) needle : (Version_row.t * float) list Lwt.t =
         ~tune_composers: (Hashtbl.find_all tune_composers tune_id)
         ~sources: (Hashtbl.find_all sources id)
         ~arrangers: (Hashtbl.find_all arrangers id)
-        ~k: (Pair.snoc @@ float_of_string score)
+        ~k: (Pair.snoc score)
     )
 
 let sql_to_version

--- a/src/server/database/version.ml
+++ b/src/server/database/version.ml
@@ -8,6 +8,9 @@ module Version_sql = Version_sql.Sqlgg(Sqlgg_postgresql)
 type t = Model_builder.Core.Version.t
 type entry = Model_builder.Core.Version.entry
 
+let sql_to_name ~id ~name ~(k : Version_name.t -> 'w) : 'w =
+  k {id = Entry.Id.of_string_exn id; name}
+
 let sql_to_row
     ~sources
     ~arrangers

--- a/src/server/database/version.ml
+++ b/src/server/database/version.ml
@@ -1,12 +1,67 @@
 open Nes
 open Dancelor_common
+open Model_new
 
+module Tune_sql = Tune_sql.Sqlgg(Sqlgg_postgresql)
 module Version_sql = Version_sql.Sqlgg(Sqlgg_postgresql)
 
 type t = Model_builder.Core.Version.t
 type entry = Model_builder.Core.Version.entry
 
-let row_to_version
+let sql_to_row
+    ~sources
+    ~arrangers
+    ~tune_composers
+    ~id
+    ~disambiguation
+    ~monolithic_bars
+    ~monolithic_or_default_structure
+    ~tune_id
+    ~tune_name
+    ~tune_kind
+    ~(k : Version_row.t -> 'w)
+    : 'w
+  =
+  let content : Version_row.content =
+    match (monolithic_bars, monolithic_or_default_structure) with
+    | (None, None) -> No_content
+    | (None, Some _default_structure) -> Destructured
+    | (Some bars, Some structure) ->
+      Monolithic {
+        bars = Int64.to_int bars;
+        structure = Option.get (Model_builder.Core.Version.Structure.of_string (NEString.of_string_exn structure));
+      }
+    | _ -> assert false
+  in
+  k {
+    id = Entry.Id.of_string_exn id;
+    tune = Tune.sql_to_row ~id: tune_id ~name: tune_name ~kind: tune_kind ~composers: tune_composers ~k: Fun.id;
+    sources;
+    disambiguation;
+    arrangers;
+    content;
+  }
+
+let search ?(threshold = 0.3) needle : (Version_row.t * float) list Lwt.t =
+  Connection.with_ @@ fun db ->
+  let%lwt tune_composers = Utils.fold_to_hashtbl Tune_sql.Fold.get_all_composers_new db (fun k ~tune_id -> Utils.sql_to_person_name ~k: (k tune_id)) in
+  let%lwt sources = Utils.fold_to_hashtbl Version_sql.Fold.get_all_sources_new db (fun k ~version_id -> Source.sql_to_short_name ~k: (k version_id)) in
+  let%lwt arrangers = Utils.fold_to_hashtbl Version_sql.Fold.get_all_arrangers_new db (fun k ~version_id -> Utils.sql_to_person_name ~k: (k version_id)) in
+  Version_sql.List.search
+    db
+    ~needle: (match needle with None -> `None | Some s -> `Some (NEString.to_string s))
+    ~threshold: (string_of_float threshold)
+    (fun ~score ~id ~tune_id ->
+      sql_to_row
+        ~id
+        ~tune_id
+        ~tune_composers: (Hashtbl.find_all tune_composers tune_id)
+        ~sources: (Hashtbl.find_all sources id)
+        ~arrangers: (Hashtbl.find_all arrangers id)
+        ~k: (Pair.snoc @@ float_of_string score)
+    )
+
+let sql_to_version
     ~id
     ~tune_id
     ~key
@@ -54,7 +109,7 @@ let row_to_version
         ()
     )
 
-let version_to_row ~create_or_update db id version =
+let version_to_sql ~create_or_update db id version =
   (* FIXME: transaction, maybe [Connection.with_transaction] *)
   let (monolithic_lilypond, monolithic_bars, monolithic_or_default_structure) =
     match Model_builder.Core.Version.content version with
@@ -169,7 +224,7 @@ let get id : Model_builder.Core.Version.entry option Lwt.t =
       )
     )
   in
-  Version_sql.Single.get db ~id (row_to_version ~id ~arrangers ~sources ~destructured_parts ~destructured_transitions)
+  Version_sql.Single.get db ~id (sql_to_version ~id ~arrangers ~sources ~destructured_parts ~destructured_transitions)
 
 let get_all () =
   Connection.with_ @@ fun db ->
@@ -219,7 +274,7 @@ let get_all () =
     )
     ();%lwt
   Version_sql.List.get_all db (fun ~id ->
-    row_to_version
+    sql_to_version
       ~id
       ~arrangers: (List.rev @@ Hashtbl.find_all arrangers id)
       ~sources: (List.rev @@ Hashtbl.find_all sources id)
@@ -276,7 +331,7 @@ let get_all_for_tune tune_id =
     )
     ();%lwt
   Version_sql.List.get_all_for_tune db ~tune_id (fun ~id ->
-    row_to_version
+    sql_to_version
       ~id
       ~tune_id
       ~arrangers: (List.rev @@ Hashtbl.find_all arrangers id)
@@ -288,12 +343,12 @@ let get_all_for_tune tune_id =
 let create version =
   Connection.with_ @@ fun db ->
   let%lwt id = Globally_unique_id.make db Version in
-  version_to_row ~create_or_update: Version_sql.create db id version;%lwt
+  version_to_sql ~create_or_update: Version_sql.create db id version;%lwt
   lwt id
 
 let update id version =
   Connection.with_ @@ fun db ->
-  version_to_row ~create_or_update: (fun db ~id -> Version_sql.update db ~id) db id version
+  version_to_sql ~create_or_update: (fun db ~id -> Version_sql.update db ~id) db id version
 
 let delete id =
   Connection.with_ @@ fun db ->

--- a/src/server/database/version.mli
+++ b/src/server/database/version.mli
@@ -19,3 +19,11 @@ val update : Version_id.t -> t -> unit Lwt.t
 val delete : Version_id.t -> unit Lwt.t
 
 val search : ?threshold: float -> string -> (Version_row.t * float) list Lwt.t
+
+(** {2 Utilities for other models} *)
+
+val sql_to_name :
+  id: string ->
+  name: string ->
+  k: (Version_name.t -> 'w) ->
+  'w

--- a/src/server/database/version.mli
+++ b/src/server/database/version.mli
@@ -1,3 +1,4 @@
+open Nes
 open Dancelor_common
 open Model_new
 
@@ -16,3 +17,5 @@ val create : t -> Version_id.t Lwt.t
 val update : Version_id.t -> t -> unit Lwt.t
 
 val delete : Version_id.t -> unit Lwt.t
+
+val search : ?threshold: float -> NEString.t option -> (Version_row.t * float) list Lwt.t

--- a/src/server/database/version.mli
+++ b/src/server/database/version.mli
@@ -18,4 +18,4 @@ val update : Version_id.t -> t -> unit Lwt.t
 
 val delete : Version_id.t -> unit Lwt.t
 
-val search : ?threshold: float -> NEString.t option -> (Version_row.t * float) list Lwt.t
+val search : ?threshold: float -> string -> (Version_row.t * float) list Lwt.t

--- a/src/server/database/version.sql
+++ b/src/server/database/version.sql
@@ -228,7 +228,9 @@ SELECT
 FROM (
     SELECT
         "id",
-	@needle {Some { word_similarity(@needle, "name") } | None { '1' } } AS "score"
+        CASE WHEN @needle = '' THEN 1.0
+             ELSE word_similarity(@needle, "name")
+        END AS "score"
     FROM "tune"
 ) AS "search"
 JOIN "tune" ON "tune"."id" = "search"."id"

--- a/src/server/database/version.sql
+++ b/src/server/database/version.sql
@@ -215,7 +215,8 @@ INSERT INTO "version_destructured_transitions" (
 
 -- @search
 SELECT
-    "search"."score",
+    CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END AS "score",
+    -- ids
     "version"."id",
     "tune"."id" AS "tune_id",
     -- version
@@ -225,17 +226,9 @@ SELECT
     -- tune
     "name" AS "tune_name",
     "kind" AS "tune_kind"
-FROM (
-    SELECT
-        "id",
-        CASE WHEN @needle = '' THEN 1.0
-             ELSE word_similarity(@needle, "name")
-        END AS "score"
-    FROM "tune"
-) AS "search"
-JOIN "tune" ON "tune"."id" = "search"."id"
-JOIN "version" ON "version"."tune_id" = "tune"."id"
-WHERE "search"."score" >= @threshold
+FROM "version"
+JOIN "tune" ON "version"."tune_id" = "tune"."id"
+WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
 ORDER BY "score" DESC, "name" ASC;
 
 -- @get_all_arrangers_new

--- a/src/server/database/version.sql
+++ b/src/server/database/version.sql
@@ -212,3 +212,43 @@ INSERT INTO "version_destructured_transitions" (
     @melody,
     @chords
 );
+
+-- @search
+SELECT
+    "search"."score",
+    "version"."id",
+    "tune"."id" AS "tune_id",
+    -- version
+    "version"."disambiguation",
+    "version"."monolithic_bars",
+    "version"."monolithic_or_default_structure",
+    -- tune
+    "name" AS "tune_name",
+    "kind" AS "tune_kind"
+FROM (
+    SELECT
+        "id",
+	@needle {Some { word_similarity(@needle, "name") } | None { '1' } } AS "score"
+    FROM "tune"
+) AS "search"
+JOIN "tune" ON "tune"."id" = "search"."id"
+JOIN "version" ON "version"."tune_id" = "tune"."id"
+WHERE "search"."score" >= @threshold
+ORDER BY "score" DESC, "name" ASC;
+
+-- @get_all_arrangers_new
+SELECT
+    "version_id",
+    "person"."id",
+    "person"."name"
+FROM "version_arrangers"
+JOIN "person" ON "version_arrangers"."arranger_id" = "person"."id";
+
+-- @get_all_sources_new
+SELECT
+    "version_id",
+    "source"."id",
+    "source"."name",
+    "source"."short_name"
+FROM "version_sources"
+JOIN "source" ON "version_sources"."source_id" = "source"."id";

--- a/src/server/permission.ml
+++ b/src/server/permission.ml
@@ -14,6 +14,7 @@ include With_reason
 let can can = fun env -> lwt (can (Environment.user env) <> None)
 
 let can_get_public env entry = can (flip can_get_public entry) env
+let can_get_public_new env entry = can (flip can_get_public_new entry) env
 
 let can_create_public env = can can_create_public env
 

--- a/tests/database.sql
+++ b/tests/database.sql
@@ -27,6 +27,13 @@ CREATE SCHEMA "dancelor";
 
 
 --
+-- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS "pg_trgm" WITH SCHEMA "dancelor";
+
+
+--
 -- Name: globally_unique_id_type; Type: TYPE; Schema: dancelor; Owner: -
 --
 
@@ -623,6 +630,7 @@ INSERT INTO "dancelor"."migrations" ("name", "applied_at") VALUES ('m056_2026_05
 INSERT INTO "dancelor"."migrations" ("name", "applied_at") VALUES ('m057_2026_05_add_unique_constraint_book_viewers_book_id_viewer_id', '2026-05-15 10:17:27.616679+00');
 INSERT INTO "dancelor"."migrations" ("name", "applied_at") VALUES ('m058_2026_05_add_unique_constraint_book_owners_book_id_owner_id', '2026-05-15 10:17:27.622578+00');
 INSERT INTO "dancelor"."migrations" ("name", "applied_at") VALUES ('m059_2026_05_string_to_nestring_option', '2026-05-29 14:34:07.211399+00');
+INSERT INTO "dancelor"."migrations" ("name", "applied_at") VALUES ('m060_2026_06_create_extension_pg_trgm', '2026-06-09 16:38:11.371022+00');
 
 
 --

--- a/tests/schemaNixosTest.nix
+++ b/tests/schemaNixosTest.nix
@@ -48,6 +48,7 @@
       ## The `dancelor` database now has the schema produced by migrations.
       ## Create a second database and import schema.sql directly into it.
       machine.succeed("sudo -u postgres createdb --owner=dancelor dancelor_from_schema")
+      machine.succeed("sudo -u dancelor psql --dbname=dancelor_from_schema --file=${../src/server/database/schema-extra-before.sql}")
       machine.succeed("sudo -u dancelor psql --dbname=dancelor_from_schema --file=${../src/server/database/schema.sql}")
 
       ## Dump both schemas and compare.


### PR DESCRIPTION
In doing so, write the first queries that return rows directly rather than returning old models then converting to rows. They proved pretty easy to write!

The new search's performances are drastically better than the old one's, but for now it only support textual search. I will over time add more expressivity when we feel the need.