### PR TITLE
Use `sqlgg`'s feature to attach `Entry.Id.t` types to all id columns

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -185,11 +185,12 @@
           ##   - https://github.com/ygrek/sqlgg/pull/276 - support for ALTER COLUMN
           ##   - https://github.com/ygrek/sqlgg/pull/281 - support for CREATE TYPE AS ENUM
           ##   - <no PR yet> - support for pgtrgm functions and operators
+          ##   - https://github.com/ygrek/sqlgg/pull/288 - attach column [sqlgg] metadata to quoted identifiers
           ##
           owner = "niols"; # FIXME: should be ygrek
           repo = pname;
-          rev = "e4a9544ee9c205a48d328e697708dfa6cb904873";
-          sha256 = "sha256-S43s0lDUjGFpscN/y8HnLTnwonvxor5h8N2MqvrUc44=";
+          rev = "520b6ca76916be253b49ef49b92e407a19f5f2a9";
+          sha256 = "sha256-lJHUbwBCGT2LZIOxO0OJH5YHkezTW4GGUUmoHKYPklM=";
         };
         nativeBuildInputs = with pkgs.ocamlPackages; [
           menhir

--- a/src/server/database/book.ml
+++ b/src/server/database/book.ml
@@ -77,11 +77,7 @@ let get_content_for ~user db book_ids =
   let%lwt conceptors_for = Set.get_conceptors_for db `All in
   let%lwt content_versions_for = get_content_versions_for db book_ids in
   Utils.fold_to_get
-    (
-      Book_sql.Fold.get_content_for
-        ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "")
-        ~book_ids
-    )
+    (Book_sql.Fold.get_content_for ~user_id: user ~book_ids)
     db
     (fun
         k
@@ -166,33 +162,30 @@ let get_content_for ~user db book_ids =
     )
 
 let get_row ~user id : Book_row.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   let%lwt authors = (fun f -> f id) <$> get_authors_for db (`One_of [id]) in
   Book_sql.Single.get_row
     db
-    ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "")
+    ~user_id: user
     ~id
     (book_sql_to_row ~id ~authors ~k: Fun.id)
 
 let get_rows ~user ids : (Book_id.t, Book_row.t) Utils.tbl Lwt.t =
-  let ids = List.map Entry.Id.to_string ids in
   Connection.with_ @@ fun db ->
   let%lwt authors_for = get_authors_for db (`One_of ids) in
   Utils.fold_to_tbl
-    (Book_sql.Fold.get_rows ~ids ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: ""))
+    (Book_sql.Fold.get_rows ~ids ~user_id: user)
     db
-    (fun k ~id -> book_sql_to_row ~id ~authors: (authors_for id) ~k: (k @@ Entry.Id.of_string_exn id))
+    (fun k ~id -> book_sql_to_row ~id ~authors: (authors_for id) ~k: (k id))
 
 let get_view ~user id : Book_view.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   let%lwt authors = (fun f -> f id) <$> get_authors_for db (`One_of [id]) in
   let%lwt sources = (fun f -> f id) <$> get_sources_for db (`One_of [id]) in
   let%lwt content = (fun f -> f id) <$> get_content_for ~user db (`One_of [id]) in
   Book_sql.Single.get_view
     db
-    ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "")
+    ~user_id: user
     ~id
     (book_sql_to_view ~id ~authors ~sources ~content ~k: Fun.id)
 
@@ -202,12 +195,12 @@ let search ~user query : (Book_row.t * float) list Lwt.t =
   let%lwt authors_for = get_authors_for db `All in
   Book_sql.List.search
     db
-    ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "")
+    ~user_id: user
     ~terms
-    ~author: (Utils.list_option_map_to_sql Entry.Id.to_string author)
-    ~contains_version: (Utils.list_option_map_to_sql Entry.Id.to_string contains_version)
-    ~contains_tune: (Utils.list_option_map_to_sql Entry.Id.to_string contains_tune)
-    ~contains_set: (Utils.list_option_map_to_sql Entry.Id.to_string contains_set)
+    ~author: (Utils.option_to_sql author)
+    ~contains_version: (Utils.option_to_sql contains_version)
+    ~contains_tune: (Utils.option_to_sql contains_tune)
+    ~contains_set: (Utils.option_to_sql contains_set)
     (fun ~score ~id ->
       book_sql_to_row
         ~id
@@ -248,7 +241,7 @@ let sql_to_book
     | _ -> assert false
   in
   Entry.make
-    ~id: (Entry.Id.of_string_exn id)
+    ~id
     ~meta: (Entry.Meta.make ~created_at ~modified_at ())
     ~access: (Entry.Access.Private.make ~owners: (NEList.of_list_exn owners) ~visibility ())
     (
@@ -265,7 +258,6 @@ let sql_to_book
 
 let book_to_sql ~create_or_update db id book =
   (* FIXME: transaction, maybe [Connection.with_transaction] *)
-  let id = Entry.Id.to_string id in
   ignore
   <$> create_or_update
       db
@@ -281,7 +273,7 @@ let book_to_sql ~create_or_update db id book =
       <$> Book_sql.add_one_author
           db
           ~book_id: id
-          ~author_id: (Entry.Id.to_string author)
+          ~author_id: author
     )
     (Model_builder.Core.Book.authors book);%lwt
   ignore <$> Book_sql.delete_all_sources db ~book_id: id;%lwt
@@ -291,7 +283,7 @@ let book_to_sql ~create_or_update db id book =
       <$> Book_sql.add_one_source
           db
           ~book_id: id
-          ~source_id: (Entry.Id.to_string source)
+          ~source_id: source
     )
     (Model_builder.Core.Book.sources book);%lwt
   ignore <$> Book_sql.delete_all_content db ~book_id: id;%lwt
@@ -315,8 +307,8 @@ let book_to_sql ~create_or_update db id book =
           ~index: (Int64.of_int content_index)
           ~page_type
           ~part_title: (Option.map NEString.to_string part_title)
-          ~dance_id: (Option.map Entry.Id.to_string dance_id)
-          ~set_id: (Option.map Entry.Id.to_string set_id)
+          ~dance_id
+          ~set_id
           ~set_parameter_display_name: (Option.map NEString.to_string @@ Model_builder.Core.Set_parameters.display_name set_params)
           ~set_parameter_display_conceptor: (Option.map NEString.to_string @@ Model_builder.Core.Set_parameters.display_conceptor set_params)
           ~set_parameter_display_kind: (Option.map NEString.to_string @@ Model_builder.Core.Set_parameters.display_kind set_params)
@@ -335,7 +327,7 @@ let book_to_sql ~create_or_update db id book =
               ~book_id: id
               ~content_index: (Int64.of_int content_index)
               ~index: (Int64.of_int index)
-              ~version_id: (Entry.Id.to_string version)
+              ~version_id: version
               ~version_parameter_transposition_semitones: (Option.map (Int64.of_int % Transposition.to_semitones) @@ Model_builder.Core.Version_parameters.transposition params)
               ~version_parameter_first_bar: (Option.map Int64.of_int @@ Model_builder.Core.Version_parameters.first_bar params)
               ~version_parameter_clef: (Option.map Music.Clef.to_string @@ Model_builder.Core.Version_parameters.clef params)
@@ -360,7 +352,7 @@ let sql_to_content_version ~k = fun
   ->
   k
     (
-      Entry.Id.of_string_exn version_id,
+      version_id,
       Model_builder.Core.Version_parameters.make
         ?transposition: (Option.map (Transposition.from_semitones % Int64.to_int) version_parameter_transposition_semitones)
         ?first_bar: (Option.map Int64.to_int version_parameter_first_bar)
@@ -409,20 +401,19 @@ let sql_to_content_item ~versions_and_params ~k = fun
   k @@
     match page_type with
     | `Part -> Model_builder.Core.Book.Part (NEString.of_string_exn @@ Option.get part_title)
