### PR TITLE
Three fixes with respect to versions pre-rendering

### DIFF
--- a/src/nes/nesLwt_stream.ml
+++ b/src/nes/nesLwt_stream.ml
@@ -3,38 +3,6 @@ include Lwt_stream
 let get_available_1 stream =
   NesList.to_option (get_available_up_to 1 stream)
 
-let choose_biased =
-  (* Given a list of streams, attempt to get a value from them in a
-     non-blocking way. If they have no value, check whether they are
-     closed, and filter them out. Return the list of streams that are
-     still in the game. *)
-  let get_first_available streams =
-    let rec aux prev_streams = function
-      | [] -> Error (List.rev prev_streams)
-      | stream :: streams ->
-        match get_available_1 stream with
-        | Some x -> Ok (x, List.rev_append prev_streams streams)
-        | None when is_closed stream -> aux prev_streams streams
-        | None -> aux (stream :: prev_streams) streams
-    in
-    aux [] streams
-  in
-  let rec next_biased streams =
-    match get_first_available streams with
-    | Ok (x, streams) -> Lwt.return_some (x, streams)
-    | Error [] -> Lwt.return_none
-    | Error streams ->
-      (* wait for at least one element to be available *)
-      let%lwt _ = Lwt.pick (List.map peek streams) in
-      next_biased streams
-  in
-  fun streams ->
-    let streams = ref streams in
-    Lwt_stream.from @@ fun () ->
-    match%lwt next_biased !streams with
-    | None -> Lwt.return_none
-    | Some (x, streams') -> streams := streams'; Lwt.return_some x
-
 type 'a next = Next of 'a | Last of 'a
 
 let from_next f =

--- a/src/nes/nesLwt_stream.mli
+++ b/src/nes/nesLwt_stream.mli
@@ -11,13 +11,6 @@ val get_available_1 : 'a t -> 'a option
     [None], in this case, represents the absence of elements, not the end of the
     stream. *)
 
-val choose_biased : 'a t list -> 'a t
-(** Given a list of stream, produce a stream that reads from all of
-    them. When several streams have available values, prefer the ones
-    earlier in the list. When no streams have available values, pick
-    the first value that gets available. The stream closes when all
-    the streams from the list have closed. *)
-
 val return_lwt : 'a Lwt.t -> 'a t [@@alert unsafe "Lwt_stream.return_lwt has the bad practice of ignoring its argument; use NesLwt_stream.return_lwt' instead"]
 
 val return_lwt' : 'a Lwt.t -> 'a t

--- a/src/server/controller/book.ml
+++ b/src/server/controller/book.ml
@@ -114,7 +114,7 @@ let build_pdf env id book_params rendering_params =
   in
   let%lwt book = Model_to_renderer.book_to_renderer_book' book book_params in
   let%lwt book_pdf_arg = Model_to_renderer.renderer_book_to_renderer_book_pdf_arg book rendering_params pdf_metadata in
-  uncurry Job.register_job <$> Renderer.make_book_pdf book_pdf_arg
+  uncurry Job.register_job_and_file <$> Renderer.make_book_pdf book_pdf_arg
 
 let search env slice filter =
   let%lwt result = search env slice filter in

--- a/src/server/controller/job.ml
+++ b/src/server/controller/job.ml
@@ -41,24 +41,27 @@ type job_and_file = {
     registered in {!job_of_expr}. *)
 let job_and_file_of_id : (Job_id.t, job_and_file) Hashtbl.t = Hashtbl.create 8
 
