### PR TITLE
Unescape cover from PostgreSQL's `BYTEA` on OCaml side

### DIFF
--- a/src/server/database/source.ml
+++ b/src/server/database/source.ml
@@ -119,6 +119,7 @@ let with_cover id f =
   match cover with
   | None -> f None
   | Some cover ->
+    let cover = Postgresql.unescape_bytea cover in
     Lwt_io.with_temp_file (fun (fname, ochan) ->
       Lwt_io.write ochan cover;%lwt
       f (Some fname)


### PR DESCRIPTION
This is a normal limitation of libpsql-based clients that they get
`BYTEA` under an hex-encoded form. This function does exactly what is
needed. Ideally, sqlgg would take care of it itself, but that's a
problem for the future.

Closes #931