-    | `Dance_only -> Dance (Entry.Id.of_string_exn (Option.get dance_id), Dance_only)
-    | `Dance_versions -> Dance (Entry.Id.of_string_exn (Option.get dance_id), Dance_versions (NEList.of_list_exn versions_and_params))
-    | `Dance_set -> Dance (Entry.Id.of_string_exn (Option.get dance_id), Dance_set (Entry.Id.of_string_exn (Option.get set_id), set_params))
+    | `Dance_only -> Dance (Option.get dance_id, Dance_only)
+    | `Dance_versions -> Dance (Option.get dance_id, Dance_versions (NEList.of_list_exn versions_and_params))
+    | `Dance_set -> Dance (Option.get dance_id, Dance_set (Option.get set_id, set_params))
     | `Versions -> Versions (NEList.of_list_exn versions_and_params)
-    | `Set -> Set (Entry.Id.of_string_exn (Option.get set_id), set_params)
+    | `Set -> Set (Option.get set_id, set_params)
     | _ -> assert false
 
 let get id : Model_builder.Core.Book.entry option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
-  let%lwt authors = Book_sql.List.get_authors db ~book_id: id (fun ~author_id -> Entry.Id.of_string_exn author_id) in
-  let%lwt sources = Book_sql.List.get_sources db ~book_id: id (fun ~source_id -> Entry.Id.of_string_exn source_id) in
-  let%lwt owners = Entry_sql.List.get_owners db ~entry_id: id (fun ~owner_id -> Entry.Id.of_string_exn owner_id) in
-  let%lwt viewers = Entry_sql.List.get_viewers db ~entry_id: id (fun ~viewer_id -> Entry.Id.of_string_exn viewer_id) in
+  let%lwt authors = Book_sql.List.get_authors db ~book_id: id (fun ~author_id -> author_id) in
+  let%lwt sources = Book_sql.List.get_sources db ~book_id: id (fun ~source_id -> source_id) in
+  let%lwt owners = Entry_sql.List.get_owners db ~entry_id: id (fun ~owner_id -> owner_id) in
+  let%lwt viewers = Entry_sql.List.get_viewers db ~entry_id: id (fun ~viewer_id -> viewer_id) in
   let content_versions = Hashtbl.create 8 in
   Book_sql.Fold.get_content_versions db ~book_id: id (fun ~content_index -> sql_to_content_version ~k: (fun v () -> Hashtbl.add content_versions content_index v)) ();%lwt
   let%lwt content = Book_sql.List.get_content db ~book_id: id (fun ~index -> sql_to_content_item ~versions_and_params: (List.rev @@ Hashtbl.find_all content_versions index) ~k: Fun.id) in
@@ -442,10 +433,9 @@ let update id book access =
 
 let delete id =
   Connection.with_ @@ fun db ->
-  let book_id = Entry.Id.to_string id in
-  ignore <$> Book_sql.delete_all_authors db ~book_id;%lwt
-  ignore <$> Book_sql.delete_all_content_versions db ~book_id;%lwt
-  ignore <$> Book_sql.delete_all_content db ~book_id;%lwt
-  ignore <$> Book_sql.delete_all_sources db ~book_id;%lwt
-  ignore <$> Book_sql.delete db ~id: book_id;%lwt
+  ignore <$> Book_sql.delete_all_authors db ~book_id: id;%lwt
+  ignore <$> Book_sql.delete_all_content_versions db ~book_id: id;%lwt
+  ignore <$> Book_sql.delete_all_content db ~book_id: id;%lwt
+  ignore <$> Book_sql.delete_all_sources db ~book_id: id;%lwt
+  ignore <$> Book_sql.delete db ~id;%lwt
   Entry_new.delete db id

--- a/src/server/database/book.sql
+++ b/src/server/database/book.sql
@@ -248,9 +248,9 @@ SELECT * FROM (
         END AS "permission"
     FROM "book"
     JOIN "entry" ON "entry"."id" = "book"."id"
-    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = @user_id
-    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = @user_id
-    LEFT JOIN "user" ON "user"."id" = @user_id
+    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "user" ON "user"."id" = (@user_id :: TEXT NULL)
     WHERE "book"."id" = @id
 ) AS "book+"
 WHERE "book+"."permission" IS NOT NULL
@@ -271,9 +271,9 @@ SELECT * FROM (
         END AS "permission"
     FROM "book"
     JOIN "entry" ON "entry"."id" = "book"."id"
-    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = @user_id
-    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = @user_id
-    LEFT JOIN "user" ON "user"."id" = @user_id
+    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "user" ON "user"."id" = (@user_id :: TEXT NULL)
     WHERE "book"."id" IN @ids
 ) AS "book+"
 WHERE "book+"."permission" IS NOT NULL;
@@ -294,9 +294,9 @@ SELECT * FROM (
         END AS "permission"
     FROM "book"
     JOIN "entry" ON "entry"."id" = "book"."id"
-    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = @user_id
-    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = @user_id
-    LEFT JOIN "user" ON "user"."id" = @user_id
+    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "user" ON "user"."id" = (@user_id :: TEXT NULL)
     WHERE "book"."id" = @id
 ) AS "book+"
 WHERE "book+"."permission" IS NOT NULL
@@ -318,9 +318,9 @@ SELECT * FROM (
         END AS "permission"
     FROM "book"
     JOIN "entry" ON "entry"."id" = "book"."id"
-    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = @user_id
-    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = @user_id
-    LEFT JOIN "user" ON "user"."id" = @user_id
+    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "user" ON "user"."id" = (@user_id :: TEXT NULL)
     WHERE
 	(@terms = '' OR @terms <% "name")
         AND @author { Some { EXISTS (SELECT 1 FROM "book_authors" WHERE "book_id" = "book"."id" AND "author_id" IN @author) } | None { TRUE } }
@@ -393,9 +393,9 @@ FROM "book_content"
 LEFT JOIN "dance" ON "book_content"."dance_id" = "dance"."id"
 LEFT JOIN "set" ON "book_content"."set_id" = "set"."id"
 LEFT JOIN "entry" AS "set_entry" ON "set_entry"."id" = "set"."id"
-LEFT JOIN "entry_owners" AS "set_entry_owners" ON "set_entry_owners"."entry_id" = "set_entry"."id" AND "set_entry_owners"."owner_id" = @user_id
-LEFT JOIN "entry_viewers" AS "set_entry_viewers" ON "set_entry_viewers"."entry_id" = "set_entry"."id" AND "set_entry_viewers"."viewer_id" = @user_id
-LEFT JOIN "user" ON "user"."id" = @user_id
+LEFT JOIN "entry_owners" AS "set_entry_owners" ON "set_entry_owners"."entry_id" = "set_entry"."id" AND "set_entry_owners"."owner_id" = (@user_id :: TEXT NULL)
+LEFT JOIN "entry_viewers" AS "set_entry_viewers" ON "set_entry_viewers"."entry_id" = "set_entry"."id" AND "set_entry_viewers"."viewer_id" = (@user_id :: TEXT NULL)
+LEFT JOIN "user" ON "user"."id" = (@user_id :: TEXT NULL)
 WHERE @book_ids { One_of { "book_id" IN @book_ids } | All { TRUE } }
 ORDER BY "index";
 

--- a/src/server/database/dance.ml
+++ b/src/server/database/dance.ml
@@ -19,19 +19,16 @@ let get_tunes_for db dance_ids =
   Utils.fold_to_get (Dance_sql.Fold.get_tunes_for ~dance_ids) db (fun k ~dance_id ~id -> tune_sql_to_row ~id ~composers: (composers_for id) ~k: (k dance_id))
 
 let get_row id : Dance_row.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   let%lwt devisers = (fun f -> f id) <$> get_devisers_for db (`One_of [id]) in
   Dance_sql.Single.get_row db ~id (dance_sql_to_row ~id ~devisers ~k: Fun.id)
 
 let get_rows ids : (Dance_id.t, Dance_row.t) Utils.tbl Lwt.t =
