### PR TITLE
Better error message on `Other Cohttp method

### DIFF
--- a/src/madge/request.ml
+++ b/src/madge/request.ml
@@ -36,7 +36,7 @@ let cohttp_code_meth_to_meth = function
   | `OPTIONS -> OPTIONS
   | `TRACE -> TRACE
   | `CONNECT -> CONNECT
-  | `Other _ -> assert false (* FIXME *)
+  | `Other x -> failwithf "cohttp_code_meth_to_meth: unsupported Cohttp.Code.meth: `Other %s" x
 
 let is_safe = function
   | GET | HEAD | OPTIONS | TRACE -> true


### PR DESCRIPTION
Sometimes (rarely) I can see logs like:

```
error │ server │ Uncaught Lwt exception in the callback:
  File "src/madge/request.ml", line 39, characters 16-22: Assertion failed
  Raised at Madge__Request.cohttp_code_meth_to_meth in file "src/madge/request.ml", line 39, characters 16-28
  Called from Dune__exe__Server.callback.(fun) in file "src/server/server.ml", line 43, characters 15-77
  Called from Lwt.Sequential_composition.backtrace_catch in file "src/core/lwt.ml", line 2090, characters 10-14
  Re-raised at Dune__exe__Server.catchall.(fun) in file "src/server/server.ml", lines 23-28, characters 4-14
```

and this doesn't give me much to work with. I hope I understand a bit better what is going on next time I look at this.