-let register_job (expr : expr) (file : string) : Job_id.t Endpoints.Job.registration_response =
-  let job_and_file =
-    match Hashtbl.find_opt job_of_expr expr with
-    | Some job when not (is_failed !(job.state)) ->
-      (*  if there is a job for the same expression, but not necessarily the
-          same file, we can just return without starting an actual job; we do
-          not do so for failed job in case the failure was transient *)
-      {id = Job_id.create (); job; file}
-    | _ ->
-      (* otherwise, we really do have to register a new job *)
-      let id = Job_id.create () in
-      let job = {expr; state = ref Pending} in
-      (* NOTE: we use {!Hashtbl.replace} because {!Hashtbl.add} might keep failed jobs *)
-      Hashtbl.replace job_of_expr expr job;
-      add_pending_job (Some job);
-      Log.debug (fun m -> m "Registered new job: %s" (expr_val expr));
-      {id; job; file}
-  in
+let register_job ~add_pending (expr : expr) : job =
+  match Hashtbl.find_opt job_of_expr expr with
+  | Some job when not (is_failed !(job.state)) ->
+    (*  if there is a job for the same expression, but not necessarily the
+        same file, we can just return without starting an actual job; we do
+        not do so for failed job in case the failure was transient *)
+    Log.debug (fun m -> m "Found existing and non-failed job");
+    job
+  | _ ->
+    (* otherwise, we really do have to register a new job *)
+    let job = {expr; state = ref Pending} in
+    (* NOTE: we use {!Hashtbl.replace} because {!Hashtbl.add} might keep failed jobs *)
+    Hashtbl.replace job_of_expr expr job;
+    if add_pending then add_pending_job (Some job);
+    Log.debug (fun m -> m "Registered new job: %s" (expr_val expr));
+    job
+
+let register_job_and_file (expr : expr) (file : string) : Job_id.t Endpoints.Job.registration_response =
+  Log.debug (fun m -> m "register_job");
+  let job = register_job ~add_pending: true expr in
+  let job_and_file = {id = Job_id.create (); job; file} in
   Hashtbl.add job_and_file_of_id job_and_file.id job_and_file;
   (* shortcut for when the job is already successful. this is not possible with
      new job, but will often happen with cache hits. it saves one network call

--- a/src/server/controller/set.ml
+++ b/src/server/controller/set.ml
@@ -138,7 +138,7 @@ let build_pdf env id set_params rendering_params =
   in
   let%lwt set = Model_to_renderer.set_to_renderer_set' (Entry.id set) set_params in
   let%lwt book_pdf_arg = Model_to_renderer.renderer_set_to_renderer_book_pdf_arg set rendering_params pdf_metadata in
-  uncurry Job.register_job <$> Renderer.make_book_pdf book_pdf_arg
+  uncurry Job.register_job_and_file <$> Renderer.make_book_pdf book_pdf_arg
 
 let search env slice filter =
   let%lwt result = search env slice filter in

--- a/src/server/controller/version.ml
+++ b/src/server/controller/version.ml
@@ -247,7 +247,7 @@ let build_pdf env id version_params rendering_params =
   let version_params = Model.Version_parameters.set_display_name (NEString.of_string_exn " ") version_params in
   let%lwt set = Model_to_renderer.versions_to_renderer_set' (NEList.singleton (Entry.id version, version_params)) set_params in
   let%lwt book_pdf_arg = Model_to_renderer.renderer_set_to_renderer_book_pdf_arg set rendering_params pdf_metadata in
-  uncurry Job.register_job <$> Renderer.make_book_pdf book_pdf_arg
+  uncurry Job.register_job_and_file <$> Renderer.make_book_pdf book_pdf_arg
 
 (** For use in {!Routine}. *)
 let render_snippets ?version_params version =
@@ -259,7 +259,7 @@ let register_snippets_job ?version_params version =
   let%lwt svg_job = Renderer.make_tune_svg tune in
   let%lwt ogg_job = Renderer.make_tune_ogg tune in
   lwt @@
-    match (uncurry Job.register_job svg_job, uncurry Job.register_job ogg_job) with
+    match (uncurry Job.register_job_and_file svg_job, uncurry Job.register_job_and_file ogg_job) with
     | Already_succeeded svg_job_id, Already_succeeded ogg_job_id -> Endpoints.Job.Already_succeeded Endpoints.Version.Snippet_ids.{svg_job_id; ogg_job_id}
     | Registered svg_job_id, Already_succeeded ogg_job_id -> Registered {svg_job_id; ogg_job_id}
     | Already_succeeded svg_job_id, Registered ogg_job_id -> Registered {svg_job_id; ogg_job_id}

--- a/src/server/routine.ml
+++ b/src/server/routine.ml
@@ -9,53 +9,57 @@ let all_versions =
   Lwt_stream.concat @@
   Lwt_stream.from @@ fun () ->
   Lwt_unix.sleep 600.;%lwt
+  Log.debug (fun m -> m "Generating the list of all versions for pre-rendering");
   (some % Lwt_stream.of_list) <$> Database.Version.get_all ()
 
+(** A stream of prerendering jobs for versions in the database. This
+    contains only pending and failed jobs, the others do not need to
+    run again. *)
 let all_versions_prerendering_job =
-  Lwt_stream.map_s
+  Lwt_stream.filter_map_s
     (fun version ->
-      let%lwt name = Model.Version.one_name' version in
-      Log.debug (fun m -> m "Prerendering snippets for version %s" (NEString.to_string name));
-      let%lwt render_snippets_expr = Controller.Version.render_snippets (Entry.value version) in
-      lwt
-        Controller.Job.{
-          expr = render_snippets_expr;
-          state = ref Pending
-        }
+      let run_with_params =
+        match Model.Version.content' version with
+        | No_content -> `No_need_to_run
+        | Monolithic _ -> `Run_with_params None
+        | Destructured {default_structure; _} -> `Run_with_params (some @@ Model.Version_parameters.make ~structure: default_structure ()) (* FIXME: at the moment, this requires us to keep this in sync with the client, when this should be the default *)
+      in
+      match run_with_params with
+      | `No_need_to_run -> lwt_none
+      | `Run_with_params params ->
+        let%lwt job =
+          Controller.Job.register_job ~add_pending: false
+          <$> Controller.Version.render_snippets ?version_params: params (Entry.value version)
+        in
+        match !(job.state) with
+        | Failed _ | Pending -> lwt_some job
+        | _ -> lwt_none
     )
     all_versions
 
-let run_jobs_from ~max_concurrency =
+let run_jobs_from ~tag ~max_concurrency =
   Lwt_stream.iter_n
     ~max_concurrency
     (fun job ->
       try%lwt
+        Log.debug (fun m -> m "run_jobs_from %s: %s" tag Controller.Job.(expr_val job.expr));
         Controller.Job.run_job job
       with
         | exn -> !(Lwt.async_exception_hook) exn; lwt_unit
     )
 
 let initialiase_job_runners ~threads =
-  assert (threads >= 2);
+  (* NOTE: There used to be something fancy where we had exactly
+     [threads] threads, and one would pick up pre-rendering jobs when
+     there was no pending job. As it turns out, reading in several
+     places from the same stream is not safe and can lead to
+     duplicates. There are ways around it, but the amount of code that
+     it produces is not worth the trouble. *)
   Lwt.async (fun () ->
-    (* Have one thread pick jobs from the version prerendering queue when
-       there is nothing in the pending jobs queue. *)
-    run_jobs_from
-      ~max_concurrency: 1
-      (
-        Lwt_stream.choose_biased [
-          Controller.Job.pending_jobs;
-          all_versions_prerendering_job;
-        ]
-      )
-  );
-  Lwt.async (fun () ->
-    (* The others (at least one) are fully dedicated to user jobs,
-       even when there are none, so they are ready to start
-       immediately when a new job is created. *)
-    run_jobs_from
-      ~max_concurrency: (threads - 1)
-      Controller.Job.pending_jobs
+    Lwt.join [
+      run_jobs_from ~tag: "prerender" ~max_concurrency: 1 all_versions_prerendering_job;
+      run_jobs_from ~tag: "pending" ~max_concurrency: threads Controller.Job.pending_jobs;
+    ]
   )
 
 let initialise () =


### PR DESCRIPTION
1. The pre-rendering would not be putting jobs in the job cache,
   meaning that they would be in the Nix cache but it would still
   take a while to look at them once.

2. The pre-rendering of destructured versions would pre-render without
   parameters, which is not what the client does.

3. It turns out that the `NesLwt_stream.biased` was correct, but it is
   `Lwt_stream` itself that doesn't guarantee that several readers
   will get distinct values. Simplify the routine job runners.