-  let ids = List.map Entry.Id.to_string ids in
   Connection.with_ @@ fun db ->
   let%lwt devisers_for = get_devisers_for db (`One_of ids) in
-  Utils.fold_to_tbl (Dance_sql.Fold.get_rows ~ids) db (fun k ~id -> dance_sql_to_row ~id ~devisers: (devisers_for id) ~k: (k @@ Entry.Id.of_string_exn id))
+  Utils.fold_to_tbl (Dance_sql.Fold.get_rows ~ids) db (fun k ~id -> dance_sql_to_row ~id ~devisers: (devisers_for id) ~k: (k id))
 
 let get_view id : Dance_view.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   let%lwt extra_names = (fun f -> f id) <$> get_extra_names_for db (`One_of [id]) in
   let%lwt devisers = (fun f -> f id) <$> get_devisers_for db (`One_of [id]) in
@@ -45,7 +42,7 @@ let search query : (Dance_row.t * float) list Lwt.t =
   Dance_sql.List.search
     db
     ~terms
-    ~deviser: (Utils.list_option_map_to_sql Entry.Id.to_string deviser)
+    ~deviser: (Utils.option_to_sql deviser)
     (fun ~score ~id -> dance_sql_to_row ~id ~devisers: (devisers_for id) ~k: (Pair.snoc score))
 
 (* Legacy *)
@@ -67,7 +64,7 @@ let sql_to_dance
     ~devisers
   =
   Entry.make
-    ~id: (Entry.Id.of_string_exn id)
+    ~id
     ~meta: (Entry.Meta.make ~created_at ~modified_at ())
     ~access: Entry.Access.Public
     (
@@ -84,7 +81,6 @@ let sql_to_dance
 
 let dance_to_sql ~create_or_update db id dance =
   (* FIXME: transaction, maybe [Connection.with_transaction] *)
-  let id = Entry.Id.to_string id in
   ignore
   <$> create_or_update
       db
@@ -109,15 +105,14 @@ let dance_to_sql ~create_or_update db id dance =
           db
           ~dance_id: id
           ~index: (Int64.of_int index)
-          ~deviser_id: (Entry.Id.to_string deviser_id)
+          ~deviser_id
     )
     (Model_builder.Core.Dance.devisers dance)
 
 let get id : Model_builder.Core.Dance.entry option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   let%lwt extra_names = Dance_sql.List.get_extra_names db ~dance_id: id (fun ~extra_name -> NEString.of_string_exn extra_name) in
-  let%lwt devisers = Dance_sql.List.get_devisers db ~dance_id: id (fun ~deviser_id -> Entry.Id.of_string_exn deviser_id) in
+  let%lwt devisers = Dance_sql.List.get_devisers db ~dance_id: id (fun ~deviser_id -> deviser_id) in
   Dance_sql.Single.get db ~id (sql_to_dance ~id ~extra_names ~devisers)
 
 let create dance =
@@ -133,8 +128,7 @@ let update id dance =
 
 let delete id =
   Connection.with_ @@ fun db ->
-  let dance_id = Entry.Id.to_string id in
-  ignore <$> Dance_sql.delete_all_extra_names db ~dance_id;%lwt
-  ignore <$> Dance_sql.delete_all_devisers db ~dance_id;%lwt
-  ignore <$> Dance_sql.delete db ~id: dance_id;%lwt
+  ignore <$> Dance_sql.delete_all_extra_names db ~dance_id: id;%lwt
+  ignore <$> Dance_sql.delete_all_devisers db ~dance_id: id;%lwt
+  ignore <$> Dance_sql.delete db ~id;%lwt
   Entry_new.delete db id

--- a/src/server/database/entry.sql
+++ b/src/server/database/entry.sql
@@ -91,9 +91,9 @@ SELECT
     "entry"."id",
     "entry"."type"
 FROM "entry"
-LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = @user_id
-LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = @user_id
-LEFT JOIN "user" ON "user"."id" = @user_id
+LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = (@user_id :: TEXT NULL)
+LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = (@user_id :: TEXT NULL)
+LEFT JOIN "user" ON "user"."id" = (@user_id :: TEXT NULL)
 WHERE
     ("entry"."type" IN ('Person', 'Dance', 'Source', 'Tune', 'Version', 'User'))
     OR ("entry"."visibility" = 'Everyone')

--- a/src/server/database/entry_new.ml
+++ b/src/server/database/entry_new.ml
@@ -28,7 +28,7 @@ let classify_type : type_ -> [`Public | `Private] = function
   | `Set | `Book -> `Private
 
 let get_type db id =
-  Entry_sql.get_type db ~id: (Entry.Id.to_string id)
+  Entry_sql.get_type db ~id
 
 (** Handles only the insertion into the ["entry"] table. In
     particular, this function does not handle the ["entry_viewers"]
@@ -38,7 +38,7 @@ let insert_to_entry_table db ~visibility type_ =
     let id = Entry.Id.make () in
     match%lwt get_type db id with
     | None ->
-      let%lwt _ = Entry_sql.register db ~id: (Entry.Id.to_string id) ~type_ ~visibility in
+      let%lwt _ = Entry_sql.register db ~id ~type_ ~visibility in
       lwt @@ Entry.Id.unsafe_coerce id
     | Some _ ->
       make () (* extremely unlikely *)
@@ -55,24 +55,24 @@ let insert_or_update_private db access f =
     | Select_viewers viewers -> (`Select_viewers, NEList.to_list viewers)
   in
   let%lwt id = f visibility in
-  ignore <$> Entry_sql.delete_all_viewers db ~entry_id: (Entry.Id.to_string id);%lwt
+  ignore <$> Entry_sql.delete_all_viewers db ~entry_id: id;%lwt
   Lwt_list.iter_s
     (fun viewer ->
       ignore
       <$> Entry_sql.add_one_viewer
           db
-          ~entry_id: (Entry.Id.to_string id)
-          ~viewer_id: (Entry.Id.to_string viewer)
+          ~entry_id: id
+          ~viewer_id: viewer
     )
     viewers;%lwt
-  ignore <$> Entry_sql.delete_all_owners db ~entry_id: (Entry.Id.to_string id);%lwt
+  ignore <$> Entry_sql.delete_all_owners db ~entry_id: id;%lwt
   Lwt_list.iter_s
     (fun owner ->
       ignore
       <$> Entry_sql.add_one_owner
           db
-          ~entry_id: (Entry.Id.to_string id)
-          ~owner_id: (Entry.Id.to_string owner)
+          ~entry_id: id
+          ~owner_id: owner
     )
     (NEList.to_list @@ Entry.Access.Private.owners access);%lwt
   lwt id
@@ -91,14 +91,13 @@ let make_private db type_ access =
 let update_private_access db id access =
   ignore
   <$> insert_or_update_private db access @@ fun visibility ->
-    ignore <$> Entry_sql.update_visibility db ~id: (Entry.Id.to_string id) ~visibility: (Some visibility);%lwt
+    ignore <$> Entry_sql.update_visibility db ~id ~visibility: (Some visibility);%lwt
     lwt id
 
 let touch db id =
-  ignore <$> Entry_sql.touch db ~id: (Entry.Id.to_string id)
+  ignore <$> Entry_sql.touch db ~id
 
 let delete db id =
-  let id = Entry.Id.to_string id in
   ignore <$> Entry_sql.delete_all_owners db ~entry_id: id;%lwt
   ignore <$> Entry_sql.delete_all_viewers db ~entry_id: id;%lwt
   ignore <$> Entry_sql.delete db ~id
@@ -108,16 +107,17 @@ let get_newest ~user ~limit =
   Connection.with_ @@ fun db ->
   (* FIXME: some gymnastics just because users aren't handled so well yet *)
   let%lwt newest =
-    Entry_sql.List.get_newest db ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "") ~limit: (Int64.of_int limit) (fun ~id ~type_ ->
-      match type_ with
-      | `Book -> some @@ Any_id.Book (Entry.Id.of_string_exn id)
-      | `Dance -> some @@ Any_id.Dance (Entry.Id.of_string_exn id)
-      | `Person -> some @@ Any_id.Person (Entry.Id.of_string_exn id)
-      | `Set -> some @@ Any_id.Set (Entry.Id.of_string_exn id)
-      | `Source -> some @@ Any_id.Source (Entry.Id.of_string_exn id)
-      | `Tune -> some @@ Any_id.Tune (Entry.Id.of_string_exn id)
-      | `User -> None (* FIXME: we should handle users too *)
-      | `Version -> some @@ Any_id.Version (Entry.Id.of_string_exn id)
+    Entry_sql.List.get_newest db ~user_id: user ~limit: (Int64.of_int limit) (fun ~id ~type_ ->
+      some @@
+        match type_ with
+        | `Book -> Any_id.book @@ Entry.Id.unsafe_coerce id
+        | `Dance -> Any_id.dance @@ Entry.Id.unsafe_coerce id
+        | `Person -> Any_id.person @@ Entry.Id.unsafe_coerce id
+        | `Set -> Any_id.set @@ Entry.Id.unsafe_coerce id
+        | `Source -> Any_id.source @@ Entry.Id.unsafe_coerce id
+        | `Tune -> Any_id.tune @@ Entry.Id.unsafe_coerce id
+        | `User -> Any_id.user @@ Entry.Id.unsafe_coerce id
+        | `Version -> Any_id.version @@ Entry.Id.unsafe_coerce id
     )
   in
   lwt @@ List.filter_map Fun.id newest

--- a/src/server/database/person.ml
+++ b/src/server/database/person.ml
@@ -8,22 +8,18 @@ open Sql_to_view
 module Person_sql = Person_sql.Sqlgg(Sqlgg_postgresql)
 
 let get_row id : Person_row.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   Person_sql.Single.get_row db ~id (person_sql_to_row ~id ~k: Fun.id)
 
 let get_rows ids : (Person_id.t, Person_row.t) Utils.tbl Lwt.t =
-  let ids = List.map Entry.Id.to_string ids in
   Connection.with_ @@ fun db ->
-  Utils.fold_to_tbl (Person_sql.Fold.get_rows ~ids) db (fun k ~id -> person_sql_to_row ~id ~k: (k @@ Entry.Id.of_string_exn id))
+  Utils.fold_to_tbl (Person_sql.Fold.get_rows ~ids) db (fun k ~id -> person_sql_to_row ~id ~k: (k id))
 
 let get_view id : Person_view.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   Person_sql.Single.get_view db ~id (person_sql_to_view ~id ~k: Fun.id)
 
 let get_row_for_user (id : User_id.t) : Person_row.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   Person_sql.Single.get_row_for_user db ~id (person_sql_to_row ~k: Fun.id)
 
@@ -50,7 +46,7 @@ let sql_to_person
     ~modified_at
   =
   Entry.make
-    ~id: (Entry.Id.of_string_exn id)
+    ~id
     ~meta: (Entry.Meta.make ~created_at ~modified_at ())
     ~access: Entry.Access.Public
     (
@@ -64,14 +60,13 @@ let sql_to_person
 
 let person_to_sql ~create_or_update id person =
   create_or_update
-    ~id: (Entry.Id.to_string id)
+    ~id
     ~name: (NEString.to_string @@ Model_builder.Core.Person.name person)
     ~scddb_id: (Option.map Int64.of_int @@ Model_builder.Core.Person.scddb_id person)
     ~composed_tunes_are_public: (Model_builder.Core.Person.composed_tunes_are_public person)
     ~published_tunes_are_public: (Model_builder.Core.Person.published_tunes_are_public person)
 
 let get id : Model_builder.Core.Person.entry option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   Person_sql.Single.get db ~id (sql_to_person ~id)
 
@@ -88,5 +83,5 @@ let update id person =
 
 let delete id =
   Connection.with_ @@ fun db ->
-  ignore <$> Person_sql.delete db ~id: (Entry.Id.to_string id);%lwt
+  ignore <$> Person_sql.delete db ~id;%lwt
   Entry_new.delete db id

--- a/src/server/database/schema.sql
+++ b/src/server/database/schema.sql
@@ -2,6 +2,7 @@ CREATE TYPE "type" AS ENUM ('Person', 'User', 'Dance', 'Source', 'Tune', 'Versio
 CREATE TYPE "visibility" AS ENUM ('Owners_only', 'Everyone', 'Select_viewers');
 
 CREATE TABLE "entry" (
+    -- [sqlgg] module=Sql_types.Entry_id_conv
     "id" VARCHAR(14) NOT NULL,
     "type" "type" NOT NULL,
     "created_at" TIMESTAMP NOT NULL,
@@ -11,6 +12,7 @@ CREATE TABLE "entry" (
 );
 
 CREATE TABLE "person" (
+    -- [sqlgg] module=Sql_types.Person_id_conv
     "id" VARCHAR(14) NOT NULL PRIMARY KEY,
     "name" VARCHAR(256) NOT NULL,
     "scddb_id" INT,
@@ -22,12 +24,14 @@ CREATE TABLE "person" (
 CREATE TYPE "role" AS ENUM ('Normal_user', 'Maintainer', 'Administrator');
 
 CREATE TABLE "user" (
+    -- [sqlgg] module=Sql_types.User_id_conv
     "id" VARCHAR(14) NOT NULL PRIMARY KEY,
     "username" VARCHAR(256) NOT NULL UNIQUE,
     "password" VARCHAR(256),
     "password_reset_token_hash" VARCHAR(256),
     "password_reset_token_max_date" TIMESTAMP,
     "omniscience" BOOLEAN NOT NULL,
+    -- [sqlgg] module=Sql_types.Person_id_conv
     "person_id" VARCHAR(14) NULL,
     "role" "role" NOT NULL,
     CONSTRAINT "fk_user_id" FOREIGN KEY ("id") REFERENCES "entry" ("id"),
@@ -35,7 +39,9 @@ CREATE TABLE "user" (
 );
 
 CREATE TABLE "entry_viewers" (
+    -- [sqlgg] module=Sql_types.Entry_id_conv
     "entry_id" VARCHAR(14) NOT NULL,
+    -- [sqlgg] module=Sql_types.User_id_conv
     "viewer_id" VARCHAR(14) NOT NULL,
     CONSTRAINT "fk_entry_viewers_entry_id" FOREIGN KEY ("entry_id") REFERENCES "entry" ("id"),
     CONSTRAINT "fk_entry_viewers_viewer_id" FOREIGN KEY ("viewer_id") REFERENCES "user" ("id"),
@@ -43,7 +49,9 @@ CREATE TABLE "entry_viewers" (
 );
 
 CREATE TABLE "entry_owners" (
+    -- [sqlgg] module=Sql_types.Entry_id_conv
     "entry_id" VARCHAR(14) NOT NULL,
+    -- [sqlgg] module=Sql_types.User_id_conv
     "owner_id" VARCHAR(14) NOT NULL,
     CONSTRAINT "fk_entry_owners_entry_id" FOREIGN KEY ("entry_id") REFERENCES "entry" ("id"),
     CONSTRAINT "fk_entry_owners_owner_id" FOREIGN KEY ("owner_id") REFERENCES "user" ("id"),
@@ -51,6 +59,7 @@ CREATE TABLE "entry_owners" (
 );
 
 CREATE TABLE "remember_me_tokens" (
+    -- [sqlgg] module=Sql_types.User_id_conv
     "user_id" VARCHAR(14) NOT NULL,
     "key" VARCHAR(256) NOT NULL,
     "hash" VARCHAR(256) NOT NULL,
@@ -60,6 +69,7 @@ CREATE TABLE "remember_me_tokens" (
 );
 
 CREATE TABLE "source" (
+    -- [sqlgg] module=Sql_types.Source_id_conv
     "id" VARCHAR(14) NOT NULL PRIMARY KEY,
     "cover" BYTEA DEFAULT NULL,
     "name" VARCHAR(256) NOT NULL,
@@ -71,7 +81,9 @@ CREATE TABLE "source" (
 );
 
 CREATE TABLE "source_editors" (
+    -- [sqlgg] module=Sql_types.Source_id_conv
     "source_id" VARCHAR(14) NOT NULL,
+    -- [sqlgg] module=Sql_types.Person_id_conv
     "person_id" VARCHAR(14) NOT NULL,
     CONSTRAINT "fk_source_editors_source_id" FOREIGN KEY ("source_id") REFERENCES "source" ("id"),
     CONSTRAINT "fk_source_editors_person_id" FOREIGN KEY ("person_id") REFERENCES "person" ("id"),
@@ -81,6 +93,7 @@ CREATE TABLE "source_editors" (
 CREATE TYPE "two_chords" AS ENUM ('Dont_know', 'One_chord', 'Two_chords');
 
 CREATE TABLE "dance" (
+    -- [sqlgg] module=Sql_types.Dance_id_conv
     "id" VARCHAR(14) NOT NULL PRIMARY KEY,
     "name" VARCHAR(256) NOT NULL,
     "kind" VARCHAR(32) NOT NULL,
@@ -92,8 +105,10 @@ CREATE TABLE "dance" (
 );
 
 CREATE TABLE "dance_devisers" (
+    -- [sqlgg] module=Sql_types.Dance_id_conv
     "dance_id" VARCHAR(14) NOT NULL,
     "index" INT NOT NULL,
+    -- [sqlgg] module=Sql_types.Person_id_conv
     "deviser_id" VARCHAR(14) NOT NULL,
     CONSTRAINT "fk_dance_devisers_dance_id" FOREIGN KEY ("dance_id") REFERENCES "dance" ("id"),
     CONSTRAINT "fk_dance_devisers_deviser_id" FOREIGN KEY ("deviser_id") REFERENCES "person" ("id"),
@@ -102,6 +117,7 @@ CREATE TABLE "dance_devisers" (
 );
 
 CREATE TABLE "dance_extra_names" (
+    -- [sqlgg] module=Sql_types.Dance_id_conv
     "dance_id" VARCHAR(14) NOT NULL,
     "extra_name" VARCHAR(256) NOT NULL,
     CONSTRAINT "fk_dance_extra_names_dance_id" FOREIGN KEY ("dance_id") REFERENCES "dance" ("id")
@@ -110,6 +126,7 @@ CREATE TABLE "dance_extra_names" (
 CREATE TYPE "kind" AS ENUM ('Jig', 'Reel', 'Strathspey', 'Waltz', 'Polka', 'Jig_9_8', 'Other');
 
 CREATE TABLE "tune" (
+    -- [sqlgg] module=Sql_types.Tune_id_conv
     "id" VARCHAR(14) NOT NULL PRIMARY KEY,
     "name" VARCHAR NOT NULL,
     "remark" VARCHAR,
@@ -120,14 +137,17 @@ CREATE TABLE "tune" (
 );
 
 CREATE TABLE "tune_extra_names" (
+    -- [sqlgg] module=Sql_types.Tune_id_conv
     "tune_id" VARCHAR(14) NOT NULL,
     "extra_name" VARCHAR NOT NULL,
     CONSTRAINT "fk_tune_extra_names_tune_id" FOREIGN KEY ("tune_id") REFERENCES "tune" ("id")
 );
 
 CREATE TABLE "tune_composers" (
+    -- [sqlgg] module=Sql_types.Tune_id_conv
     "tune_id" VARCHAR(14) NOT NULL,
     "index" INT NOT NULL,
+    -- [sqlgg] module=Sql_types.Person_id_conv
     "composer_id" VARCHAR(14) NOT NULL,
     "details" VARCHAR,
     CONSTRAINT "fk_tune_composers_tune_id" FOREIGN KEY ("tune_id") REFERENCES "tune" ("id"),
@@ -137,7 +157,9 @@ CREATE TABLE "tune_composers" (
 );
 
 CREATE TABLE "recommended_tunes" (
+    -- [sqlgg] module=Sql_types.Dance_id_conv
     "dance_id" VARCHAR(14) NOT NULL,
+    -- [sqlgg] module=Sql_types.Tune_id_conv
     "tune_id" VARCHAR(14) NOT NULL,
     CONSTRAINT "fk_recommended_tunes_dance_id" FOREIGN KEY ("dance_id") REFERENCES "dance" ("id"),
     CONSTRAINT "fk_recommended_tunes_tune_id" FOREIGN KEY ("tune_id") REFERENCES "tune" ("id"),
@@ -145,7 +167,9 @@ CREATE TABLE "recommended_tunes" (
 );
 
 CREATE TABLE "version" (
+    -- [sqlgg] module=Sql_types.Version_id_conv
     "id" VARCHAR(14) NOT NULL PRIMARY KEY,
+    -- [sqlgg] module=Sql_types.Tune_id_conv
     "tune_id" VARCHAR(14) NOT NULL,
     "key" VARCHAR(32) NOT NULL,
     "remark" VARCHAR,
@@ -158,7 +182,9 @@ CREATE TABLE "version" (
 );
 
 CREATE TABLE "version_arrangers" (
+    -- [sqlgg] module=Sql_types.Version_id_conv
     "version_id" VARCHAR(14) NOT NULL,
+    -- [sqlgg] module=Sql_types.Person_id_conv
     "arranger_id" VARCHAR(14) NOT NULL,
     CONSTRAINT "fk_version_arrangers_version_id" FOREIGN KEY ("version_id") REFERENCES "version" ("id"),
     CONSTRAINT "fk_version_arrangers_arranger_id" FOREIGN KEY ("arranger_id") REFERENCES "person" ("id"),
@@ -166,7 +192,9 @@ CREATE TABLE "version_arrangers" (
 );
 
 CREATE TABLE "version_sources" (
+    -- [sqlgg] module=Sql_types.Version_id_conv
     "version_id" VARCHAR(14) NOT NULL,
+    -- [sqlgg] module=Sql_types.Source_id_conv
     "source_id" VARCHAR(14) NOT NULL,
     "structure" VARCHAR(32) NOT NULL,
     "details" VARCHAR,
@@ -176,6 +204,7 @@ CREATE TABLE "version_sources" (
 );
 
 CREATE TABLE "version_destructured_parts" (
+    -- [sqlgg] module=Sql_types.Version_id_conv
     "version_id" VARCHAR(14) NOT NULL,
     "part" VARCHAR(32) NOT NULL,
     "melody" VARCHAR NOT NULL,
@@ -185,6 +214,7 @@ CREATE TABLE "version_destructured_parts" (
 );
 
 CREATE TABLE "version_destructured_transitions" (
+    -- [sqlgg] module=Sql_types.Version_id_conv
     "version_id" VARCHAR(14) NOT NULL,
     "from_parts" VARCHAR(32) NOT NULL,
     "to_parts" VARCHAR(32) NOT NULL,
@@ -195,6 +225,7 @@ CREATE TABLE "version_destructured_transitions" (
 );
 
 CREATE TABLE "set" (
+    -- [sqlgg] module=Sql_types.Set_id_conv
     "id" VARCHAR(14) NOT NULL PRIMARY KEY,
     "name" VARCHAR NOT NULL,
     "kind" VARCHAR NOT NULL,
@@ -204,7 +235,9 @@ CREATE TABLE "set" (
 );
 
 CREATE TABLE "set_conceptors" (
+    -- [sqlgg] module=Sql_types.Set_id_conv
     "set_id" VARCHAR(14) NOT NULL,
+    -- [sqlgg] module=Sql_types.Person_id_conv
     "conceptor_id" VARCHAR(14) NOT NULL,
     CONSTRAINT "fk_set_conceptors_set_id" FOREIGN KEY ("set_id") REFERENCES "set" ("id"),
     CONSTRAINT "fk_set_conceptors_conceptor_id" FOREIGN KEY ("conceptor_id") REFERENCES "person" ("id"),
@@ -212,8 +245,10 @@ CREATE TABLE "set_conceptors" (
 );
 
 CREATE TABLE "set_content" (
+    -- [sqlgg] module=Sql_types.Set_id_conv
     "set_id" VARCHAR(14) NOT NULL,
     "index" INT NOT NULL,
+    -- [sqlgg] module=Sql_types.Version_id_conv
     "version_id" VARCHAR(14) NOT NULL,
     "version_parameter_transposition_semitones" INT,
     "version_parameter_first_bar" INT,
@@ -228,6 +263,7 @@ CREATE TABLE "set_content" (
 );
 
 CREATE TABLE "book" (
+    -- [sqlgg] module=Sql_types.Book_id_conv
     "id" VARCHAR(14) NOT NULL PRIMARY KEY,
     "name" VARCHAR NOT NULL,
     "date" VARCHAR,
@@ -237,7 +273,9 @@ CREATE TABLE "book" (
 );
 
 CREATE TABLE "book_authors" (
+    -- [sqlgg] module=Sql_types.Book_id_conv
     "book_id" VARCHAR(14) NOT NULL,
+    -- [sqlgg] module=Sql_types.Person_id_conv
     "author_id" VARCHAR(14) NOT NULL,
     CONSTRAINT "fk_book_authors_book_id" FOREIGN KEY ("book_id") REFERENCES "book" ("id"),
     CONSTRAINT "fk_book_authors_author_id" FOREIGN KEY ("author_id") REFERENCES "person" ("id"),
@@ -245,7 +283,9 @@ CREATE TABLE "book_authors" (
 );
 
 CREATE TABLE "book_sources" (
+    -- [sqlgg] module=Sql_types.Book_id_conv
     "book_id" VARCHAR(14) NOT NULL,
+    -- [sqlgg] module=Sql_types.Source_id_conv
     "source_id" VARCHAR(14) NOT NULL,
     CONSTRAINT "fk_book_sources_book_id" FOREIGN KEY ("book_id") REFERENCES "book" ("id"),
     CONSTRAINT "fk_book_sources_source_id" FOREIGN KEY ("source_id") REFERENCES "source" ("id"),
@@ -255,10 +295,13 @@ CREATE TABLE "book_sources" (
 CREATE TYPE "page_type" AS ENUM ('Part', 'Dance_only', 'Dance_versions', 'Dance_set', 'Versions', 'Set');
 
 CREATE TABLE "book_content" (
+    -- [sqlgg] module=Sql_types.Book_id_conv
     "book_id" VARCHAR(14) NOT NULL,
     "index" INT NOT NULL,
     "part_title" VARCHAR,
+    -- [sqlgg] module=Sql_types.Dance_id_conv
     "dance_id" VARCHAR(14),
+    -- [sqlgg] module=Sql_types.Set_id_conv
     "set_id" VARCHAR(14), -- standalone or within dance
     "set_parameter_display_name" VARCHAR,
     "set_parameter_display_conceptor" VARCHAR,
@@ -278,9 +321,11 @@ CREATE TABLE "book_content" (
 );
 
 CREATE TABLE "book_content_versions" ( -- standalone or within dance
+    -- [sqlgg] module=Sql_types.Book_id_conv
     "book_id" VARCHAR(14) NOT NULL,
     "content_index" INT NOT NULL,
     "index" INT NOT NULL,
+    -- [sqlgg] module=Sql_types.Version_id_conv
     "version_id" VARCHAR(14) NOT NULL,
     "version_parameter_transposition_semitones" INT,
     "version_parameter_first_bar" INT,

--- a/src/server/database/set.ml
+++ b/src/server/database/set.ml
@@ -51,7 +51,7 @@ let get_content_for db set_ids =
         ~monolithic_or_default_structure: version_monolithic_or_default_structure
         ~tune_name
         ~tune_kind
-        ~tune_composers: (tune_composers_for version_id)
+        ~tune_composers: (tune_composers_for tune_id)
         ~sources: (version_sources_for version_id)
         ~arrangers: (version_arrangers_for version_id)
         ~k: Fun.id
@@ -71,40 +71,37 @@ let get_content_for db set_ids =
   )
 
 let get_row ~user id : Set_row.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   let%lwt tunes = (fun f -> f id) <$> get_tunes_for db (`One_of [id]) in
   let%lwt conceptors = (fun f -> f id) <$> get_conceptors_for db (`One_of [id]) in
   Set_sql.Single.get_row
     db
-    ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "")
+    ~user_id: user
     ~id
     (set_sql_to_row ~id ~tunes ~conceptors ~k: Fun.id)
 
 let get_rows ~user ids : (Set_id.t, Set_row.t) Utils.tbl Lwt.t =
-  let ids = List.map Entry.Id.to_string ids in
   Connection.with_ @@ fun db ->
   let%lwt tunes_for = get_tunes_for db (`One_of ids) in
   let%lwt conceptors_for = get_conceptors_for db (`One_of ids) in
   Utils.fold_to_tbl
-    (Set_sql.Fold.get_rows ~ids ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: ""))
+    (Set_sql.Fold.get_rows ~ids ~user_id: user)
     db
     (fun k ~id ->
       set_sql_to_row
         ~id
         ~tunes: (tunes_for id)
         ~conceptors: (conceptors_for id)
-        ~k: (k @@ Entry.Id.of_string_exn id)
+        ~k: (k id)
     )
 
 let get_view ~user id : Set_view.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   let%lwt conceptors = (fun f -> f id) <$> get_conceptors_for db (`One_of [id]) in
   let%lwt content = (fun f -> f id) <$> get_content_for db (`One_of [id]) in
   Set_sql.Single.get_view
     db
-    ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "")
+    ~user_id: user
     ~id
     (set_sql_to_view ~id ~conceptors ~content ~k: Fun.id)
 
@@ -115,11 +112,11 @@ let search ~user query : (Set_row.t * float) list Lwt.t =
   let%lwt conceptors_for = get_conceptors_for db `All in
   Set_sql.List.search
     db
-    ~user_id: (Option.fold user ~some: Entry.Id.to_string ~none: "")
+    ~user_id: user
     ~terms
-    ~conceptor: (Utils.list_option_map_to_sql Entry.Id.to_string conceptor)
-    ~contains_version: (Utils.list_option_map_to_sql Entry.Id.to_string contains_version)
-    ~contains_tune: (Utils.list_option_map_to_sql Entry.Id.to_string contains_tune)
+    ~conceptor: (Utils.option_to_sql conceptor)
+    ~contains_version: (Utils.option_to_sql contains_version)
+    ~contains_tune: (Utils.option_to_sql contains_tune)
     (fun ~score ~id ->
       set_sql_to_row
         ~id
@@ -160,7 +157,7 @@ let sql_to_set
     | _ -> assert false
   in
   Entry.make
-    ~id: (Entry.Id.of_string_exn id)
+    ~id: id
     ~meta: (Entry.Meta.make ~created_at ~modified_at ())
     ~access: (Entry.Access.Private.make ~owners: (NEList.of_list_exn owners) ~visibility ())
     (
@@ -175,7 +172,6 @@ let sql_to_set
     )
 
 let set_to_sql ~create_or_update db id set =
-  let id = Entry.Id.to_string id in
   ignore
   <$> create_or_update
       db
@@ -191,7 +187,7 @@ let set_to_sql ~create_or_update db id set =
       <$> Set_sql.add_one_conceptor
           db
           ~set_id: id
-          ~conceptor_id: (Entry.Id.to_string conceptor)
+          ~conceptor_id: conceptor
     )
     (Model_builder.Core.Set.conceptors set);%lwt
   ignore <$> Set_sql.delete_all_content db ~set_id: id;%lwt
@@ -202,7 +198,7 @@ let set_to_sql ~create_or_update db id set =
           db
           ~set_id: id
           ~index: (Int64.of_int index)
-          ~version_id: (Entry.Id.to_string version)
+          ~version_id: version
           ~version_parameter_transposition_semitones: (Option.map (Int64.of_int % Transposition.to_semitones) @@ Model_builder.Core.Version_parameters.transposition params)
           ~version_parameter_first_bar: (Option.map Int64.of_int @@ Model_builder.Core.Version_parameters.first_bar params)
           ~version_parameter_clef: (Option.map Music.Clef.to_string @@ Model_builder.Core.Version_parameters.clef params)
@@ -214,11 +210,10 @@ let set_to_sql ~create_or_update db id set =
     (Model_builder.Core.Set.contents set)
 
 let get id : Model_builder.Core.Set.entry option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
-  let%lwt conceptors = Set_sql.List.get_conceptors db ~set_id: id (fun ~conceptor_id -> Entry.Id.of_string_exn conceptor_id) in
-  let%lwt owners = Entry_sql.List.get_owners db ~entry_id: id (fun ~owner_id -> Entry.Id.of_string_exn owner_id) in
-  let%lwt viewers = Entry_sql.List.get_viewers db ~entry_id: id (fun ~viewer_id -> Entry.Id.of_string_exn viewer_id) in
+  let%lwt conceptors = Set_sql.List.get_conceptors db ~set_id: id (fun ~conceptor_id -> conceptor_id) in
+  let%lwt owners = Entry_sql.List.get_owners db ~entry_id: id (fun ~owner_id -> owner_id) in
+  let%lwt viewers = Entry_sql.List.get_viewers db ~entry_id: id (fun ~viewer_id -> viewer_id) in
   let%lwt content =
     Set_sql.List.get_content db ~set_id: id (fun
         ~version_id
@@ -231,7 +226,7 @@ let get id : Model_builder.Core.Set.entry option Lwt.t =
         ~version_parameter_display_composer
       ->
       (
-        Entry.Id.of_string_exn version_id,
+        version_id,
         Model_builder.Core.Version_parameters.make
           ?transposition: (Option.map (Transposition.from_semitones % Int64.to_int) version_parameter_transposition_semitones)
           ?first_bar: (Option.map Int64.to_int version_parameter_first_bar)
@@ -260,8 +255,7 @@ let update id set access =
 
 let delete id =
   Connection.with_ @@ fun db ->
-  let set_id = Entry.Id.to_string id in
-  ignore <$> Set_sql.delete_all_conceptors db ~set_id;%lwt
-  ignore <$> Set_sql.delete_all_content db ~set_id;%lwt
-  ignore <$> Set_sql.delete db ~id: set_id;%lwt
+  ignore <$> Set_sql.delete_all_conceptors db ~set_id: id;%lwt
+  ignore <$> Set_sql.delete_all_content db ~set_id: id;%lwt
+  ignore <$> Set_sql.delete db ~id;%lwt
   Entry_new.delete db id

--- a/src/server/database/set.mli
+++ b/src/server/database/set.mli
@@ -12,9 +12,9 @@ val search : user: User_id.t option -> Set_query.t -> (Set_row.t * float) list L
 
 (** {2 Utilities for other models} *)
 
-val get_tunes_for : Connection.t -> [`All | `One_of of string list] -> (string -> Version_name.t list) Lwt.t
+val get_tunes_for : Connection.t -> Set_id.t Utils.all_or_one_of -> (Set_id.t -> Version_name.t list) Lwt.t
 
-val get_conceptors_for : Connection.t -> [`All | `One_of of string list] -> (string -> Person_name.t list) Lwt.t
+val get_conceptors_for : Connection.t -> Set_id.t Utils.all_or_one_of -> (Set_id.t -> Person_name.t list) Lwt.t
 
 (** {2 Legacy} *)
 

--- a/src/server/database/set.sql
+++ b/src/server/database/set.sql
@@ -137,9 +137,9 @@ SELECT * FROM (
         END AS "permission"
     FROM "set"
     JOIN "entry" ON "entry"."id" = "set"."id"
-    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = @user_id
-    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = @user_id
-    LEFT JOIN "user" ON "user"."id" = @user_id
+    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "user" ON "user"."id" = (@user_id :: TEXT NULL)
     WHERE "set"."id" = @id
 ) AS "set+"
 WHERE "set+"."permission" IS NOT NULL
@@ -160,9 +160,9 @@ SELECT * FROM (
         END AS "permission"
     FROM "set"
     JOIN "entry" ON "entry"."id" = "set"."id"
-    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = @user_id
-    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = @user_id
-    LEFT JOIN "user" ON "user"."id" = @user_id
+    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "user" ON "user"."id" = (@user_id :: TEXT NULL)
     WHERE "set"."id" IN @ids
 ) AS "set+"
 WHERE "set+"."permission" IS NOT NULL;
@@ -183,9 +183,9 @@ SELECT * FROM (
         END AS "permission"
     FROM "set"
     JOIN "entry" ON "entry"."id" = "set"."id"
-    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = @user_id
-    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = @user_id
-    LEFT JOIN "user" ON "user"."id" = @user_id
+    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "user" ON "user"."id" = (@user_id :: TEXT NULL)
     WHERE "set"."id" = @id
 ) AS "set+"
 WHERE "set+"."permission" IS NOT NULL
@@ -207,9 +207,9 @@ SELECT * FROM (
         END AS "permission"
     FROM "set"
     JOIN "entry" ON "entry"."id" = "set"."id"
-    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = @user_id
-    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = @user_id
-    LEFT JOIN "user" ON "user"."id" = @user_id
+    LEFT JOIN "entry_owners" ON "entry_owners"."entry_id" = "entry"."id" AND "entry_owners"."owner_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "entry_viewers" ON "entry_viewers"."entry_id" = "entry"."id" AND "entry_viewers"."viewer_id" = (@user_id :: TEXT NULL)
+    LEFT JOIN "user" ON "user"."id" = (@user_id :: TEXT NULL)
     WHERE
         (@terms = '' OR @terms <% "name")
         AND @conceptor { Some { EXISTS (SELECT 1 FROM "set_conceptors" WHERE "set_id" = "set"."id" AND "conceptor_id" IN @conceptor) } | None { TRUE } }

--- a/src/server/database/source.ml
+++ b/src/server/database/source.ml
@@ -12,19 +12,16 @@ let get_editors_for db source_ids =
   Utils.fold_to_tbl (Source_sql.Fold.get_editors_for ~source_ids) db (fun k ~source_id -> person_sql_to_name ~k: (k source_id))
 
 let get_row id : Source_row.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   let%lwt editors = flip Utils.tbl_get id <$> get_editors_for db (`One_of [id]) in
   Source_sql.Single.get_row db ~id (source_sql_to_row ~id ~editors ~k: Fun.id)
 
 let get_rows ids : (Source_id.t, Source_row.t) Utils.tbl Lwt.t =
-  let ids = List.map Entry.Id.to_string ids in
   Connection.with_ @@ fun db ->
   let%lwt editors_for = get_editors_for db (`One_of ids) in
-  Utils.fold_to_tbl (Source_sql.Fold.get_rows ~ids) db (fun k ~id -> source_sql_to_row ~id ~editors: (Utils.tbl_get editors_for id) ~k: (k @@ Entry.Id.of_string_exn id))
+  Utils.fold_to_tbl (Source_sql.Fold.get_rows ~ids) db (fun k ~id -> source_sql_to_row ~id ~editors: (Utils.tbl_get editors_for id) ~k: (k id))
 
 let get_view id : Source_view.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   let%lwt editors = flip Utils.tbl_get id <$> get_editors_for db (`One_of [id]) in
   Source_sql.Single.get_view db ~id (source_sql_to_view ~editors ~id ~k: Fun.id)
@@ -36,7 +33,7 @@ let search query : (Source_row.t * float) list Lwt.t =
   Source_sql.List.search
     db
     ~terms
-    ~editor: (Utils.list_option_map_to_sql Entry.Id.to_string editor)
+    ~editor: (Utils.option_to_sql editor)
     (fun ~score ~id -> source_sql_to_row ~id ~editors: (Utils.tbl_get editors_for id) ~k: (Pair.snoc score))
 
 (* Legacy *)
@@ -56,7 +53,7 @@ let sql_to_source
     ~modified_at
   =
   Entry.make
-    ~id: (Entry.Id.of_string_exn id)
+    ~id
     ~meta: (Entry.Meta.make ~created_at ~modified_at ())
     ~access: Entry.Access.Public
     (
@@ -72,7 +69,6 @@ let sql_to_source
 
 let source_to_sql ~create_or_update ~delete_all_editors ~add_one_editor id source =
   (* FIXME: transaction, maybe [Connection.with_transaction] *)
-  let id = Entry.Id.to_string id in
   ignore
   <$> create_or_update
       ~id
@@ -84,14 +80,13 @@ let source_to_sql ~create_or_update ~delete_all_editors ~add_one_editor id sourc
   ignore <$> delete_all_editors ~source_id: id;%lwt
   Lwt_list.iter_s
     (fun person_id ->
-      ignore <$> add_one_editor ~source_id: id ~person_id: (Entry.Id.to_string person_id)
+      ignore <$> add_one_editor ~source_id: id ~person_id
     )
     (Model_builder.Core.Source.editors source)
 
 let get id : Model_builder.Core.Source.entry option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
-  let%lwt editors = Source_sql.List.get_editors db ~source_id: id (fun ~person_id -> Entry.Id.of_string_exn person_id) in
+  let%lwt editors = Source_sql.List.get_editors db ~source_id: id (fun ~person_id -> person_id) in
   Source_sql.Single.get db ~id (sql_to_source ~id ~editors)
 
 let create source =
@@ -117,14 +112,14 @@ let update id source =
 
 let delete id =
   Connection.with_ @@ fun db ->
-  ignore <$> Source_sql.delete_all_editors ~source_id: (Entry.Id.to_string id) db;%lwt
-  ignore <$> Source_sql.delete db ~id: (Entry.Id.to_string id);%lwt
+  ignore <$> Source_sql.delete_all_editors ~source_id: id db;%lwt
+  ignore <$> Source_sql.delete db ~id;%lwt
   Entry_new.delete db id
 
 let with_cover id f =
   let%lwt cover =
     Connection.with_ @@ fun db ->
-    Option.join <$> Source_sql.get_cover db ~id: (Entry.Id.to_string id)
+    Option.join <$> Source_sql.get_cover db ~id
   in
   match cover with
   | None -> f None

--- a/src/server/database/sql_to_name.ml
+++ b/src/server/database/sql_to_name.ml
@@ -2,17 +2,17 @@ open Dancelor_common
 open Model_new
 
 let person_sql_to_name ~id ~name ~(k : Person_name.t -> 'w) : 'w =
-  k {id = Entry.Id.of_string_exn id; name}
+  k {id; name}
 
 let person_sql_to_name_with_details ~id ~name ~details ~(k : Person_name_with_details.t -> 'w) : 'w =
-  k {id = Entry.Id.of_string_exn id; name; details}
+  k {id; name; details}
 
 let source_sql_to_name ~id ~name ~(k : Source_name.t -> 'w) : 'w =
-  k {id = Entry.Id.of_string_exn id; name}
+  k {id; name}
 
 let source_sql_to_short_name ~id ~name ~short_name ~(k : Source_short_name.t -> 'w) : 'w =
   let short_name = Option.value short_name ~default: name in
-  k {id = Entry.Id.of_string_exn id; short_name}
+  k {id; short_name}
 
 let version_sql_to_name ~id ~name ~(k : Version_name.t -> 'w) : 'w =
-  k {id = Entry.Id.of_string_exn id; name}
+  k {id; name}

--- a/src/server/database/sql_to_row.ml
+++ b/src/server/database/sql_to_row.ml
@@ -3,14 +3,14 @@ open Dancelor_common
 open Model_new
 
 let person_sql_to_row ~id ~name ~(k : Person_row.t -> 'w) : 'w =
-  k {id = Entry.Id.of_string_exn id; name}
+  k {id; name}
 
 let source_sql_to_row ~id ~name ~date ~editors ~(k : Source_row.t -> 'w) : 'w =
-  k {id = Entry.Id.of_string_exn id; name; date = Option.map (Option.get % PartialDate.from_string) date; editors}
+  k {id; name; date = Option.map (Option.get % PartialDate.from_string) date; editors}
 
 let dance_sql_to_row ~id ~name ~kind ~devisers ~disambiguation ~(k : Dance_row.t -> 'w) : 'w =
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     name;
     kind = Kind_dance.of_string kind;
     devisers;
@@ -19,7 +19,7 @@ let dance_sql_to_row ~id ~name ~kind ~devisers ~disambiguation ~(k : Dance_row.t
 
 let tune_sql_to_row ~id ~name ~kind ~composers ~(k : Tune_row.t -> 'w) : 'w =
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     name;
     kind = Sql_types.kind_base_to_common kind;
     composers;
@@ -51,7 +51,7 @@ let version_sql_to_row
     | _ -> assert false
   in
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     tune = tune_sql_to_row ~id: tune_id ~name: tune_name ~kind: tune_kind ~composers: tune_composers ~k: Fun.id;
     sources;
     disambiguation;
@@ -61,7 +61,7 @@ let version_sql_to_row
 
 let set_sql_to_row ~id ~name ~kind ~conceptors ~tunes ~permission ~(k : Set_row.t -> 'w) : 'w =
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     name;
     kind = Kind_dance.of_string kind;
     conceptors;
@@ -71,7 +71,7 @@ let set_sql_to_row ~id ~name ~kind ~conceptors ~tunes ~permission ~(k : Set_row.
 
 let book_sql_to_row ~id ~name ~date ~authors ~permission ~(k : Book_row.t -> 'w) : 'w =
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     name;
     date = Option.map (Option.get % PartialDate.from_string) date;
     authors;

--- a/src/server/database/sql_to_view.ml
+++ b/src/server/database/sql_to_view.ml
@@ -4,7 +4,7 @@ open Model_new
 
 let person_sql_to_view ~id ~name ~scddb_id ~composed_tunes_are_public ~published_tunes_are_public ~(k : Person_view.t -> 'w) : 'w =
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     name;
     scddb_id = Option.map Int64.to_int scddb_id;
     composed_tunes_are_public;
@@ -13,7 +13,7 @@ let person_sql_to_view ~id ~name ~scddb_id ~composed_tunes_are_public ~published
 
 let source_sql_to_view ~id ~name ~short_name ~editors ~scddb_id ~description ~date ~(k : Source_view.t -> 'w) : 'w =
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     name;
     short_name;
     editors;
@@ -24,7 +24,7 @@ let source_sql_to_view ~id ~name ~short_name ~editors ~scddb_id ~description ~da
 
 let dance_sql_to_view ~id ~name ~extra_names ~kind ~devisers ~scddb_id ~disambiguation ~date ~two_chords ~tunes ~(k : Dance_view.t -> 'w) : 'w =
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     name;
     extra_names;
     kind = Kind_dance.of_string kind;
@@ -49,7 +49,7 @@ let tune_sql_to_version_row_without_tune ~id ~sources ~disambiguation ~arrangers
     | _ -> assert false
   in
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     sources;
     disambiguation;
     arrangers;
@@ -58,7 +58,7 @@ let tune_sql_to_version_row_without_tune ~id ~sources ~disambiguation ~arrangers
 
 let tune_sql_to_view ~id ~name ~extra_names ~kind ~composers ~dances ~remark ~scddb_id ~date ~versions ~(k : Tune_view.t -> 'w) : 'w =
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     name;
     extra_names;
     kind = Sql_types.kind_base_to_common kind;
@@ -79,7 +79,7 @@ let version_sql_to_source
     : 'w
   =
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     name;
     structure = Option.get (Model_builder.Core.Version.Structure.of_string (NEString.of_string_exn structure));
     details;
@@ -123,7 +123,7 @@ let version_sql_to_view
     | _ -> assert false
   in
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     tune =
     tune_sql_to_view
       ~id: tune_id
@@ -147,7 +147,7 @@ let version_sql_to_view
 
 let set_sql_to_view ~id ~name ~kind ~conceptors ~content ~order ~remark ~permission ~(k : Set_view.t -> 'w) : 'w =
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     name;
     kind = Kind_dance.of_string kind;
     conceptors;
@@ -159,7 +159,7 @@ let set_sql_to_view ~id ~name ~kind ~conceptors ~content ~order ~remark ~permiss
 
 let book_sql_to_view ~id ~name ~date ~authors ~content ~remark ~sources ~scddb_id ~permission ~(k : Book_view.t -> 'w) : 'w =
   k {
-    id = Entry.Id.of_string_exn id;
+    id;
     name;
     date = Option.map (Option.get % PartialDate.from_string) date;
     authors;

--- a/src/server/database/sql_types.ml
+++ b/src/server/database/sql_types.ml
@@ -1,5 +1,26 @@
 open Dancelor_common
 
+module Make_id_conv (T : sig type t end) = struct
+  let get_column : string -> T.t Entry.Id.t = Entry.Id.of_string_exn
+  let get_column_nullable : string option -> T.t Entry.Id.t option = Option.map Entry.Id.of_string_exn
+  let set_param : T.t Entry.Id.t -> string = Entry.Id.to_string
+end
+
+module Entry_id_conv = struct
+  let get_column : string -> 'any Entry.Id.t = Entry.Id.of_string_exn
+  let get_column_nullable : string option -> 'any Entry.Id.t option = fun x -> Option.map Entry.Id.of_string_exn x
+  let set_param : 'any Entry.Id.t -> string = Entry.Id.to_string
+end
+
+module Person_id_conv = Make_id_conv(Model_builder.Core.Person)
+module Dance_id_conv = Make_id_conv(Model_builder.Core.Dance)
+module Source_id_conv = Make_id_conv(Model_builder.Core.Source)
+module Tune_id_conv = Make_id_conv(Model_builder.Core.Tune)
+module Version_id_conv = Make_id_conv(Model_builder.Core.Version)
+module Set_id_conv = Make_id_conv(Model_builder.Core.Set)
+module Book_id_conv = Make_id_conv(Model_builder.Core.Book)
+module User_id_conv = Make_id_conv(Model_builder.Core.User)
+
 type kind_base = [`Jig | `Reel | `Strathspey | `Waltz | `Polka | `Jig_9_8 | `Other]
 
 let kind_base_to_common : kind_base -> Kind_base.t = function

--- a/src/server/database/tune.ml
+++ b/src/server/database/tune.ml
@@ -27,27 +27,24 @@ let get_composers_with_details_for db tune_ids =
   Utils.fold_to_get (Tune_sql.Fold.get_composers_with_details_for ~tune_ids) db (fun k ~tune_id -> person_sql_to_name_with_details ~k: (k tune_id))
 
 let get_row id : Tune_row.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   let%lwt composers = (fun f -> f id) <$> get_composers_for db (`One_of [id]) in
   Tune_sql.Single.get_row db ~id (tune_sql_to_row ~id ~composers ~k: Fun.id)
 
 let get_rows ids : (Tune_id.t, Tune_row.t) Utils.tbl Lwt.t =
-  let ids = List.map Entry.Id.to_string ids in
   Connection.with_ @@ fun db ->
   let%lwt composers_for = get_composers_for db (`One_of ids) in
-  Utils.fold_to_tbl (Tune_sql.Fold.get_rows ~ids) db (fun k ~id -> tune_sql_to_row ~id ~composers: (composers_for id) ~k: (k @@ Entry.Id.of_string_exn id))
+  Utils.fold_to_tbl (Tune_sql.Fold.get_rows ~ids) db (fun k ~id -> tune_sql_to_row ~id ~composers: (composers_for id) ~k: (k id))
 
 let get_rows_for_dance dance_id : Tune_row.t list Lwt.t =
   Connection.with_ @@ fun db ->
   let%lwt composers_for = get_composers_for db `All in
   Tune_sql.List.get_rows_for_dance
     db
-    ~dance_id: (Entry.Id.to_string dance_id)
+    ~dance_id
     (fun ~id -> tune_sql_to_row ~id ~composers: (composers_for id) ~k: Fun.id)
 
 let get_view id : Tune_view.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   let%lwt extra_names = (fun f -> f id) <$> get_extra_names_for db (`One_of [id]) in
   let%lwt dances = (fun f -> f id) <$> get_dances_for db (`One_of [id]) in
@@ -63,7 +60,7 @@ let search query : (Tune_row.t * float) list Lwt.t =
     db
     ~terms
     ~kind: (Option.map (List.map Sql_types.kind_base_of_common) kind)
-    ~composer: (Utils.list_option_map_to_sql Entry.Id.to_string composer)
+    ~composer: (Utils.option_to_sql composer)
     (fun ~score ~id -> tune_sql_to_row ~id ~composers: (composers_for id) ~k: (Pair.snoc score))
 
 (* Legacy *)
@@ -85,7 +82,7 @@ let sql_to_tune
     ~dances
   =
   Entry.make
-    ~id: (Entry.Id.of_string_exn id)
+    ~id
     ~meta: (Entry.Meta.make ~created_at ~modified_at ())
     ~access: Entry.Access.Public
     (
@@ -102,7 +99,6 @@ let sql_to_tune
 
 let tune_to_sql ~create_or_update db id tune =
   (* FIXME: transaction, maybe [Connection.with_transaction] *)
-  let id = Entry.Id.to_string id in
   ignore
   <$> create_or_update
       db
@@ -126,23 +122,22 @@ let tune_to_sql ~create_or_update db id tune =
           db
           ~tune_id: id
           ~index: (Int64.of_int index)
-          ~composer_id: (Entry.Id.to_string composer)
+          ~composer_id: composer
           ~details: (Option.map NEString.to_string details)
     )
     (Model_builder.Core.Tune.composers tune);%lwt
   ignore <$> Tune_sql.delete_all_dances db ~tune_id: id;%lwt
   Lwt_list.iter_s
     (fun dance_id ->
-      ignore <$> Tune_sql.add_one_dance db ~tune_id: id ~dance_id: (Entry.Id.to_string dance_id)
+      ignore <$> Tune_sql.add_one_dance db ~tune_id: id ~dance_id
     )
     (Model_builder.Core.Tune.dances tune)
 
 let get id : Model_builder.Core.Tune.entry option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   let%lwt extra_names = Tune_sql.List.get_extra_names db ~tune_id: id (fun ~extra_name -> NEString.of_string_exn extra_name) in
-  let%lwt composers = Tune_sql.List.get_composers db ~tune_id: id (fun ~composer_id ~details -> (Entry.Id.of_string_exn composer_id, Option.map NEString.of_string_exn details)) in
-  let%lwt dances = Tune_sql.List.get_dances db ~tune_id: id (fun ~dance_id -> Entry.Id.of_string_exn dance_id) in
+  let%lwt composers = Tune_sql.List.get_composers db ~tune_id: id (fun ~composer_id ~details -> (composer_id, Option.map NEString.of_string_exn details)) in
+  let%lwt dances = Tune_sql.List.get_dances db ~tune_id: id (fun ~dance_id -> dance_id) in
   Tune_sql.Single.get db ~id (sql_to_tune ~id ~extra_names ~composers ~dances)
 
 let create tune =
@@ -158,9 +153,8 @@ let update id tune =
 
 let delete id =
   Connection.with_ @@ fun db ->
-  let tune_id = Entry.Id.to_string id in
-  ignore <$> Tune_sql.delete_all_extra_names db ~tune_id;%lwt
-  ignore <$> Tune_sql.delete_all_composers db ~tune_id;%lwt
-  ignore <$> Tune_sql.delete_all_dances db ~tune_id;%lwt
-  ignore <$> Tune_sql.delete db ~id: tune_id;%lwt
+  ignore <$> Tune_sql.delete_all_extra_names db ~tune_id: id;%lwt
+  ignore <$> Tune_sql.delete_all_composers db ~tune_id: id;%lwt
+  ignore <$> Tune_sql.delete_all_dances db ~tune_id: id;%lwt
+  ignore <$> Tune_sql.delete db ~id;%lwt
   Entry_new.delete db id

--- a/src/server/database/user.ml
+++ b/src/server/database/user.ml
@@ -11,10 +11,9 @@ module Remember_me_token_clear = Fresh.Make(String)
 module Remember_me_token_hashed = Fresh.Make(HashedSecret)
 
 let sql_to_row ~id ~username ~(k : User_row.t -> 'w) : 'w =
-  k {id = Entry.Id.of_string_exn id; username = Username.of_string_exn username}
+  k {id; username = Username.of_string_exn username}
 
 let get_row id : User_row.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   User_sql.Single.get_row db ~id (sql_to_row ~id ~k: Fun.id)
 
@@ -50,7 +49,7 @@ let row_to_user
     ~modified_at
   =
   Entry.make
-    ~id: (Entry.Id.of_string_exn id)
+    ~id
     ~meta: (Entry.Meta.make ~created_at ~modified_at ())
     ~access: Entry.Access.Public
     (
@@ -61,7 +60,6 @@ let row_to_user
     )
 
 let get id : entry option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
   User_sql.Single.get db ~id (row_to_user ~id)
 
@@ -102,7 +100,7 @@ let create ~username ~role ~password_reset_token_hash ~password_reset_token_max_
   let%lwt _ =
     User_sql.create
       db
-      ~id: (Entry.Id.to_string id)
+      ~id
       ~username: (Username.to_string username)
       ~role
       ~omniscience
@@ -115,14 +113,14 @@ let remove_all_remember_me_tokens user_id =
   Connection.with_ @@ fun db ->
   (* FIXME: an index covering user_id *)
   ignore
-  <$> User_sql.remove_all_remember_me_tokens db ~user_id: (Entry.Id.to_string user_id)
+  <$> User_sql.remove_all_remember_me_tokens db ~user_id
 
 let remove_one_remember_me_token user_id key =
   Connection.with_ @@ fun db ->
   ignore
   <$> User_sql.remove_one_remember_me_token
       db
-      ~user_id: (Entry.Id.to_string user_id)
+      ~user_id
       ~key: (Remember_me_key.project key)
 
 let set_password_reset_token id password_reset_token_hash password_reset_token_max_date =
@@ -131,7 +129,7 @@ let set_password_reset_token id password_reset_token_hash password_reset_token_m
   ignore
   <$> User_sql.set_password_reset_token
       db
-      ~id: (Entry.Id.to_string id)
+      ~id
       ~password_reset_token_hash: (Some (HashedSecret.unsafe_to_string @@ Password_reset_token_hashed.project password_reset_token_hash))
       ~password_reset_token_max_date: (Some password_reset_token_max_date)
 
@@ -141,14 +139,14 @@ let set_password id password =
   ignore
   <$> User_sql.set_password
       db
-      ~id: (Entry.Id.to_string id)
+      ~id
       ~password: (some @@ HashedSecret.unsafe_to_string @@ Password_hashed.project password)
 
 let find_remember_me_token user_id key =
   Connection.with_ @@ fun db ->
   User_sql.Single.find_remember_me_token
     db
-    ~user_id: (Entry.Id.to_string user_id)
+    ~user_id
     ~key: (Remember_me_key.project key)
     (fun ~hash ~max_date -> (Remember_me_token_hashed.inject @@ HashedSecret.unsafe_of_string hash, max_date))
 
@@ -157,11 +155,11 @@ let add_remember_me_token user_id key hash max_date =
   ignore
   <$> User_sql.add_remember_me_token
       db
-      ~user_id: (Entry.Id.to_string user_id)
+      ~user_id
       ~key: (Remember_me_key.project key)
       ~hash: (HashedSecret.unsafe_to_string @@ Remember_me_token_hashed.project hash)
       ~max_date
 
 let set_omniscience id value =
   Connection.with_ @@ fun db ->
-  ignore <$> User_sql.set_omniscience db ~id: (Entry.Id.to_string id) ~omniscience: value
+  ignore <$> User_sql.set_omniscience db ~id ~omniscience: value

--- a/src/server/database/utils.ml
+++ b/src/server/database/utils.ml
@@ -14,6 +14,18 @@ let fold_to_get fold db k =
   let%lwt tbl = fold_to_tbl fold db k in
   lwt @@ tbl_get tbl
 
-let list_option_map_to_sql f = function
+type 'a sql_option = [`None | `Some of 'a]
+
+let option_to_sql : 'a option -> 'a sql_option = function
   | None -> `None
-  | Some x -> `Some (List.map f x)
+  | Some x -> `Some x
+
+let sql_to_option : 'a sql_option -> 'a option = function
+  | `None -> None
+  | `Some x -> Some x
+
+type 'a all_or_one_of = [`All | `One_of of 'a list]
+
+let map_all_or_one_of f = function
+  | `All -> `All
+  | `One_of xs -> `One_of (List.map f xs)

--- a/src/server/database/version.ml
+++ b/src/server/database/version.ml
@@ -37,9 +37,9 @@ let get_arrangers_for db version_ids =
   Utils.fold_to_get (Version_sql.Fold.get_arrangers_for ~version_ids) db (fun k ~version_id -> person_sql_to_name ~k: (k version_id))
 
 let get_row id : Version_row.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
-  let%lwt tune_composers = (fun f -> f id) <$> get_tune_composers_for db (`One_of [id]) in
+  (* FIXME: `All to then only grab one *)
+  let%lwt tune_composers_for = get_tune_composers_for db `All in
   let%lwt sources = (fun f -> f id) <$> get_sources_for db (`One_of [id]) in
   let%lwt arrangers = (fun f -> f id) <$> get_arrangers_for db (`One_of [id]) in
   Version_sql.Single.get_row
@@ -49,16 +49,16 @@ let get_row id : Version_row.t option Lwt.t =
       version_sql_to_row
         ~id
         ~tune_id
-        ~tune_composers
+        ~tune_composers: (tune_composers_for tune_id)
         ~sources
         ~arrangers
         ~k: Fun.id
     )
 
 let get_rows ids : (Version_id.t, Version_row.t) Utils.tbl Lwt.t =
-  let ids = List.map Entry.Id.to_string ids in
   Connection.with_ @@ fun db ->
-  let%lwt tune_composers_for = get_tune_composers_for db (`One_of ids) in
+  (* FIXME: `All to then only grab a handful *)
+  let%lwt tune_composers_for = get_tune_composers_for db `All in
   let%lwt sources_for = get_sources_for db (`One_of ids) in
   let%lwt arrangers_for = get_arrangers_for db (`One_of ids) in
   Utils.fold_to_tbl
@@ -71,19 +71,30 @@ let get_rows ids : (Version_id.t, Version_row.t) Utils.tbl Lwt.t =
         ~tune_composers: (tune_composers_for tune_id)
         ~sources: (sources_for id)
         ~arrangers: (arrangers_for id)
-        ~k: (k @@ Entry.Id.of_string_exn id)
+        ~k: (k id)
     )
 
 let get_view id : Version_view.t option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
-  let%lwt tune_extra_names = (fun f -> f id) <$> get_tune_extra_names_for db (`One_of [id]) in
-  let%lwt tune_dances = (fun f -> f id) <$> get_tune_dances_for db (`One_of [id]) in
-  let%lwt tune_versions = (fun f -> f id) <$> get_tune_versions_for db (`One_of [id]) in
-  let%lwt tune_composers = (fun f -> f id) <$> get_tune_composers_with_details_for db (`One_of [id]) in
+  (* FIXME: `All to then only grab a handful (x4) *)
+  let%lwt tune_extra_names_for = get_tune_extra_names_for db `All in
+  let%lwt tune_dances_for = get_tune_dances_for db `All in
+  let%lwt tune_versions_for = get_tune_versions_for db `All in
+  let%lwt tune_composers_for = get_tune_composers_with_details_for db `All in
   let%lwt arrangers = (fun f -> f id) <$> get_arrangers_for db (`One_of [id]) in
   let%lwt sources = (fun f -> f id) <$> get_version_sources_for db (`One_of [id]) in
-  Version_sql.Single.get_view db ~id (version_sql_to_view ~arrangers ~sources ~tune_extra_names ~tune_dances ~tune_composers ~tune_versions ~id ~k: Fun.id)
+  Version_sql.Single.get_view db ~id (fun ~tune_id ->
+    version_sql_to_view
+      ~tune_id
+      ~arrangers
+      ~sources
+      ~tune_extra_names: (tune_extra_names_for tune_id)
+      ~tune_dances: (tune_dances_for tune_id)
+      ~tune_composers: (tune_composers_for tune_id)
+      ~tune_versions: (tune_versions_for tune_id)
+      ~id
+      ~k: Fun.id
+  )
 
 let search query : (Version_row.t * float) list Lwt.t =
   let {Query.common = {terms}; specific = {Version_query.tune; key; source}} = query in
@@ -95,9 +106,9 @@ let search query : (Version_row.t * float) list Lwt.t =
     db
     ~terms
     ~key: (Option.map (List.map Music.Key.to_string) key)
-    ~source: (Utils.list_option_map_to_sql Entry.Id.to_string source)
+    ~source: (Utils.option_to_sql source)
     ~tune_kind: (Option.map (List.map Sql_types.kind_base_of_common) tune.kind)
-    ~tune_composer: (Utils.list_option_map_to_sql Entry.Id.to_string tune.composer)
+    ~tune_composer: (Utils.option_to_sql tune.composer)
     (fun ~score ~id ~tune_id ->
       version_sql_to_row
         ~id
@@ -146,12 +157,12 @@ let sql_to_version
     | _ -> assert false
   in
   Entry.make
-    ~id: (Entry.Id.of_string_exn id)
+    ~id
     ~meta: (Entry.Meta.make ~created_at ~modified_at ())
     ~access: Entry.Access.Public
     (
       Model_builder.Core.Version.make
-        ~tune: (Entry.Id.of_string_exn tune_id)
+        ~tune: tune_id
         ~key: (Music.Key.of_string key)
         ~remark: (Option.map NEString.of_string_exn remark)
         ~disambiguation: (Option.map NEString.of_string_exn disambiguation)
@@ -169,12 +180,11 @@ let version_to_sql ~create_or_update db id version =
     | Monolithic {lilypond; bars; structure} -> (Some lilypond, Some (Int64.of_int bars), Some (NEString.to_string @@ Model_builder.Core.Version.Structure.to_string structure))
     | Destructured {default_structure; _} -> (None, None, Some (NEString.to_string @@ Model_builder.Core.Version.Structure.to_string default_structure))
   in
-  let id = Entry.Id.to_string id in
   ignore
   <$> create_or_update
       db
       ~id
-      ~tune_id: (Entry.Id.to_string @@ Model_builder.Core.Version.tune version)
+      ~tune_id: (Model_builder.Core.Version.tune version)
       ~key: (Music.Key.to_string @@ Model_builder.Core.Version.key version)
       ~remark: (Option.map NEString.to_string @@ Model_builder.Core.Version.remark version)
       ~disambiguation: (Option.map NEString.to_string @@ Model_builder.Core.Version.disambiguation version)
@@ -188,7 +198,7 @@ let version_to_sql ~create_or_update db id version =
       <$> Version_sql.add_one_arranger
           db
           ~version_id: id
-          ~arranger_id: (Entry.Id.to_string arranger)
+          ~arranger_id: arranger
     )
     (Model_builder.Core.Version.arrangers version);%lwt
   ignore <$> Version_sql.delete_all_sources db ~version_id: id;%lwt
@@ -198,7 +208,7 @@ let version_to_sql ~create_or_update db id version =
       <$> Version_sql.add_one_source
           db
           ~version_id: id
-          ~source_id: (Entry.Id.to_string source)
+          ~source_id: source
           ~structure: (NEString.to_string @@ Model_builder.Core.Version.Structure.to_string structure)
           ~details: (Option.map NEString.to_string details)
     )
@@ -244,13 +254,12 @@ let check_destructured_parts =
   )
 
 let get id : Model_builder.Core.Version.entry option Lwt.t =
-  let id = Entry.Id.to_string id in
   Connection.with_ @@ fun db ->
-  let%lwt arrangers = Version_sql.List.get_arrangers db ~version_id: id (fun ~arranger_id -> Entry.Id.of_string_exn arranger_id) in
+  let%lwt arrangers = Version_sql.List.get_arrangers db ~version_id: id (fun ~arranger_id -> arranger_id) in
   let%lwt sources =
     Version_sql.List.get_sources db ~version_id: id (fun ~source_id ~structure ~details ->
       {
-        Model_builder.Core.Version.source = Entry.Id.of_string_exn source_id;
+        Model_builder.Core.Version.source = source_id;
         structure = Option.get (Model_builder.Core.Version.Structure.of_string (NEString.of_string_exn structure));
         details = Option.map NEString.of_string_exn details;
       }
@@ -287,7 +296,7 @@ let get_all () =
   Version_sql.Fold.get_all_arrangers
     db
     (fun ~version_id ~arranger_id () ->
-      Hashtbl.add arrangers version_id (Entry.Id.of_string_exn arranger_id)
+      Hashtbl.add arrangers version_id arranger_id
     )
     ();%lwt
   Version_sql.Fold.get_all_sources
@@ -297,7 +306,7 @@ let get_all () =
         sources
         version_id
         {
-          Model_builder.Core.Version.source = Entry.Id.of_string_exn source_id;
+          Model_builder.Core.Version.source = source_id;
           structure = Option.get (Model_builder.Core.Version.Structure.of_string (NEString.of_string_exn structure));
           details = Option.map NEString.of_string_exn details;
         }
@@ -335,7 +344,6 @@ let get_all () =
   )
 
 let get_all_for_tune tune_id =
-  let tune_id = Entry.Id.to_string tune_id in
   Connection.with_ @@ fun db ->
   let arrangers = Hashtbl.create 8 in
   let sources = Hashtbl.create 8 in
@@ -344,7 +352,7 @@ let get_all_for_tune tune_id =
   Version_sql.Fold.get_all_arrangers
     db
     (fun ~version_id ~arranger_id () ->
-      Hashtbl.add arrangers version_id (Entry.Id.of_string_exn arranger_id)
+      Hashtbl.add arrangers version_id arranger_id
     )
     ();%lwt
   Version_sql.Fold.get_all_sources
@@ -354,7 +362,7 @@ let get_all_for_tune tune_id =
         sources
         version_id
         {
-          Model_builder.Core.Version.source = Entry.Id.of_string_exn source_id;
+          Model_builder.Core.Version.source = source_id;
           structure = Option.get (Model_builder.Core.Version.Structure.of_string (NEString.of_string_exn structure));
           details = Option.map NEString.of_string_exn details;
         }
@@ -405,10 +413,9 @@ let update id version =
 
 let delete id =
   Connection.with_ @@ fun db ->
-  let version_id = Entry.Id.to_string id in
-  ignore <$> Version_sql.delete_all_arrangers db ~version_id;%lwt
-  ignore <$> Version_sql.delete_all_sources db ~version_id;%lwt
-  ignore <$> Version_sql.delete_all_destructured_parts db ~version_id;%lwt
-  ignore <$> Version_sql.delete_all_destructured_transitions db ~version_id;%lwt
-  ignore <$> Version_sql.delete db ~id: version_id;%lwt
+  ignore <$> Version_sql.delete_all_arrangers db ~version_id: id;%lwt
+  ignore <$> Version_sql.delete_all_sources db ~version_id: id;%lwt
+  ignore <$> Version_sql.delete_all_destructured_parts db ~version_id: id;%lwt
+  ignore <$> Version_sql.delete_all_destructured_transitions db ~version_id: id;%lwt
+  ignore <$> Version_sql.delete db ~id;%lwt
   Entry_new.delete db id

--- a/src/server/database/version.mli
+++ b/src/server/database/version.mli
@@ -13,9 +13,9 @@ val search : Version_query.t -> (Version_row.t * float) list Lwt.t
 
 (** {2 Utilities for other models} *)
 
-val get_tune_composers_for : Connection.t -> [`All | `One_of of string list] -> (string -> Person_name.t list) Lwt.t
-val get_sources_for : Connection.t -> [`All | `One_of of string list] -> (string -> Source_short_name.t list) Lwt.t
-val get_arrangers_for : Connection.t -> [`All | `One_of of string list] -> (string -> Person_name.t list) Lwt.t
+val get_tune_composers_for : Connection.t -> Tune_id.t Utils.all_or_one_of -> (Tune_id.t -> Person_name.t list) Lwt.t
+val get_sources_for : Connection.t -> Version_id.t Utils.all_or_one_of -> (Version_id.t -> Source_short_name.t list) Lwt.t
+val get_arrangers_for : Connection.t -> Version_id.t Utils.all_or_one_of -> (Version_id.t -> Person_name.t list) Lwt.t
 
 (** {2 Legacy} *)
 


### PR DESCRIPTION
Incidentally, this showed that we were using a version id as a tune id in various places, leading to the tune/version viewer not showing bits of information. This is fixed:

Closes #1006
Closes #1007

Additionally, this forced me to clean up the disgusting:
```ocaml
~user_id: (User.fold user ~some: Entry.Id.to_string ~none: "")
```
Now, `user_id : User_id.t option` and all is well.