### PR TITLE
Use PostgreSQL's `<%` similarity binary operator

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -184,11 +184,12 @@
           ##
           ##   - https://github.com/ygrek/sqlgg/pull/276 - support for ALTER COLUMN
           ##   - https://github.com/ygrek/sqlgg/pull/281 - support for CREATE TYPE AS ENUM
+          ##   - <no PR yet> - support for pgtrgm functions and operators
           ##
           owner = "niols"; # FIXME: should be ygrek
           repo = pname;
-          rev = "24f8ad1c456f63d60a5fb62467035be214108b3d";
-          sha256 = "sha256-tz50B8xyb2wm5Gkz7lMez8lmXFMssVi8TjdMz/Cjwuo=";
+          rev = "e4a9544ee9c205a48d328e697708dfa6cb904873";
+          sha256 = "sha256-S43s0lDUjGFpscN/y8HnLTnwonvxor5h8N2MqvrUc44=";
         };
         nativeBuildInputs = with pkgs.ocamlPackages; [
           menhir

--- a/src/server/database/book.ml
+++ b/src/server/database/book.ml
@@ -16,14 +16,13 @@ let sql_to_row ~id ~name ~date ~authors ~permission ~(k : Book_row.t -> 'w) : 'w
     permission = (match permission with `Everyone -> Everyone | `Owner -> Owner | `Viewer -> Viewer | `Omniscient_administrator -> Omniscient_administrator);
   }
 
-let search ~user ?(threshold = 0.3) needle : (Book_row.t * float) list Lwt.t =
+let search ~user needle : (Book_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
   let%lwt authors = Utils.fold_to_hashtbl Book_sql.Fold.get_all_authors_new db (fun k ~book_id -> Person.sql_to_name ~k: (k book_id)) in
   Book_sql.List.search
     db
     ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "")
     ~needle
-    ~threshold
     (fun ~score ~id ->
       sql_to_row
         ~id

--- a/src/server/database/book.mli
+++ b/src/server/database/book.mli
@@ -15,4 +15,4 @@ val update : Book_id.t -> t -> Entry.Access.Private.t -> unit Lwt.t
 
 val delete : Book_id.t -> unit Lwt.t
 
-val search : user: User_id.t option -> ?threshold: float -> string -> (Book_row.t * float) list Lwt.t
+val search : user: User_id.t option -> string -> (Book_row.t * float) list Lwt.t

--- a/src/server/database/book.sql
+++ b/src/server/database/book.sql
@@ -316,7 +316,7 @@ SELECT * FROM (
     LEFT JOIN "book_owners" ON "book_owners"."book_id" = "book"."id" AND "book_owners"."owner_id" = @user_id
     LEFT JOIN "book_viewers" ON "book_viewers"."book_id" = "book"."id" AND "book_viewers"."viewer_id" = @user_id
     LEFT JOIN "user" ON "user"."id" = @user_id
-    WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
+    WHERE (@needle = '' OR @needle <% "name")
 ) AS "book+"
 WHERE "book+"."permission" IS NOT NULL
 ORDER BY "score" DESC, "name" ASC;

--- a/src/server/database/dance.ml
+++ b/src/server/database/dance.ml
@@ -26,13 +26,12 @@ let sql_to_row ~id ~name ~kind ~devisers ~disambiguation ~(k : Dance_row.t -> 'w
     disambiguation;
   }
 
-let search ?(threshold = 0.3) needle : (Dance_row.t * float) list Lwt.t =
+let search needle : (Dance_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
   let%lwt devisers = Utils.fold_to_hashtbl Dance_sql.Fold.get_all_devisers_new db (fun k ~dance_id -> Person.sql_to_name ~k: (k dance_id)) in
   Dance_sql.List.search
     db
     ~needle
-    ~threshold
     (fun ~score ~id -> sql_to_row ~id ~devisers: (Hashtbl.find_all devisers id) ~k: (Pair.snoc score))
 
 let sql_to_dance

--- a/src/server/database/dance.mli
+++ b/src/server/database/dance.mli
@@ -16,4 +16,4 @@ val update : t Entry.id -> t -> unit Lwt.t
 
 val delete : t Entry.id -> unit Lwt.t
 
-val search : ?threshold: float -> string -> (Dance_row.t * float) list Lwt.t
+val search : string -> (Dance_row.t * float) list Lwt.t

--- a/src/server/database/dance.sql
+++ b/src/server/database/dance.sql
@@ -127,7 +127,7 @@ SELECT
     "kind",
     "disambiguation"
 FROM "dance"
-WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
+WHERE (@needle = '' OR @needle <% "name")
 ORDER BY "score" DESC, "name" ASC;
 
 -- @get_all_devisers_new

--- a/src/server/database/person.ml
+++ b/src/server/database/person.ml
@@ -13,12 +13,11 @@ let sql_to_name ~id ~name ~(k : Person_name.t -> 'w) : 'w =
 let sql_to_row ~id ~name (k : Person_row.t -> 'w) : 'w =
   k {id = Entry.Id.of_string_exn id; name}
 
-let search ?(threshold = 0.3) needle : (Person_row.t * float) list Lwt.t =
+let search needle : (Person_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
   Person_sql.List.search
     db
     ~needle
-    ~threshold
     (fun ~score -> sql_to_row (Pair.snoc score))
 
 let sql_to_person

--- a/src/server/database/person.mli
+++ b/src/server/database/person.mli
@@ -16,7 +16,7 @@ val update : Person_id.t -> t -> unit Lwt.t
 
 val delete : Person_id.t -> unit Lwt.t
 
-val search : ?threshold: float -> string -> (Person_row.t * float) list Lwt.t
+val search : string -> (Person_row.t * float) list Lwt.t
 
 (** {2 Utilities for other models} *)
 

--- a/src/server/database/person.sql
+++ b/src/server/database/person.sql
@@ -60,5 +60,5 @@ SELECT
     "id",
     "name"
 FROM "person"
-WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
+WHERE (@needle = '' OR @needle <% "name")
 ORDER BY "score" DESC, "name" ASC;

--- a/src/server/database/set.ml
+++ b/src/server/database/set.ml
@@ -17,7 +17,7 @@ let sql_to_row ~id ~name ~kind ~conceptors ~tunes ~permission ~(k : Set_row.t ->
     permission = (match permission with `Everyone -> Everyone | `Owner -> Owner | `Viewer -> Viewer | `Omniscient_administrator -> Omniscient_administrator);
   }
 
-let search ~user ?(threshold = 0.3) needle : (Set_row.t * float) list Lwt.t =
+let search ~user needle : (Set_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
   let%lwt tunes = Utils.fold_to_hashtbl Set_sql.Fold.get_all_tunes_new db (fun k ~set_id -> Version.sql_to_name ~k: (k set_id)) in
   let%lwt conceptors = Utils.fold_to_hashtbl Set_sql.Fold.get_all_conceptors_new db (fun k ~set_id -> Person.sql_to_name ~k: (k set_id)) in
@@ -25,7 +25,6 @@ let search ~user ?(threshold = 0.3) needle : (Set_row.t * float) list Lwt.t =
     db
     ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "")
     ~needle
-    ~threshold
     (fun ~score ~id ->
       sql_to_row
         ~id

--- a/src/server/database/set.mli
+++ b/src/server/database/set.mli
@@ -15,4 +15,4 @@ val update : Set_id.t -> t -> Entry.Access.Private.t -> unit Lwt.t
 
 val delete : Set_id.t -> unit Lwt.t
 
-val search : user: User_id.t option -> ?threshold: float -> string -> (Set_row.t * float) list Lwt.t
+val search : user: User_id.t option -> string -> (Set_row.t * float) list Lwt.t

--- a/src/server/database/set.sql
+++ b/src/server/database/set.sql
@@ -205,7 +205,7 @@ SELECT * FROM (
     LEFT JOIN "set_owners" ON "set_owners"."set_id" = "set"."id" AND "set_owners"."owner_id" = @user_id
     LEFT JOIN "set_viewers" ON "set_viewers"."set_id" = "set"."id" AND "set_viewers"."viewer_id" = @user_id
     LEFT JOIN "user" ON "user"."id" = @user_id
-    WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
+    WHERE (@needle = '' OR @needle <% "name")
 ) AS "set+"
 WHERE "set+"."permission" IS NOT NULL
 ORDER BY "score" DESC, "name" ASC;

--- a/src/server/database/source.ml
+++ b/src/server/database/source.ml
@@ -14,13 +14,12 @@ let sql_to_short_name ~id ~name ~short_name ~(k : Source_short_name.t -> 'w) : '
 let sql_to_row ~id ~name ~date ~editors ~(k : Source_row.t -> 'w) : 'w =
   k {id = Entry.Id.of_string_exn id; name; date = Option.map (Option.get % PartialDate.from_string) date; editors}
 
-let search ?(threshold = 0.3) needle : (Source_row.t * float) list Lwt.t =
+let search needle : (Source_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
   let%lwt editors = Utils.fold_to_hashtbl Source_sql.Fold.get_all_editors_new db (fun k ~source_id -> Person.sql_to_name ~k: (k source_id)) in
   Source_sql.List.search
     db
     ~needle
-    ~threshold
     (fun ~score ~id -> sql_to_row ~id ~editors: (Hashtbl.find_all editors id) ~k: (Pair.snoc score))
 
 let sql_to_source

--- a/src/server/database/source.mli
+++ b/src/server/database/source.mli
@@ -20,7 +20,7 @@ val with_cover : Source_id.t -> (string option -> 'a Lwt.t) -> 'a Lwt.t
 (** Given a source id, produce a file containing the cover and pass its path to
     the callback. [None] means that there is no cover for this source. *)
 
-val search : ?threshold: float -> string -> (Source_row.t * float) list Lwt.t
+val search : string -> (Source_row.t * float) list Lwt.t
 
 (** {2 Utilities for other models} *)
 

--- a/src/server/database/source.sql
+++ b/src/server/database/source.sql
@@ -95,7 +95,7 @@ SELECT
     "name",
     "date"
 FROM "source"
-WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
+WHERE (@needle = '' OR @needle <% "name")
 ORDER BY "score" DESC, "name" ASC;
 
 -- @get_all_editors_new

--- a/src/server/database/tune.ml
+++ b/src/server/database/tune.ml
@@ -15,13 +15,12 @@ let sql_to_row ~id ~name ~kind ~composers ~(k : Tune_row.t -> 'w) : 'w =
     composers;
   }
 
-let search ?(threshold = 0.3) needle : (Tune_row.t * float) list Lwt.t =
+let search needle : (Tune_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
   let%lwt composers = Utils.fold_to_hashtbl Tune_sql.Fold.get_all_composers_new db (fun k ~tune_id -> Person.sql_to_name ~k: (k tune_id)) in
   Tune_sql.List.search
     db
     ~needle
-    ~threshold
     (fun ~score ~id -> sql_to_row ~id ~composers: (Hashtbl.find_all composers id) ~k: (Pair.snoc score))
 
 let sql_to_tune

--- a/src/server/database/tune.mli
+++ b/src/server/database/tune.mli
@@ -16,7 +16,7 @@ val update : t Entry.id -> t -> unit Lwt.t
 
 val delete : t Entry.id -> unit Lwt.t
 
-val search : ?threshold: float -> string -> (Tune_row.t * float) list Lwt.t
+val search : string -> (Tune_row.t * float) list Lwt.t
 
 (** {2 Utilities for other models} *)
 

--- a/src/server/database/tune.sql
+++ b/src/server/database/tune.sql
@@ -150,7 +150,7 @@ SELECT
     "name",
     "kind"
 FROM "tune"
-WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
+WHERE (@needle = '' OR @needle <% "name")
 ORDER BY "score" DESC, "name" ASC;
 
 -- @get_all_composers_new

--- a/src/server/database/version.ml
+++ b/src/server/database/version.ml
@@ -45,7 +45,7 @@ let sql_to_row
     content;
   }
 
-let search ?(threshold = 0.3) needle : (Version_row.t * float) list Lwt.t =
+let search needle : (Version_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
   let%lwt tune_composers = Utils.fold_to_hashtbl Tune_sql.Fold.get_all_composers_new db (fun k ~tune_id -> Person.sql_to_name ~k: (k tune_id)) in
   let%lwt sources = Utils.fold_to_hashtbl Version_sql.Fold.get_all_sources_new db (fun k ~version_id -> Source.sql_to_short_name ~k: (k version_id)) in
@@ -53,7 +53,6 @@ let search ?(threshold = 0.3) needle : (Version_row.t * float) list Lwt.t =
   Version_sql.List.search
     db
     ~needle
-    ~threshold
     (fun ~score ~id ~tune_id ->
       sql_to_row
         ~id

--- a/src/server/database/version.mli
+++ b/src/server/database/version.mli
@@ -18,7 +18,7 @@ val update : Version_id.t -> t -> unit Lwt.t
 
 val delete : Version_id.t -> unit Lwt.t
 
-val search : ?threshold: float -> string -> (Version_row.t * float) list Lwt.t
+val search : string -> (Version_row.t * float) list Lwt.t
 
 (** {2 Utilities for other models} *)
 

--- a/src/server/database/version.sql
+++ b/src/server/database/version.sql
@@ -228,7 +228,7 @@ SELECT
     "kind" AS "tune_kind"
 FROM "version"
 JOIN "tune" ON "version"."tune_id" = "tune"."id"
-WHERE (CASE WHEN @needle = '' THEN 1.0 ELSE word_similarity(@needle, "name") END) >= @threshold
+WHERE (@needle = '' OR @needle <% "name")
 ORDER BY "score" DESC, "name" ASC;
 
 -- @get_all_arrangers_new


### PR DESCRIPTION
This makes the code slightly cleaner, opens the door to using an index for such queries, but it does require patching sqlgg to support the operators. The sqlgg patch also adds known types for `word_similarity`, among other pgtrgm-related improvements.