### PR TITLE
Abstract Hashtbl in database utils; fix missing reverse

### DIFF
--- a/src/server/database/book.ml
+++ b/src/server/database/book.ml
@@ -19,7 +19,7 @@ let sql_to_row ~id ~name ~date ~authors ~permission ~(k : Book_row.t -> 'w) : 'w
 
 let search ~user needle : (Book_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
-  let%lwt authors = Utils.fold_to_hashtbl Book_sql.Fold.get_all_authors_new db (fun k ~book_id -> Person.sql_to_name ~k: (k book_id)) in
+  let%lwt authors = Utils.fold_to_tbl Book_sql.Fold.get_all_authors_new db (fun k ~book_id -> Person.sql_to_name ~k: (k book_id)) in
   Book_sql.List.search
     db
     ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "")
@@ -27,7 +27,7 @@ let search ~user needle : (Book_row.t * float) list Lwt.t =
     (fun ~score ~id ->
       sql_to_row
         ~id
-        ~authors: (Hashtbl.find_all authors id)
+        ~authors: (Utils.tbl_get authors id)
         ~k: (Pair.snoc score)
     )
 

--- a/src/server/database/dance.ml
+++ b/src/server/database/dance.ml
@@ -28,11 +28,11 @@ let sql_to_row ~id ~name ~kind ~devisers ~disambiguation ~(k : Dance_row.t -> 'w
 
 let search needle : (Dance_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
-  let%lwt devisers = Utils.fold_to_hashtbl Dance_sql.Fold.get_all_devisers_new db (fun k ~dance_id -> Person.sql_to_name ~k: (k dance_id)) in
+  let%lwt devisers = Utils.fold_to_tbl Dance_sql.Fold.get_all_devisers_new db (fun k ~dance_id -> Person.sql_to_name ~k: (k dance_id)) in
   Dance_sql.List.search
     db
     ~needle
-    (fun ~score ~id -> sql_to_row ~id ~devisers: (Hashtbl.find_all devisers id) ~k: (Pair.snoc score))
+    (fun ~score ~id -> sql_to_row ~id ~devisers: (Utils.tbl_get devisers id) ~k: (Pair.snoc score))
 
 let sql_to_dance
     ~id

--- a/src/server/database/set.ml
+++ b/src/server/database/set.ml
@@ -20,8 +20,8 @@ let sql_to_row ~id ~name ~kind ~conceptors ~tunes ~permission ~(k : Set_row.t ->
 
 let search ~user needle : (Set_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
-  let%lwt tunes = Utils.fold_to_hashtbl Set_sql.Fold.get_all_tunes_new db (fun k ~set_id -> Version.sql_to_name ~k: (k set_id)) in
-  let%lwt conceptors = Utils.fold_to_hashtbl Set_sql.Fold.get_all_conceptors_new db (fun k ~set_id -> Person.sql_to_name ~k: (k set_id)) in
+  let%lwt tunes = Utils.fold_to_tbl Set_sql.Fold.get_all_tunes_new db (fun k ~set_id -> Version.sql_to_name ~k: (k set_id)) in
+  let%lwt conceptors = Utils.fold_to_tbl Set_sql.Fold.get_all_conceptors_new db (fun k ~set_id -> Person.sql_to_name ~k: (k set_id)) in
   Set_sql.List.search
     db
     ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "")
@@ -29,8 +29,8 @@ let search ~user needle : (Set_row.t * float) list Lwt.t =
     (fun ~score ~id ->
       sql_to_row
         ~id
-        ~tunes: (Hashtbl.find_all tunes id)
-        ~conceptors: (Hashtbl.find_all conceptors id)
+        ~tunes: (Utils.tbl_get tunes id)
+        ~conceptors: (Utils.tbl_get conceptors id)
         ~k: (Pair.snoc score)
     )
 

--- a/src/server/database/source.ml
+++ b/src/server/database/source.ml
@@ -16,11 +16,11 @@ let sql_to_row ~id ~name ~date ~editors ~(k : Source_row.t -> 'w) : 'w =
 
 let search needle : (Source_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
-  let%lwt editors = Utils.fold_to_hashtbl Source_sql.Fold.get_all_editors_new db (fun k ~source_id -> Person.sql_to_name ~k: (k source_id)) in
+  let%lwt editors = Utils.fold_to_tbl Source_sql.Fold.get_all_editors_new db (fun k ~source_id -> Person.sql_to_name ~k: (k source_id)) in
   Source_sql.List.search
     db
     ~needle
-    (fun ~score ~id -> sql_to_row ~id ~editors: (Hashtbl.find_all editors id) ~k: (Pair.snoc score))
+    (fun ~score ~id -> sql_to_row ~id ~editors: (Utils.tbl_get editors id) ~k: (Pair.snoc score))
 
 let sql_to_source
     ~id

--- a/src/server/database/tune.ml
+++ b/src/server/database/tune.ml
@@ -17,11 +17,11 @@ let sql_to_row ~id ~name ~kind ~composers ~(k : Tune_row.t -> 'w) : 'w =
 
 let search needle : (Tune_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
-  let%lwt composers = Utils.fold_to_hashtbl Tune_sql.Fold.get_all_composers_new db (fun k ~tune_id -> Person.sql_to_name ~k: (k tune_id)) in
+  let%lwt composers = Utils.fold_to_tbl Tune_sql.Fold.get_all_composers_new db (fun k ~tune_id -> Person.sql_to_name ~k: (k tune_id)) in
   Tune_sql.List.search
     db
     ~needle
-    (fun ~score ~id -> sql_to_row ~id ~composers: (Hashtbl.find_all composers id) ~k: (Pair.snoc score))
+    (fun ~score ~id -> sql_to_row ~id ~composers: (Utils.tbl_get composers id) ~k: (Pair.snoc score))
 
 let sql_to_tune
     ~id

--- a/src/server/database/utils.ml
+++ b/src/server/database/utils.ml
@@ -1,6 +1,11 @@
 open Nes
 
-let fold_to_hashtbl fold db k =
-  let tbl = Hashtbl.create 8 in
-  fold db (k (fun key value () -> Hashtbl.add tbl key value)) ();%lwt
-  lwt tbl
+type ('k, 'v) tbl = Tbl of ('k, 'v) Hashtbl.t
+
+let fold_to_tbl fold db k =
+  let t = Hashtbl.create 8 in
+  fold db (k (fun key value () -> Hashtbl.add t key value)) ();%lwt
+  lwt @@ Tbl t
+
+let tbl_get (Tbl t) k =
+  List.rev @@ Hashtbl.find_all t k

--- a/src/server/database/version.ml
+++ b/src/server/database/version.ml
@@ -47,9 +47,9 @@ let sql_to_row
 
 let search needle : (Version_row.t * float) list Lwt.t =
   Connection.with_ @@ fun db ->
-  let%lwt tune_composers = Utils.fold_to_hashtbl Tune_sql.Fold.get_all_composers_new db (fun k ~tune_id -> Person.sql_to_name ~k: (k tune_id)) in
-  let%lwt sources = Utils.fold_to_hashtbl Version_sql.Fold.get_all_sources_new db (fun k ~version_id -> Source.sql_to_short_name ~k: (k version_id)) in
-  let%lwt arrangers = Utils.fold_to_hashtbl Version_sql.Fold.get_all_arrangers_new db (fun k ~version_id -> Person.sql_to_name ~k: (k version_id)) in
+  let%lwt tune_composers = Utils.fold_to_tbl Tune_sql.Fold.get_all_composers_new db (fun k ~tune_id -> Person.sql_to_name ~k: (k tune_id)) in
+  let%lwt sources = Utils.fold_to_tbl Version_sql.Fold.get_all_sources_new db (fun k ~version_id -> Source.sql_to_short_name ~k: (k version_id)) in
+  let%lwt arrangers = Utils.fold_to_tbl Version_sql.Fold.get_all_arrangers_new db (fun k ~version_id -> Person.sql_to_name ~k: (k version_id)) in
   Version_sql.List.search
     db
     ~needle
@@ -57,9 +57,9 @@ let search needle : (Version_row.t * float) list Lwt.t =
       sql_to_row
         ~id
         ~tune_id
-        ~tune_composers: (Hashtbl.find_all tune_composers tune_id)
-        ~sources: (Hashtbl.find_all sources id)
-        ~arrangers: (Hashtbl.find_all arrangers id)
+        ~tune_composers: (Utils.tbl_get tune_composers tune_id)
+        ~sources: (Utils.tbl_get sources id)
+        ~arrangers: (Utils.tbl_get arrangers id)
         ~k: (Pair.snoc score)
     )
 


### PR DESCRIPTION
`Hashtbl.find_all` returns bindings in reverse order, which is fine
sometimes and sometimes not. We now enforce going through the
`tbl_get` helper which systematically reverses, ensuring that we
respect the SQL's `ORDER BY` if there is one.